### PR TITLE
feat(coord-sync): send session provider to coord.sessions — Phase 6

### DIFF
--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1307,6 +1307,9 @@ pub async fn spawn_worker_session(
                 declared_paths: vec![],
                 share_output: true,
                 redact_secrets: None,
+                // Worker sessions launch the Claude CLI — provider is known
+                // at spawn. Forwarded to coord.sessions.provider.
+                provider: Some("claude".to_string()),
             };
             match registry.register_external(intent) {
                 Ok(coord_id) => {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -38,6 +38,11 @@ pub struct StartSessionArgs {
     pub share_output: bool,
     #[serde(default)]
     pub redact_secrets: Option<bool>,
+    /// Phase 6 — AI-CLI provider hosting the session (`"claude"`, `"codex"`).
+    /// Forwarded to `coord.sessions.provider`. Optional; absent for plain
+    /// shells.
+    #[serde(default)]
+    pub provider: Option<String>,
 }
 
 impl From<StartSessionArgs> for Intent {
@@ -55,6 +60,7 @@ impl From<StartSessionArgs> for Intent {
             declared_paths: a.declared_paths,
             share_output: a.share_output,
             redact_secrets: a.redact_secrets,
+            provider: a.provider,
         }
     }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -171,6 +171,10 @@ pub async fn terminal_create(
             .collect(),
         share_output: true,
         redact_secrets: None,
+        // A plain terminal shell has no AI-CLI provider at create time — the
+        // provider is only known once a CLI is launched in the pane and its
+        // SessionStart hook confirms it. `None` here; coord tolerates absence.
+        provider: None,
     };
     // R2 — RESUME the pane's prior coord session if one is persisted,
     // otherwise register fresh. Resuming PATCHes the EXISTING coord row
@@ -1172,6 +1176,9 @@ pub(crate) fn create_terminal_session_backend(
         declared_paths: vec![std::path::PathBuf::from(&working_dir)],
         share_output: true,
         redact_secrets: None,
+        // Gate-continuation shell — provider unknown until a CLI launches in
+        // the pane and confirms via its SessionStart hook. `None` here.
+        provider: None,
     };
 
     let mut coord_session_id: Option<uuid::Uuid> = None;

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -748,6 +748,17 @@ fn rebuild_create_body(rec: &OutboxRecord) -> JsonValue {
             body["task_run_id"] = trid.clone();
         }
     }
+    // Phase 6 (session-restore redesign) — forward the AI-CLI provider hosting
+    // the session (`"claude"`, `"codex"`, …) so coord persists
+    // `coord.sessions.provider`. The started outbox payload carries it as a
+    // top-level `provider` key (threaded from `TerminalSessionRecord.provider`
+    // via the session intent). Omitted when absent/null; coord's
+    // `CreateSessionRequest.provider` is `#[serde(default)]`.
+    if let Some(provider) = rec.payload.get("provider") {
+        if !provider.is_null() {
+            body["provider"] = provider.clone();
+        }
+    }
     body
 }
 
@@ -1059,6 +1070,7 @@ mod tests {
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
+            provider: None,
         }
     }
 
