### PR TITLE
ci: enable pull_request CI for stacked PRs on session-restore-redesign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,15 @@ on:
       - 'merge-candidate-spec/**'
       - 'merge-candidate-batch/**'
   pull_request:
-    branches: [main, develop]
+    # `session-restore-**`: stacked PRs that target a long-lived integration
+    # branch (e.g. `session-restore-redesign`) instead of `main` matched no
+    # `pull_request` trigger, so runner CI never ran on them → coord's
+    # awaiting-ci poll of `coord.pr_check_runs` stayed empty → the PRs sat at
+    # `ci-pending` forever and never auto-landed (runner #651/#652, 2026-06-26).
+    # The base-branch filter is matched against the PR's *base*, so the
+    # integration branch must be listed here for stacked-PR CI to fire. CI has
+    # no `paths:` filter, so adding the branch suffices. (Mirrors #660 on main.)
+    branches: [main, develop, 'session-restore-**']
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Propagates the `pull_request.branches` fix that landed on `main` in #660 onto the `session-restore-redesign` integration branch, so stacked PRs based on it — **runner #651** (`session-restore-codex-adapter`) and **#652** (`coord-sync-provider`) — get CI instead of sitting at `ci-pending` in coord.

**Why a separate PR:** for `pull_request`, GitHub evaluates the trigger against the workflow on the PR's merge ref, so the fix has to physically reach this integration branch (and then #651/#652 must rebase onto it to pick it up — that is the follow-on step).

Same one-line change as #660 (`+ 'session-restore-**'` to `pull_request.branches`). Note the **"Guard gating workflows from self-edits"** check will be red by design (any `ci.yml` edit) — this needs an operator admin-merge after review, exactly like #660.