### PR TITLE
ci(release): provision Tauri NSIS toolchain on Windows CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,34 @@ jobs:
       #     certutil -decode certificate/tempCert.txt certificate/cert.pfx
       #     Remove-Item certificate/tempCert.txt
 
+      # Tauri's NSIS bundler auto-downloads its toolset (makensis + plugins) and
+      # the WebView2 bootstrapper into %LOCALAPPDATA%\tauri on first use. On a
+      # fresh windows-latest runner that download has to happen every run, and
+      # when it is missing/incomplete the bundler aborts immediately after
+      # "Built application" with a bare "cannot find the file specified
+      # (os error 2)" (issue #654). Caching that dir makes the toolset present
+      # on cache-hit and persists a successful download across runs on miss.
+      # Keyed on the OS so each platform gets its own cache slot.
+      - name: Cache Tauri bundler toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/AppData/Local/tauri
+          key: tauri-toolchain-${{ runner.os }}-v1
+
+      # Belt-and-braces for the os-error-2 failure: pre-install a system NSIS so
+      # `makensis` is guaranteed on PATH even if Tauri's own download of its NSIS
+      # toolset fails or is rate-limited. Chocolatey is preinstalled on the
+      # GitHub windows-latest image. This is fast and idempotent (cache-friendly).
+      - name: Ensure NSIS is installed (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not (Get-Command makensis -ErrorAction SilentlyContinue)) {
+            choco install nsis -y --no-progress
+          } else {
+            Write-Host "makensis already available: $((Get-Command makensis).Source)"
+          }
+
       - name: Build Tauri app
         # Tauri signing disabled for alpha - will be enabled when certificates arrive
         # env:


### PR DESCRIPTION
## Summary
Fixes #654 — the `release.yml` Windows leg compiles + links fine but the Tauri bundler aborts immediately after "Built application" with a bare `The system cannot find the file specified. (os error 2)`, before any bundler output even with `--verbose`.

## Root cause
This is **environmental to the CI runner, not a config bug** (confirmed in #654: a local `tauri build --bundles nsis` with the same `tauri.conf.json` produces a working installer). Tauri's NSIS bundler auto-downloads its toolset (`makensis` + plugins) and the WebView2 bootstrapper into `%LOCALAPPDATA%\tauri` on first use. Local dev machines have that cached; a fresh `windows-latest` runner must download it every run, and when that download is missing/incomplete the bundler fails with `os error 2`. The workflow uses raw `pnpm tauri build` (not `tauri-action`), so nothing pre-provisions or caches the toolchain.

## Fix
Two small, targeted steps added just before the existing **Build Tauri app** step (the lower-risk option over swapping in `tauri-action`, which would be a much larger change to a working build invocation):

1. **`actions/cache@v4` on `~/AppData/Local/tauri`**, keyed on `runner.os` (`tauri-toolchain-${{ runner.os }}-v1`). On cache-hit the toolset is already present; on miss a successful download is persisted for subsequent runs.
2. **Windows-only `Ensure NSIS is installed` pre-step** — `choco install nsis` (Chocolatey is preinstalled on `windows-latest`) so `makensis` is guaranteed on PATH even if Tauri's own download fails or is rate-limited. Idempotent (skips if `makensis` already present).

## Preserved exactly
- The `--verbose` flag on the build step (kept for future diagnosis).
- `bundles: nsis` on the Windows matrix leg.
- `continue-on-error` only on non-Windows legs.

## Verification
YAML validated locally with `yaml.safe_load`. **Full end-to-end verification requires a real tagged release run** (the bundler path only exercises on a `v*` tag / `workflow_dispatch`), since the failure only reproduces on a fresh GitHub Windows runner.