### PR TITLE
chore(build): cap rustc peak memory in [profile.release] (#655)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,32 @@ split-debuginfo = "packed"
 
 [profile.test]
 debug = 0
+
+# Release builds OOM-killed rustc compiling `qontinui-runner` at ~16 GB RSS
+# (issue #655). At opt-level=3 this single large crate's LLVM optimization
+# dominates memory; with Cargo's default all-cores parallelism it runs
+# concurrently with other crates and total RSS exceeds available RAM ->
+# silent OOM kill (no rustc/linker error printed). Tune the release profile
+# to lower peak per-crate memory while keeping a genuinely optimized build:
+#
+#  - opt-level = 2: the biggest memory lever. opt-level=3 adds aggressive
+#    auto-vectorization + more inlining, which balloons LLVM IR for a large
+#    crate. opt-level=2 cuts peak optimization memory substantially while
+#    keeping ~all real-world runtime perf (3 over 2 mainly helps tight
+#    numeric loops; this Tauri/IPC crate has none).
+#  - codegen-units = 256: split the heavy crate into many small LLVM modules
+#    so no single in-flight codegen unit holds a huge IR graph. The release
+#    default of 16 keeps each unit large. Trades a little cross-unit inlining
+#    (minor perf, slightly larger binary) for much lower per-unit peak memory
+#    -- directly targeting the single-heavy-crate OOM.
+#  - lto = false: pin off. A whole-program LTO link would be memory-heavy on
+#    top of the per-crate cost; this keeps the final link light and prevents
+#    a future change from silently enabling it.
+#
+# Empirical confirmation (release build no longer OOMs at default
+# parallelism) must come from a full release build / CI -- too heavy to run
+# in routine checks (~1h + 16 GB peak before this change).
+[profile.release]
+opt-level = 2
+codegen-units = 256
+lto = false


### PR DESCRIPTION
Fixes #655.

## Problem
A release build (`pnpm run tauri build`) silently dies while compiling `qontinui-runner` — no rustc/linker error is printed because the process is **OOM-killed**. `rustc` compiling this single large crate at `opt-level=3` reaches **~16 GB RSS**; with Cargo's default all-cores parallelism it runs concurrently with other crates and total memory exceeds available RAM. `CARGO_BUILD_JOBS=2` lets it complete (the 16 GB compile then runs with little competition).

The workspace root `Cargo.toml` overrode `[profile.dev]` / `[profile.test]` but had **no `[profile.release]` tuning**.

## Fix
Add a `[profile.release]` section to the workspace root `Cargo.toml`:

```toml
[profile.release]
opt-level = 2
codegen-units = 256
lto = false
```

Rationale:
- **`opt-level = 2`** (was default 3) — the biggest memory lever. `opt-level=3` adds aggressive auto-vectorization + more inlining, which balloons LLVM IR for a large crate; `opt-level=2` cuts peak optimization memory substantially while keeping ~all real-world runtime perf (3 over 2 mainly helps tight numeric loops, which this Tauri/IPC crate doesn't have).
- **`codegen-units = 256`** (was default 16) — split the heavy crate into many small LLVM modules so no single in-flight codegen unit holds a huge IR graph. Trades a little cross-unit inlining (minor perf, slightly larger binary) for much lower per-unit peak memory — directly targeting the single-heavy-crate OOM.
- **`lto = false`** — pinned off so a whole-program LTO link can't be silently enabled later; keeps the final link light. (Already the release default; made explicit.)

`opt-level` is intentionally **not** dropped to 0 — this stays a real optimized build.

## Verification
- TOML/manifest parse confirmed (the `[profile.release]` table parses to `{opt-level: 2, codegen-units: 256, lto: false}`).
- `cargo metadata` passes against the main checkout; the worktree-relative run only fails on an unrelated missing sibling `qontinui-schemas/code-graph` path dependency, not this change.
- **Empirical confirmation that the release build no longer OOMs at default parallelism must come from a full release build / CI** — a full release build is ~1h + 16 GB peak before this change, too heavy to run in routine checks.