### PR TITLE
ci: run pull_request CI for stacked PRs on session-restore-** branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,15 @@ on:
       - 'merge-candidate-spec/**'
       - 'merge-candidate-batch/**'
   pull_request:
-    branches: [main, develop]
+    # `session-restore-**`: stacked PRs that target a long-lived integration
+    # branch (e.g. `session-restore-redesign`) instead of `main` matched no
+    # `pull_request` trigger, so runner CI never ran on them → coord's
+    # awaiting-ci poll of `coord.pr_check_runs` stayed empty → the PRs sat at
+    # `ci-pending` forever and never auto-landed (runner #651/#652, 2026-06-26).
+    # The base-branch filter is matched against the PR's *base*, so the
+    # integration branch must be listed here for stacked-PR CI to fire. CI has
+    # no `paths:` filter, so adding the branch suffices.
+    branches: [main, develop, 'session-restore-**']
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Stacked PRs whose **base** is a long-lived integration branch (e.g. `session-restore-redesign`) rather than `main` matched no `pull_request` trigger in `ci.yml`, so runner CI never ran on them. coord's awaiting-CI poll of `coord.pr_check_runs` then stayed empty and the PRs sat at `ci-pending` forever, never auto-landing.

**Live impact:** runner #651 (`session-restore-codex-adapter`) and #652 (`coord-sync-provider`) — both `base=session-restore-redesign` — have zero CI runs (`gh run list --branch session-restore-codex-adapter` is empty) and have been stuck `ci-pending` in coord for >24h.

The `pull_request.branches` filter matches the PR's **base** branch, so the integration branch must be listed. CI has no `paths:` filter, so adding the `session-restore-**` glob suffices (no new workflow).

**Note:** for `pull_request`, GitHub uses the workflow definition from the PR head/merge, so existing PRs #651/#652 will only pick this up once their branches carry the change (rebase onto an updated `session-restore-redesign`). This PR fixes the root cause on `main`; unblocking the two in-flight PRs needs the change propagated to the integration branch (or an `--admin` merge into it).