@@ -1286,9 +1298,55 @@ mod tests {
         assert_eq!(body["intent"]["purpose"], "coord-sync test");
         assert!(body["id"].as_str().is_some(), "id present");
         assert!(body["device_id"].as_str().is_some(), "device_id present");
+        // make_test_intent carries no provider → the key is omitted from the
+        // create body (mirrors the parent_session_id omit-when-absent rule).
+        assert!(
+            body.get("provider").is_none(),
+            "provider omitted when the intent carries none"
+        );
 
         drop(g);
         // Outbox row was ACKed.
+        wait_until(Duration::from_secs(3), || {
+            outbox.pending().map(|p| p.is_empty()).unwrap_or(false)
+        })
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_forwards_provider_in_create_body() {
+        // Phase 6 — when the session intent carries a provider, the create
+        // body forwards it as a top-level `provider` field so coord populates
+        // `coord.sessions.provider`.
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let (base, rec) = spawn_fake_coord().await;
+        let coord = CoordSync::new_for_test(
+            outbox.clone(),
+            base,
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+        );
+        let registry = build_registry(coord.clone());
+        let mut intent = make_test_intent();
+        intent.provider = Some("codex".to_string());
+        let _handle = registry.start(intent).unwrap();
+        let _drain = coord.start_drain_task();
+
+        wait_until(Duration::from_secs(5), || {
+            let r = rec.try_lock();
+            r.map(|g| !g.posts.is_empty()).unwrap_or(false)
+        })
+        .await;
+
+        let g = rec.lock().await;
+        assert_eq!(g.posts.len(), 1, "exactly one POST /sessions");
+        let body = &g.posts[0];
+        assert_eq!(
+            body["provider"], "codex",
+            "provider forwarded to the create body when the intent carries it"
+        );
+        drop(g);
         wait_until(Duration::from_secs(3), || {
             outbox.pending().map(|p| p.is_empty()).unwrap_or(false)
         })

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -635,6 +635,12 @@ fn build_child_intent(state: &HandoffState) -> Result<Intent, HandoffError> {
         .get("correlation_topic")
         .and_then(|v| v.as_str())
         .map(str::to_string);
+    // Carry the source session's provider across the handoff so the child's
+    // coord.sessions row keeps the same AI-CLI attribution.
+    let provider = src
+        .get("provider")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
 
     Ok(Intent {
         kind,
@@ -647,6 +653,7 @@ fn build_child_intent(state: &HandoffState) -> Result<Intent, HandoffError> {
         declared_paths,
         share_output,
         redact_secrets,
+        provider,
     })
 }
 

--- a/src-tauri/src/session/intent.rs
+++ b/src-tauri/src/session/intent.rs
@@ -74,6 +74,14 @@ pub struct Intent {
     /// [`Intent::share_output`] (see [`Intent::effective_redact_secrets`]).
     #[serde(default)]
     pub redact_secrets: Option<bool>,
+    /// Phase 6 (session-restore redesign) — the AI-CLI provider hosting this
+    /// session (`"claude"`, `"codex"`, …). Threaded into the `started` outbox
+    /// payload as a top-level `provider` key so the drain loop forwards it to
+    /// coord's `CreateSessionRequest.provider`, populating
+    /// `coord.sessions.provider`. `None` for a plain shell with no AI CLI or a
+    /// caller that hasn't resolved a provider — coord tolerates its absence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
 }
 
 impl Intent {
@@ -144,6 +152,7 @@ mod tests {
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
+            provider: None,
         }
     }
 
@@ -223,6 +232,7 @@ mod tests {
             declared_paths: vec![PathBuf::from("/repo/path")],
             share_output: true,
             redact_secrets: Some(false),
+            provider: Some("claude".into()),
         };
         let serialized = serde_json::to_string(&i).unwrap();
         let back: Intent = serde_json::from_str(&serialized).unwrap();

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -434,6 +434,10 @@ impl SessionRegistry {
         // `parent_session_id` is threaded into the payload so the drain
         // loop's `rebuild_create_body` forwards it to coord's
         // `CreateSessionRequest.parent_session_id`.
+        // `provider` is threaded as a TOP-LEVEL payload key (like
+        // `parent_session_id`) so the drain loop's `rebuild_create_body`
+        // forwards it to coord's `CreateSessionRequest.provider`, populating
+        // `coord.sessions.provider`. Source of truth is the intent's provider.
         let payload = json!({
             "id": id,
             "kind": intent.kind.as_str(),
@@ -442,6 +446,7 @@ impl SessionRegistry {
             "started_at": now,
             "parent_session_id": parent_session_id,
             "claude_code_session_id": claude_code_session_id,
+            "provider": intent.provider,
         });
         self.coord_sync
             .outbox()
@@ -518,6 +523,8 @@ impl SessionRegistry {
             output_pipe: None,
         };
 
+        // `provider` threaded as a top-level key (see `start_inner`) so the
+        // mirror's create body carries it to `coord.sessions.provider`.
         let payload = json!({
             "id": id,
             "kind": intent.kind.as_str(),
@@ -525,6 +532,7 @@ impl SessionRegistry {
             "state": SessionState::Active.as_str(),
             "started_at": now,
             "claude_code_session_id": claude_code_session_id,
+            "provider": intent.provider,
         });
         self.coord_sync
             .outbox()
@@ -1064,6 +1072,7 @@ mod tests {
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
+            provider: None,
         }
     }
 


### PR DESCRIPTION
Phase 6 (runner side) of the session-restore redesign. The runner now sends the session's `provider` (the AI CLI hosting it — `"claude"`/`"codex"`) to coord when mirroring a session, so `coord.sessions.provider` populates.

Threads it end-to-end (mirrors `parent_session_id`):
`TerminalSessionRecord.provider` → `Intent.provider` (new, `#[serde(default, skip_serializing_if)]`) → the `started` outbox payload (top-level `provider` key) → `rebuild_create_body` forwards it onto the `POST /sessions` body (conditional, omit-when-null). Call sites set it: `TerminalClaude` worker → `Some("claude")`; plain/gate-continuation shells → `None` (unknown until a CLI launches); handoff carries it across machines.

Verified (worktree sources): `cargo fmt` clean, `clippy -D warnings` clean, `cargo test coord_sync` → **22 passed, 0 failed** (incl. `drain_forwards_provider_in_create_body`).

Pairs with coord qontinui/qontinui-coord#764 (accept + store) and web qontinui/qontinui-web#658 (the column). Additive + safe to merge independently — a pre-Phase-6 coord harmlessly ignores the extra `provider` field; it only populates once #764 + #658 are live. **Stacked on #648** (where `TerminalSessionRecord.provider` lives).

Plan: `qontinui-dev-notes/plans/2026-06-25-runner-session-restore-redesign.md` §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)