### PR TITLE
ci(secret-scan): add caller for the shared gitleaks net (Step-4 S4.1)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,6 @@
+name: Secret Scan
+on:
+  pull_request:
+jobs:
+  secret-scan:
+    uses: qontinui/qontinui-coord/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
Calls the reusable secret-scan workflow on qontinui-coord main (gitleaks + shared allowlist). Part of Step-4 S4.1 — once required on every managed repo, the coord-side secret-path escalate gate is removed. Workflow-file-only.