### PR TITLE
feat(session-restore): Codex CLI provider #2 — read-back adapter + end-to-end wiring

### DIFF
--- a/src-tauri/resources/intercept/codex_identity_shim.bash
+++ b/src-tauri/resources/intercept/codex_identity_shim.bash
@@ -87,8 +87,16 @@ notify_session_open() {
   local term="${QONTINUI_TERMINAL_ID:-}"
   [ -z "$port" ] && return 0
   command -v curl >/dev/null 2>&1 || return 0
+  # Report the cwd in the SAME frame codex records it (Windows form). In
+  # Git-Bash `$PWD` is the mingw `/c/...` form but codex (a Windows binary)
+  # writes `C:\...` into the rollout session_meta — so `pwd -W` (MSYS Windows
+  # form `C:/...`) is what makes the runner's cwd-match succeed. Falls back to
+  # `$PWD` on a shell without `pwd -W` (real Unix). The runner ALSO folds the
+  # mingw form defensively, but emitting the Windows form here is the primary.
+  local cwd_raw
+  cwd_raw="$(pwd -W 2>/dev/null || printf '%s' "$PWD")"
   local cwd_json
-  cwd_json=$(printf '%s' "$PWD" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  cwd_json=$(printf '%s' "$cwd_raw" | sed 's/\\/\\\\/g; s/"/\\"/g')
   local body
   body="{\"terminal_id\":\"$term\",\"provider\":\"$TOOL\",\"source\":\"startup\",\"cwd\":\"$cwd_json\"}"
   curl -fsS --connect-timeout 3 --max-time 10 \

--- a/src-tauri/resources/intercept/codex_identity_shim.bash
+++ b/src-tauri/resources/intercept/codex_identity_shim.bash
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# qontinui session-restore CODEX IDENTITY shim (bash / Git-Bash / Unix).
+#
+# DISTINCT from identity_shim.bash. Codex has NO session-id flag — it GENERATES
+# its own session id (a UUIDv7 it writes into
+# `$CODEX_HOME/sessions/.../rollout-*.jsonl`'s line-1 `session_meta`). Appending
+# any identity flag would BREAK the codex argv. So this wrapper NEVER mutates the
+# user's argv and NEVER pins an id. Its only job is to SIGNAL
+# the runner that a codex session is starting in THIS terminal, so the runner
+# can begin its read-back capture (watch CODEX_HOME for the post-spawn rollout —
+# `install_effects_producer::routes()` → `/control/session-open`, then
+# `session::codex_capture::capture_and_record`).
+#
+# Always-on (NOT gated by QONTINUI_INSTALL_INTERCEPT_ENABLED — the out-of-box
+# session-restore guarantee). Materialized per-terminal by the runner
+# (`shim_materializer::materialize_identity`) from this TEMPLATE; the runner
+# substitutes the `@@…@@` placeholders. Do NOT run it raw.
+#
+# Hard invariants (mirrored from identity_shim.bash):
+#   * FAIL-OPEN: any failure -> exec the REAL codex unchanged. A user's shell
+#     must NEVER be bricked by session-restore being unavailable.
+#   * TRANSPARENT: stdio is inherited (exec), so codex sees its TTY and the user
+#     sees byte-identical output + exit code. ARGS ARE PASSED THROUGH UNCHANGED.
+#   * RECURSION-GUARD: QONTINUI_INSTALL_INTERCEPT_GUARD=1 already set -> pure
+#     passthrough (a nested invocation must not re-signal).
+#   * NEVER touch/relocate CODEX_HOME — auth lives there; relocating breaks the
+#     user's `codex login`. The runner already isolates CODEX_HOME at spawn.
+#
+# Placeholders:
+#   @@TOOL@@      the wrapped program name (always `codex` here)
+#   @@SHIM_DIR@@  absolute path of this shim's own bin dir (skipped in the
+#                 real-tool PATH scan to avoid recursion)
+set -u
+
+TOOL="@@TOOL@@"
+SHIM_DIR="@@SHIM_DIR@@"
+
+# ---------------------------------------------------------------------------
+# Resolve the REAL codex: first match on PATH that is NOT inside SHIM_DIR.
+# ---------------------------------------------------------------------------
+resolve_real() {
+  local IFS=':'
+  local dir cand
+  for dir in $PATH; do
+    [ -z "$dir" ] && continue
+    case "${dir%/}" in
+      "${SHIM_DIR%/}") continue ;;
+    esac
+    for cand in "$dir/$TOOL" "$dir/$TOOL.cmd" "$dir/$TOOL.exe"; do
+      if [ -x "$cand" ] || [ -f "$cand" ]; then
+        printf '%s' "$cand"
+        return 0
+      fi
+    done
+  done
+  return 1
+}
+
+REAL="$(resolve_real || true)"
+
+# Run the real codex, replacing this process. Strips our dir from PATH as a last
+# resort when the real tool couldn't be resolved. ARGS UNCHANGED — never inject.
+exec_real() {
+  if [ -n "${REAL:-}" ]; then
+    QONTINUI_INSTALL_INTERCEPT_GUARD=1 exec "$REAL" "$@"
+  fi
+  local newpath="" d
+  local IFS=':'
+  for d in $PATH; do
+    case "${d%/}" in "${SHIM_DIR%/}") continue ;; esac
+    if [ -z "$newpath" ]; then newpath="$d"; else newpath="$newpath:$d"; fi
+  done
+  QONTINUI_INSTALL_INTERCEPT_GUARD=1 PATH="$newpath" exec "$TOOL" "$@"
+}
+
+# Recursion guard: a nested invocation is a pure passthrough — never re-signal.
+if [ "${QONTINUI_INSTALL_INTERCEPT_GUARD:-}" = "1" ]; then
+  exec_real "$@"
+fi
+
+# Best-effort signal to the runner loopback that a codex session is starting in
+# this terminal. NO session_id field (codex generates its own; the runner reads
+# it back). This is what triggers the runner-side read-back capture. Never
+# load-bearing — short timeout, all failures ignored.
+notify_session_open() {
+  local port="${QONTINUI_INSTALL_INTERCEPT_PORT:-}"
+  local term="${QONTINUI_TERMINAL_ID:-}"
+  [ -z "$port" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  local cwd_json
+  cwd_json=$(printf '%s' "$PWD" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  local body
+  body="{\"terminal_id\":\"$term\",\"provider\":\"$TOOL\",\"source\":\"startup\",\"cwd\":\"$cwd_json\"}"
+  curl -fsS --connect-timeout 3 --max-time 10 \
+      -X POST "http://127.0.0.1:$port/control/session-open" \
+      -H 'Content-Type: application/json' \
+      -d "$body" >/dev/null 2>&1 || true
+}
+
+notify_session_open
+# Exec the REAL codex with the user's args UNCHANGED — no flag injection.
+exec_real "$@"

--- a/src-tauri/resources/intercept/codex_identity_shim.cmd
+++ b/src-tauri/resources/intercept/codex_identity_shim.cmd
@@ -1,0 +1,69 @@
+@echo off
+setlocal EnableDelayedExpansion
+rem qontinui session-restore CODEX IDENTITY shim (Windows cmd / PowerShell).
+rem
+rem DISTINCT from identity_shim.cmd. Codex has NO session-id flag — it
+rem GENERATES its own session id (written into CODEX_HOME\sessions\...\
+rem rollout-*.jsonl line-1 session_meta). Appending any identity flag would
+rem BREAK codex. So this wrapper NEVER mutates the user's argv and NEVER pins an
+rem id. Its only job: SIGNAL the runner that a codex session is starting in this
+rem terminal, so the runner begins its read-back capture (POST
+rem /control/session-open -> session::codex_capture::capture_and_record).
+rem
+rem Always-on (NOT gated by QONTINUI_INSTALL_INTERCEPT_ENABLED — the out-of-box
+rem session-restore guarantee). TEMPLATE materialized per-terminal by the runner;
+rem the runner substitutes the @@...@@ placeholders. Do NOT run it raw.
+rem
+rem Hard invariants (mirrored from identity_shim.cmd):
+rem   * FAIL-OPEN: any failure -> run the REAL codex unchanged.
+rem   * TRANSPARENT: stdio inherited; the user sees the real exit code.
+rem   * RECURSION-GUARD: QONTINUI_INSTALL_INTERCEPT_GUARD=1 -> pure passthrough.
+rem   * ARGS UNCHANGED — never inject a flag.
+rem   * NEVER touch/relocate CODEX_HOME (auth lives there).
+rem
+rem Placeholders:
+rem   @@TOOL@@      the wrapped program name (always `codex` here)
+rem   @@SHIM_DIR@@  absolute path of this shim's own bin dir
+
+set "TOOL=@@TOOL@@"
+set "SHIM_DIR=@@SHIM_DIR@@"
+
+rem ---- resolve the REAL codex: first PATH match not inside SHIM_DIR ----------
+set "REAL="
+for %%X in (cmd exe bat) do (
+  if not defined REAL (
+    for %%D in ("%PATH:;=" "%") do (
+      if not defined REAL (
+        set "DENTRY=%%~D"
+        if /I not "!DENTRY!"=="%SHIM_DIR%" (
+          if exist "!DENTRY!\%TOOL%.%%X" set "REAL=!DENTRY!\%TOOL%.%%X"
+        )
+      )
+    )
+  )
+)
+
+rem ---- recursion guard: a nested invocation never re-signals -----------------
+if "%QONTINUI_INSTALL_INTERCEPT_GUARD%"=="1" goto :passthrough
+
+rem ---- best-effort signal to the runner loopback (NO session_id; codex
+rem generates its own and the runner reads it back). Never load-bearing. -------
+if defined QONTINUI_INSTALL_INTERCEPT_PORT (
+  where curl >nul 2>nul
+  if not errorlevel 1 (
+    set "CWDJSON=%CD:\=\\%"
+    curl -fsS --connect-timeout 3 --max-time 10 -X POST "http://127.0.0.1:%QONTINUI_INSTALL_INTERCEPT_PORT%/control/session-open" -H "Content-Type: application/json" -d "{\"terminal_id\":\"%QONTINUI_TERMINAL_ID%\",\"provider\":\"%TOOL%\",\"source\":\"startup\",\"cwd\":\"!CWDJSON!\"}" >nul 2>nul
+  )
+)
+
+set "QONTINUI_INSTALL_INTERCEPT_GUARD=1"
+
+:passthrough
+rem Exec the REAL codex with the user's args UNCHANGED — no flag injection.
+set "QONTINUI_INSTALL_INTERCEPT_GUARD=1"
+if defined REAL (
+  call "%REAL%" %*
+) else (
+  call %TOOL% %*
+)
+endlocal & exit /b %ERRORLEVEL%

--- a/src-tauri/src/install_effects_producer/intercept/shim_materializer.rs
+++ b/src-tauri/src/install_effects_producer/intercept/shim_materializer.rs
@@ -41,11 +41,29 @@ const IDENTITY_SHIM_BASH: &str = include_str!("../../../resources/intercept/iden
 #[cfg(target_os = "windows")]
 const IDENTITY_SHIM_CMD: &str = include_str!("../../../resources/intercept/identity_shim.cmd");
 
+/// Always-on CODEX identity shim template (bash / Git-Bash / Unix). DISTINCT
+/// from [`IDENTITY_SHIM_BASH`]: codex has NO `--session-id` flag, so this
+/// wrapper NEVER mutates the user's argv — it only SIGNALS the runner (POST
+/// `/control/session-open` with NO `session_id`) to start the read-back capture,
+/// then execs the real codex with the args unchanged.
+const CODEX_IDENTITY_SHIM_BASH: &str =
+    include_str!("../../../resources/intercept/codex_identity_shim.bash");
+/// Always-on CODEX identity shim template (`.cmd` Windows cmd/PowerShell shadow).
+#[cfg(target_os = "windows")]
+const CODEX_IDENTITY_SHIM_CMD: &str =
+    include_str!("../../../resources/intercept/codex_identity_shim.cmd");
+
+/// The provider id whose identity rides a READ-BACK channel (no `--session-id`
+/// pin). The materializer selects the codex-specific wrapper template for this
+/// tool; every other [`IDENTITY_TOOLS`] entry gets the pinning template.
+pub const CODEX_TOOL: &str = "codex";
+
 /// The always-on identity tool family (plan §3b). These shims are ALWAYS
 /// materialized for every terminal regardless of the install-intercept master
 /// flag, so the out-of-box session-restore guarantee never rides a default-dark
-/// flag. `claude` is provider #1, `gemini` #2.
-pub const IDENTITY_TOOLS: &[&str] = &["claude", "gemini"];
+/// flag. `claude` is provider #1, `gemini` #2, `codex` #3 (read-back — its
+/// wrapper never appends `--session-id`).
+pub const IDENTITY_TOOLS: &[&str] = &["claude", "gemini", CODEX_TOOL];
 
 /// Filename prefix for a per-terminal IDENTITY shim dir
 /// (`qontinui-identity-<terminal_id>`). Distinct from [`SHIM_DIR_PREFIX`] so the
@@ -263,26 +281,55 @@ fn render_identity(body: &str, tool: &str, shim_dir: &Path) -> String {
         .replace("@@SHIM_DIR@@", &shim_dir.to_string_lossy())
 }
 
-/// Test-only accessor for [`render_identity`].
+/// Test-only accessor for [`render_identity`] over a tool's selected bash
+/// template (the pinning template for claude/gemini, the codex template for
+/// codex — see [`identity_bash_template`]).
 #[cfg(test)]
 pub fn render_identity_for_test(tool: &str, shim_dir: &Path) -> String {
-    render_identity(IDENTITY_SHIM_BASH, tool, shim_dir)
+    render_identity(identity_bash_template(tool), tool, shim_dir)
+}
+
+/// Select the bash identity-shim TEMPLATE for `tool`. `codex` rides the
+/// read-back channel (no `--session-id` flag exists), so it gets the distinct
+/// [`CODEX_IDENTITY_SHIM_BASH`] which only signals the runner and execs codex
+/// with the args UNCHANGED; every other identity tool (claude/gemini) gets the
+/// pinning [`IDENTITY_SHIM_BASH`] that appends `--session-id`.
+fn identity_bash_template(tool: &str) -> &'static str {
+    if tool == CODEX_TOOL {
+        CODEX_IDENTITY_SHIM_BASH
+    } else {
+        IDENTITY_SHIM_BASH
+    }
+}
+
+/// Select the `.cmd` identity-shim TEMPLATE for `tool` (codex → read-back
+/// wrapper; everything else → pinning wrapper). See [`identity_bash_template`].
+#[cfg(target_os = "windows")]
+fn identity_cmd_template(tool: &str) -> &'static str {
+    if tool == CODEX_TOOL {
+        CODEX_IDENTITY_SHIM_CMD
+    } else {
+        IDENTITY_SHIM_CMD
+    }
 }
 
 /// Write the platform-appropriate identity shim file(s) for `tool`
-/// (`claude`/`gemini`) into `dir`. Mirrors [`write_shims_for`]: always an
-/// extensionless script (Git Bash + Unix), plus a `.cmd` on Windows. No `.exe`
-/// stub is needed — `claude`/`gemini` ship as `.cmd`/scripts (not `.exe`), so a
-/// `.cmd`/extensionless shim wins under both shells.
+/// (`claude`/`gemini`/`codex`) into `dir`. Mirrors [`write_shims_for`]: always
+/// an extensionless script (Git Bash + Unix), plus a `.cmd` on Windows. No
+/// `.exe` stub is needed — these providers ship as `.cmd`/scripts (not `.exe`),
+/// so a `.cmd`/extensionless shim wins under both shells. The TEMPLATE is
+/// selected per tool ([`identity_bash_template`] / [`identity_cmd_template`]):
+/// claude/gemini get the pinning `--session-id` wrapper; codex gets the
+/// read-back signal-only wrapper (no flag injection).
 fn write_identity_shims_for(dir: &Path, tool: &str) -> std::io::Result<()> {
-    let bash = render_identity(IDENTITY_SHIM_BASH, tool, dir);
+    let bash = render_identity(identity_bash_template(tool), tool, dir);
     let extensionless = dir.join(tool);
     std::fs::write(&extensionless, bash.as_bytes())?;
     set_executable(&extensionless)?;
 
     #[cfg(target_os = "windows")]
     {
-        let cmd_body = render_identity(IDENTITY_SHIM_CMD, tool, dir);
+        let cmd_body = render_identity(identity_cmd_template(tool), tool, dir);
         std::fs::write(dir.join(format!("{tool}.cmd")), cmd_body.as_bytes())?;
     }
 
@@ -619,9 +666,10 @@ mod tests {
     }
 
     #[test]
-    fn materialize_identity_writes_claude_and_gemini_always() {
+    fn materialize_identity_writes_claude_gemini_and_codex_always() {
         // The identity family is materialized with NO master-flag gate — it is
-        // the out-of-box session-restore guarantee.
+        // the out-of-box session-restore guarantee. Includes the read-back
+        // provider `codex` (provider #3).
         let tmp = tempfile::tempdir().unwrap();
         let dir = materialize_identity(tmp.path(), "term-id").expect("identity materialize ok");
         assert!(
@@ -631,23 +679,60 @@ mod tests {
                 .starts_with(IDENTITY_DIR_PREFIX),
             "identity dir uses its own prefix"
         );
+        // codex MUST be in the always-on family.
+        assert!(
+            IDENTITY_TOOLS.contains(&CODEX_TOOL),
+            "codex is an always-on identity tool"
+        );
         for tool in IDENTITY_TOOLS {
             let f = dir.join(tool);
             assert!(f.exists(), "extensionless {tool} identity shim must exist");
             let body = std::fs::read_to_string(&f).unwrap();
             assert!(body.contains(&format!("TOOL=\"{tool}\"")));
-            // The shim pins the runner-injected session id and respects the
-            // recursion guard.
-            assert!(body.contains("QONTINUI_PINNED_SESSION_ID"));
-            assert!(body.contains("--session-id"));
+            // Every identity shim respects the recursion guard and signals via
+            // the control route.
             assert!(body.contains("QONTINUI_INSTALL_INTERCEPT_GUARD"));
-            // It confirms via the new control route.
             assert!(body.contains("/control/session-open"));
+
+            if *tool == CODEX_TOOL {
+                // The codex wrapper is the READ-BACK signal-only wrapper: it
+                // must NOT pin/append a `--session-id` (codex has no such flag —
+                // appending one would break it), and must NOT read the pinned-id
+                // env. Identity is read back from the rollout file instead.
+                assert!(
+                    !body.contains("--session-id"),
+                    "codex wrapper must NOT append --session-id (no such flag)"
+                );
+                assert!(
+                    !body.contains("QONTINUI_PINNED_SESSION_ID"),
+                    "codex wrapper does not pin an id"
+                );
+            } else {
+                // claude/gemini get the pinning wrapper: it reads the
+                // runner-injected pinned id and appends `--session-id`.
+                assert!(body.contains("QONTINUI_PINNED_SESSION_ID"));
+                assert!(body.contains("--session-id"));
+            }
             #[cfg(target_os = "windows")]
-            assert!(
-                dir.join(format!("{tool}.cmd")).exists(),
-                "{tool}.cmd identity shim must exist on Windows"
-            );
+            {
+                let cmd_path = dir.join(format!("{tool}.cmd"));
+                assert!(
+                    cmd_path.exists(),
+                    "{tool}.cmd identity shim must exist on Windows"
+                );
+                let cmd_body = std::fs::read_to_string(&cmd_path).unwrap();
+                if *tool == CODEX_TOOL {
+                    assert!(
+                        !cmd_body.contains("--session-id"),
+                        "codex .cmd wrapper must NOT append --session-id"
+                    );
+                } else {
+                    assert!(
+                        cmd_body.contains("--session-id"),
+                        "{tool} .cmd wrapper appends --session-id"
+                    );
+                }
+            }
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;

--- a/src-tauri/src/install_effects_producer/mod.rs
+++ b/src-tauri/src/install_effects_producer/mod.rs
@@ -141,13 +141,18 @@ pub struct SessionOpenRequest {
     /// The per-PTY terminal id the runner injected as `QONTINUI_TERMINAL_ID`.
     pub terminal_id: String,
     /// The provider session id (the runner-pinned `QONTINUI_PINNED_SESSION_ID`,
-    /// echoed back by the hook for confirmation).
+    /// echoed back by the hook for confirmation). ABSENT/empty for a READ-BACK
+    /// provider (codex generates its own id; the runner reads it back from the
+    /// rollout file) — then the route triggers the codex read-back capture for
+    /// this terminal instead of recording synchronously.
+    #[serde(default)]
     pub session_id: String,
     /// `"startup"` | `"resume"` — the hook's source signal (liveness only).
     #[serde(default)]
     pub source: Option<String>,
-    /// Which provider owns the session (`"claude"`, `"gemini"`). Defaults to
-    /// claude when the hook omits it (back-compat / Claude-only deployments).
+    /// Which provider owns the session (`"claude"`, `"gemini"`, `"codex"`).
+    /// Defaults to claude when the hook omits it (back-compat / Claude-only
+    /// deployments).
     #[serde(default)]
     pub provider: Option<String>,
     /// The provider config dir, if the hook reports it.
@@ -176,11 +181,11 @@ async fn post_session_open(
     use crate::session::session_lifecycle_store::{SessionLifecycleStore, DEFAULT_PROVIDER};
     use tauri::Manager;
 
-    if req.terminal_id.trim().is_empty() || req.session_id.trim().is_empty() {
+    if req.terminal_id.trim().is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(api_error(
-                "session-open requires non-empty terminal_id and session_id".to_string(),
+                "session-open requires a non-empty terminal_id".to_string(),
             )),
         ));
     }
@@ -191,11 +196,77 @@ async fn post_session_open(
         .filter(|p| !p.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_PROVIDER.to_string());
 
+    let is_codex = provider == crate::session::codex_capture::CODEX_PROVIDER;
+    let has_session_id = !req.session_id.trim().is_empty();
+
     // The session-restore lifecycle store, shared in Tauri state by main.rs.
     let store = state
         .app_handle
         .try_state::<Arc<SessionLifecycleStore>>()
         .map(|s| s.inner().clone());
+
+    // ---- READ-BACK provider branch (codex, no session_id) --------------------
+    // Codex has no `--session-id` flag — it GENERATES its own id and writes it
+    // into a rollout file under CODEX_HOME. The codex wrapper signals here with
+    // NO session_id; we DON'T synchronously record a pinned row (we don't know
+    // the id yet). Instead we spawn the runner-side read-back capture for THIS
+    // terminal: it watches the real CODEX_HOME for the post-spawn rollout whose
+    // line-1 `session_meta.cwd` matches this terminal's cwd, then records+confirms
+    // the real id and supersedes the speculative spawn-time claude pin. Fail-open.
+    if is_codex && !has_session_id {
+        match store {
+            Some(store) => {
+                let cwd = req.cwd.clone().unwrap_or_default();
+                let title = req
+                    .cwd
+                    .as_deref()
+                    .and_then(|c| c.trim_end_matches(['/', '\\']).rsplit(['/', '\\']).next())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or(crate::session::codex_capture::CODEX_PROVIDER)
+                    .to_string();
+                let spawn_ms = chrono::Utc::now().timestamp_millis();
+                tokio::spawn(crate::session::codex_capture::capture_and_record_by_cwd(
+                    store,
+                    req.terminal_id.clone(),
+                    req.config_dir.clone(),
+                    cwd,
+                    title,
+                    "default".to_string(),
+                    0,
+                    spawn_ms,
+                    "session_meta".to_string(),
+                    "session_id".to_string(),
+                    crate::session::codex_capture::CODEX_CAPTURE_POLL_INTERVAL,
+                    crate::session::codex_capture::CODEX_CAPTURE_TIMEOUT,
+                ));
+                info!(
+                    terminal_id = %req.terminal_id,
+                    source = %req.source.as_deref().unwrap_or("?"),
+                    "control/session-open: codex signal — read-back capture spawned for terminal"
+                );
+            }
+            None => {
+                warn!(
+                    terminal_id = %req.terminal_id,
+                    "control/session-open: codex signal but lifecycle store not in Tauri state — \
+                     read-back capture skipped (best-effort); reconcile backstop owns recovery"
+                );
+            }
+        }
+        // 200: best-effort signal; never wedge codex startup.
+        return Ok(Json(ApiResponse::success(())));
+    }
+
+    // ---- PINNED provider branch (claude/gemini hooks — session_id present) ---
+    // Unchanged synchronous record behavior.
+    if !has_session_id {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(api_error(
+                "session-open requires a non-empty session_id for a pinned provider".to_string(),
+            )),
+        ));
+    }
 
     match store {
         Some(store) => {

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -352,16 +352,24 @@ pub fn record_captured_session(
     // analogue of the Claude SessionStart hook firing).
     store.confirm_session(&session_id);
 
-    // ---- supersede the speculative spawn-time pin -----------------------------
+    // ---- supersede the speculative spawn-time pin(s) --------------------------
     // The always-on identity seam pre-records a PROVISIONAL claude row for EVERY
     // terminal (keyed on the runner-pinned uuid). When codex turned out to host
     // this terminal, that claude row is a phantom (no real claude session). Close
     // it so the terminal has exactly ONE live row (the captured codex one).
     // Records are keyed by session_id, so the claude pin is a DIFFERENT open row
-    // for the same terminal — find it and close it, skipping the codex row we
-    // just wrote.
-    if let Some(other) = store.find_open_by_terminal(&terminal_id) {
-        if other.claude_session_id != session_id {
+    // for the same terminal — close every open row for the terminal EXCEPT the
+    // codex row we just wrote.
+    //
+    // We must iterate ALL matching open rows, not `find_open_by_terminal` (a
+    // single arbitrary match): at this point the terminal has two open rows (the
+    // claude pin AND the codex row), and that helper scans `HashMap::values()`
+    // in nondeterministic order — it can return the codex row itself, so a
+    // single-find + skip-self silently skips the supersede (flaky: green on
+    // Linux, red on Windows). A loop is order-independent and also closes any
+    // additional stale pins for the terminal.
+    for other in store.open_records() {
+        if other.terminal_id == terminal_id && other.claude_session_id != session_id {
             store.record_close(&other.claude_session_id, "superseded-by-codex");
             tracing::info!(
                 terminal_id = %terminal_id,

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -14,14 +14,17 @@
 //! parses the id out of its line-1 meta — actuating
 //! [`crate::session::provider_adapter::IdentityCapture::SessionFile`].
 //!
-//! ## Why "newest post-spawn under CODEX_HOME" is deterministic
+//! ## Why cwd + post-spawn-mtime (NOT isolation) disambiguates
 //!
-//! The runner isolates `CODEX_HOME` per account
-//! ([`crate::session::provider_adapter::CodexAdapter::account_isolation`]), so the
-//! sessions tree under it is not polluted by other accounts' concurrent codex
-//! activity. The single rollout written at/after this terminal's spawn names THIS
-//! session. (A shared, un-isolated CODEX_HOME would make this racy — hence the
-//! isolation is load-bearing, not just a config nicety.)
+//! The runner deliberately does NOT relocate `CODEX_HOME` for a hand-started
+//! codex — the user's `codex login` auth lives there, so relocating it would
+//! break codex out of the box. The read-back therefore scans the user's REAL
+//! (shared, un-isolated) codex home, which a concurrent same-account codex
+//! session could also write into. The line-1 `session_meta.cwd` (matched against
+//! the cwd the identity shim POSTed) PLUS the post-spawn mtime filter together
+//! name THIS terminal's session: the cwd pins which session, the mtime drops the
+//! pre-existing rollouts. That pair is the disambiguator — not directory
+//! isolation. (See [`capture_session_id_by_cwd`] / [`effective_codex_home`].)
 //!
 //! ## Deterministic + fail-open
 //!
@@ -210,11 +213,32 @@ pub fn parse_session_meta_from_line1(
 
 /// Normalize a path for a tolerant cwd compare: forward-slash separators, no
 /// trailing separator, lowercased (Windows path-insensitivity + codex sometimes
-/// reporting a drive-letter casing that differs from the shell's `$PWD`). Pure.
+/// reporting a drive-letter casing that differs from the shell's `$PWD`), and
+/// the MSYS/Git-Bash drive form folded to the Windows form. Pure.
+///
+/// The drive fold is load-bearing: codex (a Windows binary) records its cwd as
+/// `C:\Users\…` in the rollout `session_meta`, but the bash identity shim's
+/// `$PWD` is the mingw `/c/Users/…` form. Without folding `/c/…` ⇒ `c:/…` the
+/// two never compare equal and the cwd-match silently misses (degrading every
+/// git-bash-hosted codex session to the reconcile backstop). The shim ALSO now
+/// prefers `pwd -W` so it emits the Windows form directly; this fold is the
+/// defense-in-depth half so ANY caller's mingw path still matches.
 fn normalize_path_for_compare(p: &str) -> String {
-    let unified = p.replace('\\', "/");
-    let trimmed = unified.trim_end_matches('/');
-    trimmed.to_ascii_lowercase()
+    let unified = p.replace('\\', "/").to_ascii_lowercase();
+    // `/c/users/…` ⇒ `c:/users/…` (and bare `/c` ⇒ `c:`). Guarded so a real
+    // POSIX single-letter top dir is only folded when it looks like a drive
+    // (single ascii letter between the leading slash and the next slash / EOS).
+    let b = unified.as_bytes();
+    let drive_fixed = if b.len() >= 2
+        && b[0] == b'/'
+        && b[1].is_ascii_lowercase()
+        && (b.len() == 2 || b[2] == b'/')
+    {
+        format!("{}:{}", &unified[1..2], &unified[2..])
+    } else {
+        unified
+    };
+    drive_fixed.trim_end_matches('/').to_string()
 }
 
 /// Whether two paths refer to the same directory under the tolerant compare.
@@ -641,6 +665,13 @@ mod tests {
         assert!(cwd_matches("C:\\Repos\\Widget", "c:/repos/widget/"));
         assert!(cwd_matches("/home/u/proj/", "/home/u/proj"));
         assert!(!cwd_matches("C:/repos/widget", "C:/repos/other"));
+        // MSYS/Git-Bash `$PWD` drive form vs the Windows form codex records —
+        // MUST match (the defect the temp-runner-style probe surfaced).
+        assert!(cwd_matches("/c/users/jspin/proj", "C:\\Users\\jspin\\proj"));
+        assert!(cwd_matches("/c/repos/widget", "c:/repos/widget"));
+        // A real POSIX path is NOT mangled into a different one.
+        assert!(cwd_matches("/home/u/proj", "/home/u/proj"));
+        assert!(!cwd_matches("/c/repos/widget", "/d/repos/widget"));
     }
 
     /// REAL-HOME match: among several post-spawn rollouts, the one whose line-1

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -1,0 +1,422 @@
+//! Codex read-back identity capture (session-restore-redesign Phase 3).
+//!
+//! ## Why a read-back capture (and not a hook)
+//!
+//! Codex has **no `--session-id` flag** — it GENERATES its own session id (a
+//! UUIDv7 it calls `thread_id`/`session_id`) — so the runner cannot pin identity
+//! at spawn the way it does for Claude. And Codex's `SessionStart` hook does not
+//! fire reliably in `codex exec` (upstream bug), so there is no POSTing hook to
+//! confirm a session either. Identity therefore rides a READ-BACK channel: at
+//! session start Codex writes
+//! `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ISO-ts>-<uuid>.jsonl`, whose line 1
+//! is `{"type":"session_meta","payload":{"session_id":"<uuid>", ...}}`. This
+//! module finds the NEWEST such file written AFTER a given spawn instant and
+//! parses the id out of its line-1 meta — actuating
+//! [`crate::session::provider_adapter::IdentityCapture::SessionFile`].
+//!
+//! ## Why "newest post-spawn under CODEX_HOME" is deterministic
+//!
+//! The runner isolates `CODEX_HOME` per account
+//! ([`crate::session::provider_adapter::CodexAdapter::account_isolation`]), so the
+//! sessions tree under it is not polluted by other accounts' concurrent codex
+//! activity. The single rollout written at/after this terminal's spawn names THIS
+//! session. (A shared, un-isolated CODEX_HOME would make this racy — hence the
+//! isolation is load-bearing, not just a config nicety.)
+//!
+//! ## Deterministic + fail-open
+//!
+//! Every step degrades to "did nothing" on any miss (no `CODEX_HOME`, no sessions
+//! dir, no post-spawn file, an unparseable line 1): the session is simply left to
+//! the existing reconcile backstop ([`crate::session::reconcile`]) /
+//! liveness-poll machinery, never a panic. The capture confirms via the same
+//! durable store the Claude hook path uses
+//! ([`crate::commands::terminal::record_pinned_session_open`] +
+//! [`crate::session::session_lifecycle_store::SessionLifecycleStore::confirm_session`]).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::session::session_lifecycle_store::SessionLifecycleStore;
+
+/// Provider id recorded for a captured codex session.
+pub const CODEX_PROVIDER: &str = "codex";
+
+/// Default poll interval while waiting for the rollout file to appear.
+pub const CODEX_CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// Default give-up timeout for the read-back wait — generous because the
+/// interactive Codex TUI may sit at an auth/onboarding prompt before it writes
+/// the rollout. Past this, the reconcile backstop owns recovery.
+pub const CODEX_CAPTURE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The sub-directory under `CODEX_HOME` Codex writes rollouts into.
+const SESSIONS_SUBDIR: &str = "sessions";
+/// The rollout filename prefix (`rollout-<ISO-ts>-<uuid>.jsonl`).
+const ROLLOUT_PREFIX: &str = "rollout-";
+/// The rollout filename extension.
+const ROLLOUT_EXT: &str = "jsonl";
+
+/// A discovered rollout file + the modified-time used to rank it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RolloutFile {
+    path: PathBuf,
+    /// Modified time as Unix epoch millis (the ranking key).
+    modified_ms: i64,
+}
+
+/// Recursively collect every `rollout-*.jsonl` under `sessions_root`. Returns an
+/// empty vec on any IO error (fail-open). Bounded recursion via the on-disk
+/// `YYYY/MM/DD/` layout; we walk generically so a layout tweak doesn't break it.
+fn collect_rollouts(sessions_root: &Path) -> Vec<RolloutFile> {
+    let mut out = Vec::new();
+    let mut stack = vec![sessions_root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue, // unreadable dir — skip (fail-open)
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !is_rollout_file(&path) {
+                continue;
+            }
+            let modified_ms = entry
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            out.push(RolloutFile { path, modified_ms });
+        }
+    }
+    out
+}
+
+/// Does `path` look like a codex rollout file (`rollout-*.jsonl`)?
+fn is_rollout_file(path: &Path) -> bool {
+    let is_jsonl = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case(ROLLOUT_EXT))
+        .unwrap_or(false);
+    if !is_jsonl {
+        return false;
+    }
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.starts_with(ROLLOUT_PREFIX))
+        .unwrap_or(false)
+}
+
+/// Pick the NEWEST rollout written at/after `spawn_ms` (epoch millis). A small
+/// negative skew is tolerated because file mtime granularity / clock skew can put
+/// a just-written rollout a beat before the observed spawn instant. Returns the
+/// chosen file path, or `None` when nothing qualifies (fail-open ⇒ reconcile
+/// backstop).
+fn newest_post_spawn(rollouts: &[RolloutFile], spawn_ms: i64) -> Option<&RolloutFile> {
+    const SKEW_MS: i64 = 5_000;
+    rollouts
+        .iter()
+        .filter(|r| r.modified_ms + SKEW_MS >= spawn_ms)
+        .max_by_key(|r| r.modified_ms)
+}
+
+/// Parse the session id out of a rollout file's line 1. Codex writes
+/// `{"type":"session_meta","payload":{"session_id":"<uuid>","id":"<uuid>",...}}`
+/// as the first line. `meta_line_type` is the expected `type`
+/// (`"session_meta"`); `id_field` is the id key (`"session_id"`), looked up both
+/// at the top level and under a nested `payload` object (the verified shape nests
+/// it under `payload`). Returns `None` on any parse miss (fail-open).
+pub fn parse_session_id_from_line1(
+    line1: &str,
+    meta_line_type: &str,
+    id_field: &str,
+) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(line1.trim()).ok()?;
+    // Guard on the meta line type so we don't misread a non-meta first line.
+    if v.get("type").and_then(|t| t.as_str()) != Some(meta_line_type) {
+        return None;
+    }
+    // The id lives under `payload` in the verified shape; accept a top-level
+    // field too for forward-compat.
+    let from_payload = v
+        .get("payload")
+        .and_then(|p| p.get(id_field))
+        .and_then(|s| s.as_str());
+    let from_top = v.get(id_field).and_then(|s| s.as_str());
+    from_payload
+        .or(from_top)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// Read line 1 of a file (best-effort). Returns `None` on any IO error.
+fn read_first_line(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    content.lines().next().map(|s| s.to_string())
+}
+
+/// Resolve the `sessions/` root under a `CODEX_HOME` dir.
+pub fn sessions_root(codex_home: &Path) -> PathBuf {
+    codex_home.join(SESSIONS_SUBDIR)
+}
+
+/// Pure capture core: given the sessions root, the spawn instant, and the
+/// capture spec fields, find the newest post-spawn rollout and parse its session
+/// id. `None` on any miss. Separated from the async task + store writes so the
+/// whole find+parse flow is unit-testable against a real on-disk fixture without
+/// a Tauri app handle or a running runtime.
+pub fn capture_session_id(
+    sessions_root: &Path,
+    spawn_ms: i64,
+    meta_line_type: &str,
+    id_field: &str,
+) -> Option<String> {
+    let rollouts = collect_rollouts(sessions_root);
+    let chosen = newest_post_spawn(&rollouts, spawn_ms)?;
+    let line1 = read_first_line(&chosen.path)?;
+    parse_session_id_from_line1(&line1, meta_line_type, id_field)
+}
+
+/// Record + confirm a captured codex session into the durable store. This is the
+/// read-back analogue of the Claude hook's `/control/session-open` write: it
+/// records the (now-known) real id authoritatively for `terminal_id` and
+/// CONFIRMS it (provisional→confirmed), so Phase 4's restore classifier treats it
+/// as a real session and the liveness poll keeps it alive. Idempotent —
+/// `record_open` dedups by session id and `confirm_session` is monotonic.
+pub fn record_captured_session(
+    store: &SessionLifecycleStore,
+    session_id: String,
+    terminal_id: String,
+    config_dir: Option<String>,
+    working_dir: String,
+    title: String,
+    page_id: String,
+    zone_index: i32,
+) {
+    crate::commands::terminal::record_pinned_session_open(
+        store,
+        session_id.clone(),
+        terminal_id,
+        config_dir,
+        working_dir,
+        title,
+        page_id,
+        zone_index,
+        CODEX_PROVIDER.to_string(),
+    );
+    // A real rollout file proves the session exists — confirm it (the read-back
+    // analogue of the Claude SessionStart hook firing).
+    store.confirm_session(&session_id);
+}
+
+/// Async read-back task: poll for the newest post-spawn rollout under
+/// `codex_home/sessions`, and on success record+confirm the captured session.
+/// Fail-open: on timeout (no rollout appeared) it logs and returns — the
+/// reconcile backstop owns recovery from there. Never panics.
+///
+/// `spawn_ms` is the spawn instant (epoch millis) used to reject pre-existing
+/// foreign rollouts. The provisional spawn-time record (keyed on a temporary
+/// correlation, written by the seam) is NOT mutated here — this writes the real
+/// id under a fresh authoritative+confirmed row; the provisional placeholder row
+/// (if any) is reaped by the phantom-prune in [`crate::session::reconcile`].
+#[allow(clippy::too_many_arguments)]
+pub async fn capture_and_record(
+    store: std::sync::Arc<SessionLifecycleStore>,
+    codex_home: PathBuf,
+    terminal_id: String,
+    config_dir: Option<String>,
+    working_dir: String,
+    title: String,
+    page_id: String,
+    zone_index: i32,
+    spawn_ms: i64,
+    meta_line_type: String,
+    id_field: String,
+    interval: Duration,
+    timeout: Duration,
+) {
+    let root = sessions_root(&codex_home);
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(session_id) = capture_session_id(&root, spawn_ms, &meta_line_type, &id_field) {
+            record_captured_session(
+                &store,
+                session_id.clone(),
+                terminal_id.clone(),
+                config_dir.clone(),
+                working_dir.clone(),
+                title.clone(),
+                page_id.clone(),
+                zone_index,
+            );
+            tracing::info!(
+                terminal_id = %terminal_id,
+                codex_session = %session_id,
+                "session-restore: codex read-back captured session id from rollout file"
+            );
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            tracing::info!(
+                terminal_id = %terminal_id,
+                codex_home = %codex_home.display(),
+                "session-restore: codex read-back timed out (no post-spawn rollout) — reconcile backstop owns recovery"
+            );
+            return;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    /// The verified rollout line-1 shape (`session_meta` with the id nested under
+    /// `payload`) parses out the session id.
+    #[test]
+    fn parse_line1_extracts_nested_session_id() {
+        let line = r#"{"type":"session_meta","payload":{"session_id":"abc-123","id":"abc-123","cwd":"C:/repo"}}"#;
+        assert_eq!(
+            parse_session_id_from_line1(line, "session_meta", "session_id"),
+            Some("abc-123".to_string())
+        );
+    }
+
+    /// A top-level id field is accepted too (forward-compat).
+    #[test]
+    fn parse_line1_accepts_top_level_id() {
+        let line = r#"{"type":"session_meta","session_id":"top-1"}"#;
+        assert_eq!(
+            parse_session_id_from_line1(line, "session_meta", "session_id"),
+            Some("top-1".to_string())
+        );
+    }
+
+    /// A non-meta first line, a wrong type, or garbage ⇒ None (fail-open).
+    #[test]
+    fn parse_line1_rejects_non_meta_and_garbage() {
+        assert_eq!(
+            parse_session_id_from_line1(
+                r#"{"type":"turn","payload":{"session_id":"x"}}"#,
+                "session_meta",
+                "session_id"
+            ),
+            None,
+            "wrong type rejected"
+        );
+        assert_eq!(
+            parse_session_id_from_line1("not json at all", "session_meta", "session_id"),
+            None
+        );
+        assert_eq!(
+            parse_session_id_from_line1(
+                r#"{"type":"session_meta","payload":{}}"#,
+                "session_meta",
+                "session_id"
+            ),
+            None,
+            "missing id ⇒ None"
+        );
+    }
+
+    /// End-to-end on a real on-disk fixture: a post-spawn rollout under
+    /// `sessions/YYYY/MM/DD/` is found and its session id parsed; a pre-spawn
+    /// foreign rollout is ignored.
+    #[test]
+    fn capture_session_id_finds_newest_post_spawn_rollout() {
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let day = sessions_root(home).join("2026").join("06").join("25");
+        fs::create_dir_all(&day).unwrap();
+
+        // A foreign rollout that already existed before the spawn — must be
+        // ignored even though it's a valid session_meta.
+        let foreign = day.join("rollout-2026-06-25T09-00-00-foreign-uuid.jsonl");
+        fs::write(
+            &foreign,
+            r#"{"type":"session_meta","payload":{"session_id":"foreign-uuid"}}
+{"type":"turn"}"#,
+        )
+        .unwrap();
+        // Age its mtime well before the spawn instant.
+        let early = std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(1_000);
+        filetime_set(&foreign, early);
+
+        // The spawn instant.
+        let spawn_ms = 100_000;
+
+        // Our post-spawn rollout.
+        let ours = day.join("rollout-2026-06-25T10-00-00-ours-uuid.jsonl");
+        fs::write(
+            &ours,
+            r#"{"type":"session_meta","payload":{"session_id":"ours-uuid","cwd":"C:/repo"}}
+{"type":"turn"}"#,
+        )
+        .unwrap();
+        let after = std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(200_000);
+        filetime_set(&ours, after);
+
+        let got = capture_session_id(&sessions_root(home), spawn_ms, "session_meta", "session_id");
+        assert_eq!(
+            got,
+            Some("ours-uuid".to_string()),
+            "newest post-spawn rollout wins; pre-spawn foreign ignored"
+        );
+    }
+
+    /// No sessions dir / no post-spawn file ⇒ None (fail-open, no panic).
+    #[test]
+    fn capture_session_id_is_none_when_nothing_qualifies() {
+        let dir = tempdir().unwrap();
+        // No sessions dir at all.
+        assert_eq!(
+            capture_session_id(&sessions_root(dir.path()), 0, "session_meta", "session_id"),
+            None
+        );
+    }
+
+    /// record_captured_session writes an authoritative+confirmed codex row.
+    #[test]
+    fn record_captured_session_writes_confirmed_codex_row() {
+        let dir = tempdir().unwrap();
+        let store = SessionLifecycleStore::open(dir.path().join("s.json")).unwrap();
+        record_captured_session(
+            &store,
+            "codex-sess-1".to_string(),
+            "term-1".to_string(),
+            Some("C:/codex-home".to_string()),
+            "C:/repo".to_string(),
+            "repo".to_string(),
+            "default".to_string(),
+            0,
+        );
+        let rec = store.get("codex-sess-1").expect("row written");
+        assert_eq!(rec.provider, CODEX_PROVIDER);
+        assert!(rec.confirmed_at.is_some(), "captured session is confirmed");
+        assert_eq!(rec.terminal_id, "term-1");
+        assert_eq!(
+            rec.origin.as_deref(),
+            Some(crate::session::session_lifecycle_store::ORIGIN_AUTHORITATIVE)
+        );
+    }
+
+    /// Set a file's mtime (test helper). Uses a small inline filetime shim so we
+    /// don't add a dep — writes via `std::fs::File::set_modified` (stable since
+    /// Rust 1.75).
+    fn filetime_set(path: &Path, when: std::time::SystemTime) {
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        let _ = f.set_modified(when);
+    }
+}

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -55,6 +55,26 @@ const ROLLOUT_PREFIX: &str = "rollout-";
 /// The rollout filename extension.
 const ROLLOUT_EXT: &str = "jsonl";
 
+/// Resolve the EFFECTIVE codex home the way the codex CLI does: the `CODEX_HOME`
+/// env var if set+non-empty, else `~/.codex`. Returns `None` only when neither is
+/// resolvable (no env AND no home dir) — fail-open: the caller then defers to the
+/// reconcile backstop.
+///
+/// This is the REAL-HOME resolution (the user's `codex login` auth lives there) —
+/// the runner does NOT relocate `CODEX_HOME` for a hand-started codex, so the
+/// read-back must scan wherever codex actually wrote its rollout. The cwd+mtime
+/// match below disambiguates THIS terminal's session from any other account's
+/// concurrent codex activity under the same (shared, un-isolated) home.
+pub fn effective_codex_home() -> Option<PathBuf> {
+    if let Some(home) = std::env::var("CODEX_HOME")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+    {
+        return Some(PathBuf::from(home));
+    }
+    dirs::home_dir().map(|h| h.join(".codex"))
+}
+
 /// A discovered rollout file + the modified-time used to rank it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RolloutFile {
@@ -158,6 +178,50 @@ pub fn parse_session_id_from_line1(
         .map(|s| s.to_string())
 }
 
+/// Parse BOTH the session id and the `cwd` out of a rollout file's line 1. Codex
+/// writes `{"type":"session_meta","payload":{"session_id":"<uuid>","cwd":"<dir>",
+/// ...}}`. Returns `(session_id, Option<cwd>)` — the cwd is optional (an older
+/// rollout may omit it). `None` on any parse miss (wrong type / missing id /
+/// garbage), mirroring [`parse_session_id_from_line1`].
+pub fn parse_session_meta_from_line1(
+    line1: &str,
+    meta_line_type: &str,
+    id_field: &str,
+) -> Option<(String, Option<String>)> {
+    let v: serde_json::Value = serde_json::from_str(line1.trim()).ok()?;
+    if v.get("type").and_then(|t| t.as_str()) != Some(meta_line_type) {
+        return None;
+    }
+    let payload = v.get("payload");
+    let id = payload
+        .and_then(|p| p.get(id_field))
+        .and_then(|s| s.as_str())
+        .or_else(|| v.get(id_field).and_then(|s| s.as_str()))
+        .filter(|s| !s.is_empty())?
+        .to_string();
+    let cwd = payload
+        .and_then(|p| p.get("cwd"))
+        .and_then(|s| s.as_str())
+        .or_else(|| v.get("cwd").and_then(|s| s.as_str()))
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    Some((id, cwd))
+}
+
+/// Normalize a path for a tolerant cwd compare: forward-slash separators, no
+/// trailing separator, lowercased (Windows path-insensitivity + codex sometimes
+/// reporting a drive-letter casing that differs from the shell's `$PWD`). Pure.
+fn normalize_path_for_compare(p: &str) -> String {
+    let unified = p.replace('\\', "/");
+    let trimmed = unified.trim_end_matches('/');
+    trimmed.to_ascii_lowercase()
+}
+
+/// Whether two paths refer to the same directory under the tolerant compare.
+fn cwd_matches(a: &str, b: &str) -> bool {
+    normalize_path_for_compare(a) == normalize_path_for_compare(b)
+}
+
 /// Read line 1 of a file (best-effort). Returns `None` on any IO error.
 fn read_first_line(path: &Path) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;
@@ -186,6 +250,53 @@ pub fn capture_session_id(
     parse_session_id_from_line1(&line1, meta_line_type, id_field)
 }
 
+/// REAL-HOME capture core: scan EVERY post-spawn rollout under `sessions_root`
+/// and pick the NEWEST whose line-1 `session_meta` `cwd` matches `want_cwd`
+/// (path-normalized) — returning its parsed `session_id`. `None` on any miss.
+///
+/// ## Why cwd-match (not just newest-post-spawn)
+///
+/// [`capture_session_id`] assumed an ISOLATED `$CODEX_HOME` (one account's
+/// rollouts only), so "newest post-spawn" alone names the session. A
+/// hand-started codex uses the REAL, possibly-SHARED home (the runner never
+/// relocates it — auth lives there), where another account's concurrent codex
+/// could write a newer post-spawn rollout. The line-1 `cwd` disambiguates: this
+/// terminal's rollout was written from THIS terminal's working directory.
+/// Combined with the mtime ≥ spawn filter (a small skew tolerated, as in
+/// [`newest_post_spawn`]), the cwd+mtime pair deterministically names this
+/// session. `None` on no match ⇒ reconcile backstop owns recovery.
+pub fn capture_session_id_by_cwd(
+    sessions_root: &Path,
+    spawn_ms: i64,
+    want_cwd: &str,
+    meta_line_type: &str,
+    id_field: &str,
+) -> Option<String> {
+    const SKEW_MS: i64 = 5_000;
+    let mut rollouts = collect_rollouts(sessions_root);
+    // Newest first so the FIRST cwd-match we accept is the newest qualifying one.
+    rollouts.sort_by_key(|r| std::cmp::Reverse(r.modified_ms));
+    for r in &rollouts {
+        if r.modified_ms + SKEW_MS < spawn_ms {
+            continue; // pre-spawn — a foreign/older session
+        }
+        let Some(line1) = read_first_line(&r.path) else {
+            continue;
+        };
+        let Some((id, cwd)) = parse_session_meta_from_line1(&line1, meta_line_type, id_field)
+        else {
+            continue;
+        };
+        match cwd {
+            Some(c) if cwd_matches(&c, want_cwd) => return Some(id),
+            // A rollout missing its cwd can't be matched to this terminal — skip
+            // (the cwd is the disambiguator on a shared home).
+            _ => continue,
+        }
+    }
+    None
+}
+
 /// Record + confirm a captured codex session into the durable store. This is the
 /// read-back analogue of the Claude hook's `/control/session-open` write: it
 /// records the (now-known) real id authoritatively for `terminal_id` and
@@ -205,7 +316,7 @@ pub fn record_captured_session(
     crate::commands::terminal::record_pinned_session_open(
         store,
         session_id.clone(),
-        terminal_id,
+        terminal_id.clone(),
         config_dir,
         working_dir,
         title,
@@ -216,6 +327,26 @@ pub fn record_captured_session(
     // A real rollout file proves the session exists — confirm it (the read-back
     // analogue of the Claude SessionStart hook firing).
     store.confirm_session(&session_id);
+
+    // ---- supersede the speculative spawn-time pin -----------------------------
+    // The always-on identity seam pre-records a PROVISIONAL claude row for EVERY
+    // terminal (keyed on the runner-pinned uuid). When codex turned out to host
+    // this terminal, that claude row is a phantom (no real claude session). Close
+    // it so the terminal has exactly ONE live row (the captured codex one).
+    // Records are keyed by session_id, so the claude pin is a DIFFERENT open row
+    // for the same terminal — find it and close it, skipping the codex row we
+    // just wrote.
+    if let Some(other) = store.find_open_by_terminal(&terminal_id) {
+        if other.claude_session_id != session_id {
+            store.record_close(&other.claude_session_id, "superseded-by-codex");
+            tracing::info!(
+                terminal_id = %terminal_id,
+                superseded = %other.claude_session_id,
+                codex_session = %session_id,
+                "session-restore: closed speculative spawn-time pin superseded by captured codex session"
+            );
+        }
+    }
 }
 
 /// Async read-back task: poll for the newest post-spawn rollout under
@@ -270,6 +401,76 @@ pub async fn capture_and_record(
                 terminal_id = %terminal_id,
                 codex_home = %codex_home.display(),
                 "session-restore: codex read-back timed out (no post-spawn rollout) — reconcile backstop owns recovery"
+            );
+            return;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// REAL-HOME async read-back task, triggered by the codex wrapper's
+/// `/control/session-open` POST (provider=codex, NO session_id). Resolves the
+/// EFFECTIVE codex home ([`effective_codex_home`] — `$CODEX_HOME` else `~/.codex`,
+/// NEVER relocated), then polls for the newest post-spawn rollout whose line-1
+/// `session_meta.cwd` matches `working_dir` ([`capture_session_id_by_cwd`]). On
+/// match it records+confirms the codex session and supersedes the speculative
+/// spawn-time claude pin (see [`record_captured_session`]).
+///
+/// Fail-open at every step: no resolvable home, or no cwd+post-spawn match within
+/// `timeout`, logs and returns — the reconcile backstop owns recovery. Never
+/// panics. `title`/`page_id`/`zone_index` are best-effort tile metadata.
+#[allow(clippy::too_many_arguments)]
+pub async fn capture_and_record_by_cwd(
+    store: std::sync::Arc<SessionLifecycleStore>,
+    terminal_id: String,
+    config_dir: Option<String>,
+    working_dir: String,
+    title: String,
+    page_id: String,
+    zone_index: i32,
+    spawn_ms: i64,
+    meta_line_type: String,
+    id_field: String,
+    interval: Duration,
+    timeout: Duration,
+) {
+    let Some(codex_home) = effective_codex_home() else {
+        tracing::info!(
+            terminal_id = %terminal_id,
+            "session-restore: codex read-back has no resolvable CODEX_HOME / ~/.codex — deferring to reconcile backstop"
+        );
+        return;
+    };
+    let root = sessions_root(&codex_home);
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(session_id) =
+            capture_session_id_by_cwd(&root, spawn_ms, &working_dir, &meta_line_type, &id_field)
+        {
+            record_captured_session(
+                &store,
+                session_id.clone(),
+                terminal_id.clone(),
+                config_dir.clone(),
+                working_dir.clone(),
+                title.clone(),
+                page_id.clone(),
+                zone_index,
+            );
+            tracing::info!(
+                terminal_id = %terminal_id,
+                codex_session = %session_id,
+                cwd = %working_dir,
+                "session-restore: codex read-back captured session id by cwd+mtime match"
+            );
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            tracing::info!(
+                terminal_id = %terminal_id,
+                codex_home = %codex_home.display(),
+                cwd = %working_dir,
+                "session-restore: codex read-back (by cwd) timed out — reconcile backstop owns recovery"
             );
             return;
         }
@@ -410,6 +611,159 @@ mod tests {
             rec.origin.as_deref(),
             Some(crate::session::session_lifecycle_store::ORIGIN_AUTHORITATIVE)
         );
+    }
+
+    /// `parse_session_meta_from_line1` returns both id and cwd.
+    #[test]
+    fn parse_meta_extracts_id_and_cwd() {
+        let line =
+            r#"{"type":"session_meta","payload":{"session_id":"abc","cwd":"C:\\repos\\widget"}}"#;
+        assert_eq!(
+            parse_session_meta_from_line1(line, "session_meta", "session_id"),
+            Some(("abc".to_string(), Some("C:\\repos\\widget".to_string())))
+        );
+        // Missing cwd ⇒ id with None cwd.
+        let no_cwd = r#"{"type":"session_meta","payload":{"session_id":"abc"}}"#;
+        assert_eq!(
+            parse_session_meta_from_line1(no_cwd, "session_meta", "session_id"),
+            Some(("abc".to_string(), None))
+        );
+        // Wrong type ⇒ None.
+        assert_eq!(
+            parse_session_meta_from_line1(r#"{"type":"turn"}"#, "session_meta", "session_id"),
+            None
+        );
+    }
+
+    /// The cwd compare tolerates separator + trailing-sep + case differences.
+    #[test]
+    fn cwd_match_is_tolerant() {
+        assert!(cwd_matches("C:\\Repos\\Widget", "c:/repos/widget/"));
+        assert!(cwd_matches("/home/u/proj/", "/home/u/proj"));
+        assert!(!cwd_matches("C:/repos/widget", "C:/repos/other"));
+    }
+
+    /// REAL-HOME match: among several post-spawn rollouts, the one whose line-1
+    /// `cwd` matches THIS terminal's cwd wins — even if a DIFFERENT account's
+    /// rollout (different cwd) is newer. The pre-spawn rollout is ignored.
+    #[test]
+    fn capture_by_cwd_picks_matching_cwd_post_spawn() {
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let day = sessions_root(home).join("2026").join("06").join("25");
+        fs::create_dir_all(&day).unwrap();
+
+        // A pre-spawn rollout in OUR cwd — ignored (mtime before spawn).
+        let pre = day.join("rollout-2026-06-25T08-00-00-pre.jsonl");
+        fs::write(
+            &pre,
+            r#"{"type":"session_meta","payload":{"session_id":"pre-uuid","cwd":"C:/repos/widget"}}"#,
+        )
+        .unwrap();
+        filetime_set(
+            &pre,
+            std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(1_000),
+        );
+
+        let spawn_ms = 100_000;
+
+        // A NEWER post-spawn rollout from ANOTHER account/cwd — must NOT match.
+        let other = day.join("rollout-2026-06-25T11-00-00-other.jsonl");
+        fs::write(
+            &other,
+            r#"{"type":"session_meta","payload":{"session_id":"other-uuid","cwd":"C:/repos/elsewhere"}}"#,
+        )
+        .unwrap();
+        filetime_set(
+            &other,
+            std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(300_000),
+        );
+
+        // OUR post-spawn rollout — matching cwd (note backslash + casing diff).
+        let ours = day.join("rollout-2026-06-25T10-00-00-ours.jsonl");
+        fs::write(
+            &ours,
+            r#"{"type":"session_meta","payload":{"session_id":"ours-uuid","cwd":"C:\\Repos\\Widget"}}"#,
+        )
+        .unwrap();
+        filetime_set(
+            &ours,
+            std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(200_000),
+        );
+
+        let got = capture_session_id_by_cwd(
+            &sessions_root(home),
+            spawn_ms,
+            "C:/repos/widget",
+            "session_meta",
+            "session_id",
+        );
+        assert_eq!(
+            got,
+            Some("ours-uuid".to_string()),
+            "cwd match wins over a newer non-matching rollout; pre-spawn ignored"
+        );
+
+        // No cwd matches ⇒ None (fail-open).
+        assert_eq!(
+            capture_session_id_by_cwd(
+                &sessions_root(home),
+                spawn_ms,
+                "C:/repos/nonexistent",
+                "session_meta",
+                "session_id"
+            ),
+            None
+        );
+    }
+
+    /// `record_captured_session` supersedes the speculative spawn-time claude pin
+    /// for the SAME terminal: the codex row is recorded+confirmed and the prior
+    /// claude row is closed `superseded-by-codex`, leaving exactly one live row.
+    #[test]
+    fn record_captured_session_supersedes_spawn_time_claude_pin() {
+        let dir = tempdir().unwrap();
+        let store = SessionLifecycleStore::open(dir.path().join("s.json")).unwrap();
+
+        // The seam's speculative spawn-time claude pin for this terminal.
+        crate::commands::terminal::record_pinned_session_open(
+            &store,
+            "claude-pin-uuid".to_string(),
+            "term-9".to_string(),
+            None,
+            "C:/repo".to_string(),
+            "repo".to_string(),
+            "default".to_string(),
+            0,
+            "claude".to_string(),
+        );
+        assert_eq!(store.open_records().len(), 1);
+
+        // Codex read-back captures the REAL id for the same terminal.
+        record_captured_session(
+            &store,
+            "codex-real-uuid".to_string(),
+            "term-9".to_string(),
+            None,
+            "C:/repo".to_string(),
+            "repo".to_string(),
+            "default".to_string(),
+            0,
+        );
+
+        // Exactly one OPEN row remains — the codex one — confirmed.
+        let open = store.open_records();
+        assert_eq!(open.len(), 1, "the claude pin was superseded");
+        assert_eq!(open[0].claude_session_id, "codex-real-uuid");
+        assert_eq!(open[0].provider, CODEX_PROVIDER);
+        assert!(open[0].confirmed_at.is_some());
+
+        // The claude pin is closed with the supersede reason.
+        let claude = store
+            .get("claude-pin-uuid")
+            .expect("claude row still present");
+        assert_eq!(claude.state, "closed");
+        assert_eq!(claude.close_reason.as_deref(), Some("superseded-by-codex"));
     }
 
     /// Set a file's mtime (test helper). Uses a small inline filetime shim so we

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -57,6 +57,7 @@
 //! has fully absorbed the old surface.
 
 pub mod claude_hook;
+pub mod codex_capture;
 pub mod coord_sync;
 pub mod dual_write;
 pub mod handoff;

--- a/src-tauri/src/session/provider_adapter.rs
+++ b/src-tauri/src/session/provider_adapter.rs
@@ -6,25 +6,27 @@
 //! correlation, the boot-restore orchestration, the reconcile backstop, and
 //! the local registration endpoint all work the same regardless of which AI
 //! CLI hosts the session. Everything PROVIDER-SPECIFIC sits behind the
-//! [`SessionProviderAdapter`] trait — one impl per provider (Claude is #1,
-//! Gemini #2). The runner is not a Claude client.
+//! [`SessionProviderAdapter`] trait — one impl per provider ([`ClaudeAdapter`]
+//! is #1, [`CodexAdapter`] is #2). The runner is not a Claude client.
 //!
-//! ## What this phase ships
+//! ## What this ships
 //!
-//! Phase 1 ships the TRAIT + its supporting types + the registry seam
-//! ([`adapter_for`]) ONLY. The Claude reference adapter's resume/hook bodies
-//! are Phase 2 — the [`ClaudeAdapter`] here is a minimal placeholder that
-//! returns sensible defaults (NO `todo!()`/panics on any build- or test-
-//! exercised path), so the crate compiles and Phase 2 fills the bodies in
-//! without touching the registry seam.
+//! Phase 1 shipped the TRAIT + its supporting types + the registry seam
+//! ([`adapter_for`]); Phase 2 filled in [`ClaudeAdapter`]; **Phase 3 adds the
+//! second provider, [`CodexAdapter`], and generalizes the identity model**.
 //!
-//! ## The key simplification (plan §4)
+//! ## Identity is pin-OR-read-back (the Phase 3 generalization)
 //!
-//! Both shipped adapters support `--session-id` pinning, so the runner KNOWS
-//! the session id at launch (it generated it) and records synchronously —
-//! the SessionStart hook is **confirmation + liveness + resume-source
-//! signal**, not required for identity. Identity is deterministic even before
-//! any hook fires.
+//! The original contract was PIN-ONLY (`LaunchSpec.pinned_session_id`): it
+//! assumed the runner GENERATED the id (Claude `--session-id <uuid>`) and knew
+//! it synchronously at spawn. Codex breaks that — it has no `--session-id` flag
+//! and generates its own id, which the runner must READ BACK post-launch. So
+//! identity is now an [`IdentitySource`] enum: [`IdentitySource::Pinned`]
+//! (Claude — known at spawn, recorded authoritatively) OR
+//! [`IdentitySource::ReadBack`] (Codex — recovered post-launch via an
+//! [`IdentityCapture`] channel, recorded provisionally then confirmed). The spawn
+//! seam ([`crate::terminal::session`]) branches once on the arm; every provider
+//! is modeled, not just the pin-only one.
 
 use std::collections::BTreeMap;
 
@@ -44,19 +46,90 @@ pub enum RestoreTier {
     TerminalOnly,
 }
 
+/// How the runner learns a launched session's id (plan §4, generalized in
+/// Phase 3 for the read-back providers). The original contract was **pin-only**
+/// (`pinned_session_id: String`) — it baked in the assumption that the runner
+/// GENERATED the id and therefore knew it synchronously at spawn (Claude
+/// `--session-id <uuid>`). Codex breaks that assumption: it has NO `--session-id`
+/// flag and GENERATES its own id, which the runner must READ BACK post-launch.
+///
+/// [`IdentitySource`] is the genuinely general model — every provider declares
+/// HOW its id becomes known, and the spawn seam ([`crate::terminal::session`])
+/// branches once on the arm:
+///
+/// - [`IdentitySource::Pinned`] — known synchronously; record authoritatively at
+///   spawn exactly as before (Claude).
+/// - [`IdentitySource::ReadBack`] — provider-generated; record a PROVISIONAL row
+///   at spawn (no real id yet) and capture the real id via the declared channel,
+///   then `confirm_session` it (Codex).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentitySource {
+    /// The runner pinned the id at launch (Claude `--session-id <uuid>`) — known
+    /// synchronously, recorded authoritatively at spawn with zero transcript race.
+    Pinned(String),
+    /// The provider generates the id; the runner reads it back post-launch via
+    /// the declared [`IdentityCapture`] channel. The spawn-time record is
+    /// PROVISIONAL until the capture confirms it.
+    ReadBack(IdentityCapture),
+}
+
+/// The post-launch channel a [`IdentitySource::ReadBack`] provider exposes for
+/// the runner to recover the provider-generated session id. Both arms are
+/// deterministic + fail-open: a miss degrades to the existing reconcile
+/// backstop, never panics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityCapture {
+    /// Parse a JSONL stream event from the child's stdout. Codex
+    /// `exec --json` emits `{"type":"thread.started","thread_id":"<uuid>"}` as its
+    /// FIRST stdout line, before auth. `event_type` is the `type` value to match
+    /// (`"thread.started"`); `id_field` is the field carrying the id
+    /// (`"thread_id"`). Used for headless `codex exec --json` launches where the
+    /// runner owns the child's stdout.
+    StreamEvent {
+        /// The JSONL event's `type` value to match (`"thread.started"`).
+        event_type: String,
+        /// The field on the matched event carrying the session id (`"thread_id"`).
+        id_field: String,
+    },
+    /// Watch a session-file directory under the runner-isolated provider home and
+    /// recover the id from the newest matching file written post-spawn. Codex
+    /// writes `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ISO-ts>-<uuid>.jsonl` at
+    /// session start; line 1 is
+    /// `{"type":"session_meta","payload":{"session_id":"<uuid>",...}}`. This is
+    /// the ROBUST channel — it works for ANY launch mode (interactive TUI
+    /// included), since `CODEX_HOME` is runner-isolated (no cross-account
+    /// pollution makes "the newest post-spawn rollout" deterministic).
+    SessionFile {
+        /// Env var naming the runner-isolated provider home to scan under
+        /// (`"CODEX_HOME"`).
+        dir_env: String,
+        /// Glob (relative to the provider home) selecting session files
+        /// (`"sessions/**/rollout-*.jsonl"`).
+        glob: String,
+        /// The line-1 meta event's `type` value (`"session_meta"`).
+        meta_line_type: String,
+        /// The field (under the meta event, incl. its `payload`) carrying the id
+        /// (`"session_id"`).
+        id_field: String,
+    },
+}
+
 /// The spawn recipe an adapter produces so the runner can launch the provider
-/// with a KNOWN-up-front session id (plan §4 `launch_with_identity`). The
-/// runner injects `env` into the PTY child, runs `argv`, and records
-/// `pinned_session_id` authoritatively at spawn.
+/// and learn its session id (plan §4 `launch_with_identity`). The runner injects
+/// `env` into the PTY child, runs `argv`, and resolves identity per the
+/// [`IdentitySource`] arm: a [`IdentitySource::Pinned`] id is recorded
+/// authoritatively at spawn; a [`IdentitySource::ReadBack`] id is recorded
+/// provisionally then captured + confirmed via the declared channel.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LaunchSpec {
-    /// The program-and-args to run as the PTY child (`["claude", "--session-id", "<uuid>"]`).
+    /// The program-and-args to run as the PTY child
+    /// (`["claude", "--session-id", "<uuid>"]`; `["codex"]`).
     pub argv: Vec<String>,
     /// Extra env to inject into the child (account isolation, identity vars).
     pub env: BTreeMap<String, String>,
-    /// The session id the runner pinned (`--session-id <uuid>`) — recorded
-    /// authoritatively at spawn, zero transcript race.
-    pub pinned_session_id: String,
+    /// How the runner learns this session's id — pinned (known at spawn) or
+    /// read-back (recovered post-launch). See [`IdentitySource`].
+    pub identity: IdentitySource,
 }
 
 /// How the runner attaches its SessionStart capture hook WITHOUT editing the
@@ -168,7 +241,10 @@ impl SessionProviderAdapter for ClaudeAdapter {
         LaunchSpec {
             argv,
             env: self.account_isolation(account),
-            pinned_session_id: pinned,
+            // Claude pins the id at launch — known synchronously, recorded
+            // authoritatively at spawn (zero transcript race). Byte-identical
+            // behavior to the pre-Phase-3 pin-only contract.
+            identity: IdentitySource::Pinned(pinned),
         }
     }
 
@@ -247,15 +323,129 @@ impl SessionProviderAdapter for ClaudeAdapter {
     }
 }
 
-/// Registry seam (plan §4): resolve the adapter for `provider`. Phase 1 knows
-/// only the future Claude adapter; Phase 2 fleshes out [`ClaudeAdapter`] and
-/// Phase 3 adds the Gemini arm here. An UNKNOWN provider degrades to the Claude
-/// adapter (the only shipped provider today) rather than failing — a record
-/// with an unexpected provider should still restore via the default path, never
-/// be dropped.
+/// The OpenAI Codex CLI adapter (provider #2, Phase 3). The seam-proving second
+/// provider: Codex has **no `--session-id` flag** — it GENERATES its own session
+/// id (a UUIDv7 it calls `thread_id`/`session_id`), which the runner READS BACK
+/// post-launch. So this adapter returns [`IdentitySource::ReadBack`] rather than
+/// `Pinned`, exercising the generalized identity model end-to-end.
+///
+/// ## Identity is read-back, not pinned
+///
+/// Codex writes `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ISO-ts>-<uuid>.jsonl`
+/// at session start (any launch mode — interactive TUI included); line 1 is
+/// `{"type":"session_meta","payload":{"session_id":"<uuid>",...}}`. The runner
+/// isolates `CODEX_HOME` per account, so "the newest rollout written after this
+/// spawn" deterministically names THIS session. [`crate::session::codex_capture`]
+/// actuates the [`IdentityCapture::SessionFile`] channel.
+///
+/// Pin-your-version: empirically verified against codex-cli 0.142.2 on Windows.
+pub struct CodexAdapter;
+
+/// The env var naming Codex's runner-isolated config+auth+sessions home — the
+/// `CLAUDE_CONFIG_DIR` analogue. Relocating it isolates the account AND makes the
+/// rollout-file read-back deterministic (no cross-account session pollution).
+pub const CODEX_HOME_ENV: &str = "CODEX_HOME";
+
+impl SessionProviderAdapter for CodexAdapter {
+    fn provider(&self) -> &'static str {
+        "codex"
+    }
+
+    fn launch_with_identity(&self, _cwd: &str, account: Option<&str>) -> LaunchSpec {
+        // Interactive hand-start argv. Codex has NO `--session-id` flag — it
+        // generates its own id — so we never append one; identity is read-back.
+        // (We deliberately do not force a permission/yolo flag here: the
+        // interactive Codex TUI hand-start mirrors the operator's own use, and
+        // Codex's approval posture is configured via CODEX_HOME, not argv.)
+        let argv = vec!["codex".to_string()];
+        LaunchSpec {
+            argv,
+            env: self.account_isolation(account),
+            // Codex generates the id — the runner reads it back from the newest
+            // post-spawn rollout file under the runner-isolated CODEX_HOME. The
+            // spawn-time record is PROVISIONAL until the capture confirms it.
+            identity: IdentitySource::ReadBack(IdentityCapture::SessionFile {
+                dir_env: CODEX_HOME_ENV.to_string(),
+                glob: "sessions/**/rollout-*.jsonl".to_string(),
+                meta_line_type: "session_meta".to_string(),
+                id_field: "session_id".to_string(),
+            }),
+        }
+    }
+
+    fn capture_hook_delivery(&self, _cwd: &str) -> DeliverySpec {
+        // Codex has NO reliable SessionStart hook: the upstream `SessionStart`
+        // hook does NOT fire in `codex exec` (verified upstream bug), so we do
+        // NOT deliver one. Identity instead rides the READ-BACK channel
+        // (`IdentityCapture::SessionFile` over the runner-isolated CODEX_HOME) —
+        // the rollout file's line-1 `session_meta` is the confirmation signal,
+        // not a POSTing hook. Hence `DeliverySpec::None`: there is no settings
+        // file or project-local hook to attach.
+        DeliverySpec::None
+    }
+
+    fn resume_command(&self, session_id: &str, _account: Option<&str>) -> Vec<String> {
+        // Interactive (typed-into-the-restored-PTY) resume — the `claude --resume`
+        // analogue. Codex accepts the UUID directly: `codex resume <uuid>`.
+        // (Headless is `codex exec resume <uuid>`; the interactive form is what
+        // the boot-restore types into a restored tab.) Account isolation rides
+        // the ENV (`account_isolation`), not the argv, so the resume looks
+        // identical across accounts.
+        vec![
+            "codex".to_string(),
+            "resume".to_string(),
+            session_id.to_string(),
+        ]
+    }
+
+    fn account_isolation(&self, account: Option<&str>) -> BTreeMap<String, String> {
+        let mut env = BTreeMap::new();
+        if let Some(dir) = account {
+            // Codex config/auth/sessions/keyring isolation is `CODEX_HOME` (the
+            // `CLAUDE_CONFIG_DIR` analogue). `account` is the already-resolved
+            // per-account dir; the adapter just names the env var. Absent ⇒ empty
+            // (the runner's process-global CODEX_HOME, if any, applies).
+            env.insert(CODEX_HOME_ENV.to_string(), dir.to_string());
+        }
+        env
+    }
+
+    fn resume_handshake_patterns(&self) -> HandshakePatterns {
+        // Best-effort Codex-TUI markers. BEST-EFFORT / PIN-YOUR-VERSION: these
+        // plain substrings are derived from the codex-cli 0.142.2 TUI surface and
+        // MAY need refinement against a live AUTHENTICATED codex (the success
+        // markers especially — an unauthenticated probe can't render the full
+        // resumed-conversation frame). Failure is checked first by consumers
+        // since a "no previous sessions" dialog is itself Codex UI.
+        HandshakePatterns {
+            success: vec![
+                "Codex".to_string(),          // the TUI banner / header
+                "send a message".to_string(), // input-box hint
+                "/help".to_string(),          // status-line shortcut hint
+            ],
+            failure: vec![
+                "No previous sessions".to_string(), // resume with no history
+                "not found".to_string(),            // unknown id
+                "No such session".to_string(),
+                "error: ".to_string(), // generic codex CLI error prefix
+            ],
+        }
+    }
+
+    fn restore_tier(&self) -> RestoreTier {
+        // Codex resumes the FULL conversation by id (`codex resume <uuid>`).
+        RestoreTier::Full
+    }
+}
+
+/// Registry seam (plan §4): resolve the adapter for `provider`. Phase 1 knew
+/// only the Claude adapter; Phase 2 filled it in; Phase 3 adds the Codex arm. An
+/// UNKNOWN provider degrades to the Claude adapter (the reference provider)
+/// rather than failing — a record with an unexpected provider should still
+/// restore via the default path, never be dropped.
 pub fn adapter_for(provider: &str) -> Box<dyn SessionProviderAdapter> {
     match provider {
-        // Phase 3 adds: "gemini" => Box::new(GeminiAdapter),
+        "codex" => Box::new(CodexAdapter),
         _ => Box::new(ClaudeAdapter),
     }
 }
@@ -265,11 +455,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn adapter_for_resolves_claude_and_defaults_unknown() {
+    fn adapter_for_resolves_claude_codex_and_defaults_unknown() {
         assert_eq!(adapter_for("claude").provider(), "claude");
+        assert_eq!(adapter_for("codex").provider(), "codex");
         // Unknown provider degrades to the Claude adapter (never drops).
         assert_eq!(adapter_for("gemini").provider(), "claude");
         assert_eq!(adapter_for("totally-new").provider(), "claude");
+    }
+
+    /// Helper: pull the pinned id out of a `Pinned` identity (test ergonomics).
+    fn pinned_id(spec: &LaunchSpec) -> &str {
+        match &spec.identity {
+            IdentitySource::Pinned(id) => id,
+            other => panic!("expected Pinned identity, got {other:?}"),
+        }
     }
 
     #[test]
@@ -284,7 +483,10 @@ mod tests {
         assert!(spec.argv.contains(&"--permission-mode".to_string()));
         assert!(spec.argv.contains(&"bypassPermissions".to_string()));
         assert!(spec.argv.contains(&"--session-id".to_string()));
-        assert!(spec.argv.contains(&spec.pinned_session_id));
+        // Claude's identity is Pinned (known synchronously) and the pinned id is
+        // in the argv.
+        let pinned = pinned_id(&spec).to_string();
+        assert!(spec.argv.contains(&pinned));
         assert_eq!(
             spec.env.get("CLAUDE_CONFIG_DIR").map(String::as_str),
             Some("C:/cfg")
@@ -315,6 +517,70 @@ mod tests {
             .failure
             .iter()
             .any(|s| s.contains("No conversation found")));
+    }
+
+    #[test]
+    fn codex_adapter_surface_is_read_back_and_panic_free() {
+        let a = CodexAdapter;
+        assert_eq!(a.provider(), "codex");
+        // Codex resumes the full conversation by id.
+        assert_eq!(a.restore_tier(), RestoreTier::Full);
+
+        // launch_with_identity: argv is a bare `["codex"]` hand-start — NO
+        // `--session-id` (codex has no such flag). Identity is read-back via the
+        // CODEX_HOME rollout-file channel.
+        let spec = a.launch_with_identity("C:/repo", Some("C:/codex-home"));
+        assert_eq!(spec.argv, vec!["codex".to_string()]);
+        assert!(
+            !spec.argv.iter().any(|a| a == "--session-id"),
+            "codex has NO --session-id flag"
+        );
+        match &spec.identity {
+            IdentitySource::ReadBack(IdentityCapture::SessionFile {
+                dir_env,
+                glob,
+                meta_line_type,
+                id_field,
+            }) => {
+                assert_eq!(dir_env, "CODEX_HOME");
+                assert_eq!(glob, "sessions/**/rollout-*.jsonl");
+                assert_eq!(meta_line_type, "session_meta");
+                assert_eq!(id_field, "session_id");
+            }
+            other => panic!("expected ReadBack(SessionFile), got {other:?}"),
+        }
+
+        // CODEX_HOME account isolation (the CLAUDE_CONFIG_DIR analogue).
+        assert_eq!(
+            spec.env.get("CODEX_HOME").map(String::as_str),
+            Some("C:/codex-home")
+        );
+        assert!(a.account_isolation(None).is_empty());
+        assert_eq!(
+            a.account_isolation(Some("C:/codex-home")).get("CODEX_HOME"),
+            Some(&"C:/codex-home".to_string())
+        );
+
+        // resume_command is the interactive `codex resume <id>` form.
+        assert_eq!(
+            a.resume_command("11111111-2222-7333-8444-555555555555", None),
+            vec![
+                "codex".to_string(),
+                "resume".to_string(),
+                "11111111-2222-7333-8444-555555555555".to_string()
+            ]
+        );
+
+        // capture_hook_delivery is None — codex uses read-back, not a hook.
+        assert_eq!(a.capture_hook_delivery("C:/repo"), DeliverySpec::None);
+
+        // Handshake patterns are non-empty (best-effort) on both sides.
+        let hp = a.resume_handshake_patterns();
+        assert!(!hp.success.is_empty());
+        assert!(hp
+            .failure
+            .iter()
+            .any(|s| s.contains("No previous sessions")));
     }
 
     #[test]

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -1142,28 +1142,142 @@ impl TerminalSession {
             }
         }
 
-        // 4. Record AUTHORITATIVELY at spawn (zero transcript race). The
-        // lifecycle store is shared in Tauri state by main.rs; absent in test
-        // fixtures / a boot window — then the confirming hook records instead.
+        // 4. Resolve identity per the provider adapter's IdentitySource and
+        // record. The interactive hand-start is the Claude reference path, whose
+        // identity is `Pinned` (the runner generated `pinned` above and injects
+        // it via env for the shim to apply) — so this records AUTHORITATIVELY at
+        // spawn, zero transcript race, exactly as before. The dispatcher
+        // (`consume_identity_source`) ALSO handles the `ReadBack` arm a read-back
+        // provider (codex) returns — recording provisionally + spawning the
+        // capture task — so the seam is genuinely general, not a Claude special
+        // case. The lifecycle store is shared in Tauri state by main.rs; absent
+        // in test fixtures / a boot window — then the confirming hook records.
         if let Some(store) = app_handle
             .try_state::<std::sync::Arc<crate::session::session_lifecycle_store::SessionLifecycleStore>>()
         {
-            crate::commands::terminal::record_pinned_session_open(
-                store.inner(),
-                pinned.clone(),
+            let adapter = crate::session::provider_adapter::adapter_for(
+                crate::session::session_lifecycle_store::DEFAULT_PROVIDER,
+            );
+            // The Claude adapter returns `Pinned`; we substitute the env-injected
+            // `pinned` so the recorded id matches the one the shim applies (the
+            // adapter would otherwise mint a fresh uuid). For a read-back provider
+            // the spec's `ReadBack` capture is used as-is.
+            let identity = match adapter.launch_with_identity(cwd, None).identity {
+                crate::session::provider_adapter::IdentitySource::Pinned(_) => {
+                    crate::session::provider_adapter::IdentitySource::Pinned(pinned.clone())
+                }
+                read_back => read_back,
+            };
+            Self::consume_identity_source(
+                store.inner().clone(),
+                identity,
+                adapter.provider().to_string(),
                 terminal_id.to_string(),
-                None, // config dir resolved by the hook / reconcile if needed
+                None, // config dir resolved by the hook / capture / reconcile
                 cwd.to_string(),
                 title.to_string(),
                 page_id.to_string(),
                 0,
-                crate::session::session_lifecycle_store::DEFAULT_PROVIDER.to_string(),
             );
-            info!(
-                terminal_id = %terminal_id,
-                session_id = %pinned,
-                "session-restore: session recorded authoritatively at spawn"
-            );
+        }
+    }
+
+    /// Consume a provider adapter's [`crate::session::provider_adapter::IdentitySource`]
+    /// at spawn — the generalized (pin-OR-read-back) identity recorder.
+    ///
+    /// - [`IdentitySource::Pinned`](crate::session::provider_adapter::IdentitySource::Pinned)
+    ///   → the runner KNOWS the id synchronously (Claude `--session-id`): record
+    ///   it AUTHORITATIVELY at spawn, zero transcript race (today's behavior).
+    /// - [`IdentitySource::ReadBack`](crate::session::provider_adapter::IdentitySource::ReadBack)
+    ///   with [`IdentityCapture::SessionFile`](crate::session::provider_adapter::IdentityCapture::SessionFile)
+    ///   → the provider GENERATES the id (codex): the real id isn't known at
+    ///   spawn, so DON'T write a phantom row here — spawn the read-back capture
+    ///   task ([`crate::session::codex_capture::capture_and_record`]), which finds
+    ///   the newest post-spawn rollout under the runner-isolated provider home,
+    ///   parses its line-1 `session_meta`, and records+confirms the real id. A
+    ///   miss degrades to the reconcile backstop (fail-open, never panics). The
+    ///   `StreamEvent` capture (codex `exec --json`) is not reachable from the
+    ///   interactive PTY hand-start (the runner doesn't own the child's stdout
+    ///   here) and is left to the headless `codex exec` path; it degrades to the
+    ///   reconcile backstop here.
+    #[allow(clippy::too_many_arguments)]
+    fn consume_identity_source(
+        store: std::sync::Arc<crate::session::session_lifecycle_store::SessionLifecycleStore>,
+        identity: crate::session::provider_adapter::IdentitySource,
+        provider: String,
+        terminal_id: String,
+        config_dir: Option<String>,
+        cwd: String,
+        title: String,
+        page_id: String,
+        zone_index: i32,
+    ) {
+        use crate::session::provider_adapter::{IdentityCapture, IdentitySource};
+        match identity {
+            IdentitySource::Pinned(pinned) => {
+                crate::commands::terminal::record_pinned_session_open(
+                    &store,
+                    pinned.clone(),
+                    terminal_id.clone(),
+                    config_dir,
+                    cwd,
+                    title,
+                    page_id,
+                    zone_index,
+                    provider,
+                );
+                info!(
+                    terminal_id = %terminal_id,
+                    session_id = %pinned,
+                    "session-restore: pinned session recorded authoritatively at spawn"
+                );
+            }
+            IdentitySource::ReadBack(capture) => match capture {
+                IdentityCapture::SessionFile {
+                    dir_env,
+                    meta_line_type,
+                    id_field,
+                    ..
+                } => {
+                    // The provider home to read back from. Without it (no account
+                    // isolation env), the read-back has nowhere to look — degrade
+                    // to the reconcile backstop.
+                    let Some(home) = std::env::var(&dir_env).ok().filter(|v| !v.is_empty()) else {
+                        info!(
+                            terminal_id = %terminal_id,
+                            dir_env = %dir_env,
+                            "session-restore: read-back provider home env unset — deferring to reconcile backstop"
+                        );
+                        return;
+                    };
+                    let spawn_ms = chrono::Utc::now().timestamp_millis();
+                    tokio::spawn(crate::session::codex_capture::capture_and_record(
+                        store,
+                        std::path::PathBuf::from(home),
+                        terminal_id,
+                        config_dir,
+                        cwd,
+                        title,
+                        page_id,
+                        zone_index,
+                        spawn_ms,
+                        meta_line_type,
+                        id_field,
+                        crate::session::codex_capture::CODEX_CAPTURE_POLL_INTERVAL,
+                        crate::session::codex_capture::CODEX_CAPTURE_TIMEOUT,
+                    ));
+                }
+                IdentityCapture::StreamEvent { .. } => {
+                    // Not reachable from the interactive PTY hand-start (the runner
+                    // doesn't own the child's stdout here). The headless
+                    // `codex exec --json` path owns this channel; here it degrades
+                    // to the reconcile backstop.
+                    info!(
+                        terminal_id = %terminal_id,
+                        "session-restore: StreamEvent read-back not applicable to interactive PTY — deferring to reconcile backstop"
+                    );
+                }
+            },
         }
     }
 

--- a/src/components/terminal/providerAdapter.test.ts
+++ b/src/components/terminal/providerAdapter.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { providerDescriptorFor, claudeDescriptor } from "./providerAdapter";
+import { providerDescriptorFor, claudeDescriptor, codexDescriptor } from "./providerAdapter";
 
 describe("providerDescriptorFor", () => {
   it("resolves the Claude descriptor for 'claude'", () => {
@@ -14,10 +14,37 @@ describe("providerDescriptorFor", () => {
     expect(providerDescriptorFor("claude").provider).toBe("claude");
   });
 
+  it("resolves the Codex descriptor for 'codex'", () => {
+    expect(providerDescriptorFor("codex")).toBe(codexDescriptor);
+    expect(providerDescriptorFor("codex").provider).toBe("codex");
+  });
+
   it("degrades unknown/undefined providers to the Claude descriptor (never drops)", () => {
     expect(providerDescriptorFor("gemini")).toBe(claudeDescriptor);
     expect(providerDescriptorFor("totally-new")).toBe(claudeDescriptor);
     expect(providerDescriptorFor(undefined)).toBe(claudeDescriptor);
+  });
+});
+
+describe("codexDescriptor", () => {
+  it("builds the interactive `codex resume <id>` command (no --session-id; read-back identity)", () => {
+    expect(codexDescriptor.resumeCommand("11111111-2222-7333-8444-555555555555")).toEqual([
+      "codex",
+      "resume",
+      "11111111-2222-7333-8444-555555555555",
+    ]);
+  });
+
+  it("declares the Full restore tier (codex resumes the full conversation by id)", () => {
+    expect(codexDescriptor.restoreTier()).toBe("full");
+  });
+
+  it("exposes non-empty success + failure handshake patterns (best-effort / pin-your-version)", () => {
+    const hp = codexDescriptor.handshakePatterns();
+    expect(hp.success.length).toBeGreaterThan(0);
+    expect(hp.failure.length).toBeGreaterThan(0);
+    expect(hp.failure).toContain("No previous sessions");
+    expect(hp.failure).toContain("not found");
   });
 });
 

--- a/src/components/terminal/providerAdapter.ts
+++ b/src/components/terminal/providerAdapter.ts
@@ -82,14 +82,50 @@ export const claudeDescriptor: SessionProviderDescriptor = {
 };
 
 /**
- * Registry lookup (plan §4 registry seam). Phase 1 knows only the Claude
- * descriptor; Phase 3 adds the Gemini arm. An unknown provider degrades to the
- * Claude descriptor (the only shipped provider today) rather than failing — a
- * record with an unexpected provider should still restore via the default path.
+ * The Codex descriptor (Phase 3 — provider #2, OpenAI Codex CLI). Resume is the
+ * interactive typed-into-PTV form `codex resume <id>` (codex accepts the UUID
+ * directly; the `claude --resume` analogue). The handshake patterns mirror the
+ * Rust `CodexAdapter::resume_handshake_patterns` — best-effort Codex-TUI success
+ * markers + definitive failure markers ("No previous sessions" / "not found"),
+ * failure checked first since a failure dialog is itself Codex UI. `restoreTier`
+ * is `"full"` — codex resumes the FULL conversation by id.
+ *
+ * BEST-EFFORT / PIN-YOUR-VERSION: these substrings are derived from codex-cli
+ * 0.142.2 and may need refinement against a live AUTHENTICATED codex. The
+ * identity model differs from Claude (read-back, not `--session-id` pinning), but
+ * that is a backend concern; the frontend descriptor only mirrors the resume +
+ * handshake + tier surface, which IS substring-symmetric with Claude.
+ */
+export const codexDescriptor: SessionProviderDescriptor = {
+  provider: "codex",
+  resumeCommand: (sessionId: string) => ["codex", "resume", sessionId],
+  handshakePatterns: () => ({
+    success: [
+      "Codex", // TUI banner / header
+      "send a message", // input-box hint
+      "/help", // status-line shortcut hint
+    ],
+    failure: [
+      "No previous sessions", // resume with no history
+      "not found", // unknown id
+      "No such session",
+      "error: ", // generic codex CLI error prefix
+    ],
+  }),
+  restoreTier: () => "full",
+};
+
+/**
+ * Registry lookup (plan §4 registry seam). Phase 1 knew only the Claude
+ * descriptor; Phase 2 filled it in; Phase 3 adds the Codex arm. An unknown
+ * provider degrades to the Claude descriptor (the reference provider) rather than
+ * failing — a record with an unexpected provider should still restore via the
+ * default path.
  */
 export function providerDescriptorFor(provider: string | undefined): SessionProviderDescriptor {
   switch (provider) {
-    // Phase 3 adds: case "gemini": return geminiDescriptor;
+    case "codex":
+      return codexDescriptor;
     case "claude":
     default:
       return claudeDescriptor;


### PR DESCRIPTION
Provider #2 for the session-restore redesign. **Stacked on #648** (base will
auto-retarget to main when #648 merges).

## Why Codex (not Gemini)
Gemini CLI was **sunset 2026-06-18** for individuals (+ a `GEMINI_CONFIG_DIR`
isolation bug on Windows); its successor Antigravity CLI has an **unsurfaced
session id** (antigravity-cli#7), **global-only hooks**, and **OAuth-only auth**
(#78) — both unfit for a programmatic runner. **OpenAI Codex CLI** fits the
adapter contract and, because its identity is **read-back (not pinned)**, it
proves the `SessionProviderAdapter` seam genuinely generalizes.

## What's here (3 commits)
1. **Adapter + read-back trait generalization** — `LaunchSpec.pinned_session_id`
   → `identity: IdentitySource::{Pinned | ReadBack(IdentityCapture::{StreamEvent
   | SessionFile})}`. `ClaudeAdapter` unchanged (`Pinned`). `CodexAdapter`: argv
   `["codex"]` (no `--session-id`), `ReadBack(SessionFile)`, resume `codex resume
   <id>`, `CODEX_HOME` isolation, `restore_tier=Full`. `codex_capture.rs` reads
   the id back from the rollout `session_meta`.
2. **End-to-end wiring** — a DISTINCT `codex` identity-shim wrapper (signals
   `/control/session-open` with `provider:codex`, no `session_id`, then execs real
   codex UNCHANGED — never touches `CODEX_HOME`, preserving the user's auth);
   per-tool template selection in the materializer; the `/control/session-open`
   codex branch spawns the runner-side read-back capture; capture matches the
   rollout by cwd + post-spawn mtime and supersedes the speculative claude pin.
3. **cwd-match fix** — Git-Bash `$PWD` (`/c/...`) vs codex's Windows `C:\...`
   rollout cwd never matched (caught by a live wrapper-vs-real-codex probe);
   wrapper now emits `pwd -W` and the normalizer folds the mingw drive form.

## Verification
Independently verified against worktree sources (raw cargo — note `cargo-guard.sh`
hardwires to the MAIN checkout and gives false-green for worktree changes):
clippy `-D warnings` clean; `codex_capture` 10 + `shim_materializer` /
`install_effects_producer` 20 cargo tests; `provider_adapter` 4; TS `tsc` clean +
vitest 9/9. **Live probe** against the real `codex` binary confirmed the wrapper
POSTs correctly and execs codex unchanged (rollout written, line-1 `session_meta`
parsed as expected).

## Not yet verified live (follow-up / CI)
- Full in-runner integration (a real PTY's always-on seam materializing the
  wrapper + the capture task firing in-process) — covered by CI here + the next
  runner build.
- Codex resume CONTINUITY — needs `OPENAI_API_KEY` (the id-capture + resume
  COMMAND mechanics are verified unauth, since the rollout is written pre-auth).
- Codex resume handshake-pattern strings are best-effort/pin-your-version
  (codex-cli 0.142.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)