### PR TITLE
feat(session): emit work-progress to coord on the interaction boundary

### DIFF
--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -330,6 +330,49 @@ impl AiCoordRegistrar {
         }
     }
 
+    /// Advance this session's **work-progress** clock
+    /// (`coord.sessions.last_progress_at`) on operator interaction — a sibling
+    /// of [`Self::heartbeat_on_interaction`], called from the same
+    /// `send_user_message` work-activity boundary. Plan
+    /// `2026-06-25-session-progress-reporting-and-agent-session-linkage.md`.
+    ///
+    /// This is the missing *producer* the prior plan's session-stall watcher
+    /// was starved of: it advances `last_progress_at` on the **work axis**,
+    /// orthogonal to the liveness `Heartbeat` (a session can hold a claim yet
+    /// stop advancing — the watcher flips such a session to `stalled`). The
+    /// `Progress` outbox row drains to `PATCH /sessions/:id {progress:{…}}`;
+    /// coord stamps `last_progress_at = now()` (we send no explicit timestamp).
+    ///
+    /// No-op (silently) if the session was never registered — which is also how
+    /// the `QONTINUI_SESSION_AUTOMATION_REGISTER` kill switch disables it: a
+    /// disabled session has no R4 index entry, so this resolves to `None`.
+    /// Best-effort throughout — a write failure never disturbs the live session.
+    pub fn progress_on_interaction(&self, task_run_id: &str) {
+        let Some(session_id) = self.session_id_for(task_run_id) else {
+            return;
+        };
+        // Minimal body: `session_status="working"`. Coord stamps
+        // `last_progress_at=now()` on receipt (no explicit `last_progress_at`
+        // or `progress_detail` sent — the interaction itself is the signal).
+        let payload = json!({ "id": session_id, "session_status": "working" });
+        if let Err(e) = self.inner.outbox.record(
+            self.inner.machine_id,
+            session_id,
+            SessionEventKind::Progress,
+            payload,
+        ) {
+            warn!(
+                "ai_coord_register: outbox Progress write failed for {} (best-effort): {}",
+                task_run_id, e
+            );
+        } else {
+            debug!(
+                "ai_coord_register: interaction progress for {} (coord {})",
+                task_run_id, session_id
+            );
+        }
+    }
+
     /// R5 — on AI-session end, emit a `Closed` outbox row (`DELETE
     /// /sessions/:id`) and evict the R4 index entry so coord.sessions doesn't
     /// leak a ghost row and the resolver doesn't keep a dangling mapping.
@@ -808,6 +851,54 @@ mod tests {
             .collect();
         assert_eq!(hb.len(), 1, "exactly one interaction heartbeat");
         assert_eq!(hb[0].session_id, coord_id);
+    }
+
+    #[test]
+    fn progress_only_after_register_and_keyed_by_session() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+
+        // Progress before registration is a no-op (no row) — this is also how
+        // the kill switch disables it (unregistered → no R4 index entry).
+        reg.progress_on_interaction(&trid);
+        assert!(reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .iter()
+            .all(|r| r.event_kind != SessionEventKind::Progress.as_str()));
+
+        let coord_id = reg.register_session(&trid, "purpose", None).unwrap();
+        reg.progress_on_interaction(&trid);
+
+        let prog: Vec<_> = reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.event_kind == SessionEventKind::Progress.as_str())
+            .collect();
+        assert_eq!(prog.len(), 1, "exactly one interaction progress row");
+        assert_eq!(prog[0].session_id, coord_id);
+        // Minimal body advances the work axis; coord stamps last_progress_at.
+        assert_eq!(prog[0].payload["session_status"], json!("working"));
+    }
+
+    #[test]
+    fn progress_disabled_gate_is_noop() {
+        let _env = env_lock();
+        std::env::set_var("QONTINUI_SESSION_AUTOMATION_REGISTER", "0");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+        // Disabled → register is a no-op → no index entry → progress no-ops.
+        assert!(reg.register_session(&trid, "purpose", None).is_none());
+        reg.progress_on_interaction(&trid);
+        assert!(reg.inner.outbox.pending().unwrap().is_empty());
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
     }
 
     #[test]

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -252,6 +252,11 @@ pub async fn send_user_message(
     // loop) is what lets an idle session age to `stale` so the inject trigger
     // can fire (P0.2). Best-effort + no-op when the session isn't registered.
     ai_coord_registrar.heartbeat_on_interaction(&task_run_id);
+    // Session-progress reporting — the same operator-interaction boundary is the
+    // work-activity signal that advances `coord.sessions.last_progress_at` (the
+    // producer the session-stall watcher was starved of). Orthogonal to the
+    // liveness heartbeat above; same best-effort/no-op-when-unregistered posture.
+    ai_coord_registrar.progress_on_interaction(&task_run_id);
 
     let session = session_manager
         .get(&task_run_id)

--- a/src-tauri/src/drain.rs
+++ b/src-tauri/src/drain.rs
@@ -233,6 +233,10 @@ pub fn drain(app_handle: &tauri::AppHandle, timeout: Duration) -> DrainSummary {
             // bumps the freshness so the stale sweep doesn't reap it in the
             // restart window. No-op for unregistered sessions.
             reg.heartbeat_on_interaction(task_run_id);
+            // Advance the work-progress clock alongside the liveness heartbeat:
+            // a session preserved across a planned restart was active up to the
+            // drain, so it must not be mistaken for stalled when it resumes.
+            reg.progress_on_interaction(task_run_id);
             summary.claims_persisted += 1;
         }
     } else {

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -631,6 +631,19 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
                 .send()
                 .await
         }
+        "progress" => {
+            // Work-progress report (plan
+            // 2026-06-25-session-progress-reporting-and-agent-session-linkage.md).
+            // PATCH /sessions/:id {progress:{…}} advances
+            // coord.sessions.last_progress_at on a work-activity boundary —
+            // orthogonal to the {heartbeat:true} liveness PATCH above. Coord
+            // stamps last_progress_at=now() when the body omits it.
+            let url = format!("{base}/sessions/{}", rec.session_id);
+            let body = progress_body(&rec.payload);
+            crate::auth::attach_device_auth(inner.http.patch(&url).json(&body))
+                .send()
+                .await
+        }
         "commit_report" => {
             // Commit ↔ session lineage push-report (plan
             // 2026-06-07-coord-commit-session-lineage.md, Population path 2).
@@ -772,6 +785,26 @@ fn state_change_body(payload: &JsonValue) -> JsonValue {
     // caller only changed metadata.
     body.insert("heartbeat".into(), JsonValue::Bool(true));
     JsonValue::Object(body)
+}
+
+/// Build the `PATCH /sessions/:id {progress:{…}}` body from a `progress`
+/// outbox payload. The registrar records the work-progress fields flat in the
+/// payload (`session_status`, optional `last_progress_at` / `progress_detail`);
+/// coord's `UpdateSessionRequest` nests them under `progress` and stamps
+/// `last_progress_at = now()` when omitted. Advances the work-progress axis
+/// (`coord.sessions.last_progress_at`), independent of the liveness heartbeat.
+fn progress_body(payload: &JsonValue) -> JsonValue {
+    let mut progress = serde_json::Map::new();
+    if let Some(status) = payload.get("session_status") {
+        progress.insert("session_status".into(), status.clone());
+    }
+    if let Some(at) = payload.get("last_progress_at") {
+        progress.insert("last_progress_at".into(), at.clone());
+    }
+    if let Some(detail) = payload.get("progress_detail") {
+        progress.insert("progress_detail".into(), detail.clone());
+    }
+    json!({ "progress": JsonValue::Object(progress) })
 }
 
 /// Build the `POST /sessions/:id/steal` body from the claim_stolen
@@ -1591,6 +1624,32 @@ mod tests {
         assert_eq!(body["branch"], "main");
         assert_eq!(body["heartbeat"], true);
         assert!(body.get("unrelated").is_none());
+    }
+
+    /// `progress` body nests the flat work-progress fields under `progress`
+    /// (coord's `UpdateSessionRequest` shape) and drops unknown keys. A minimal
+    /// payload yields a `{progress:{session_status}}` body — coord stamps
+    /// last_progress_at=now() when the body omits it.
+    #[test]
+    fn progress_body_nests_known_fields_under_progress() {
+        let minimal = json!({ "id": Uuid::new_v4(), "session_status": "working" });
+        let body = progress_body(&minimal);
+        assert_eq!(body["progress"]["session_status"], "working");
+        // `id` is the outbox routing key, not a progress field — not forwarded.
+        assert!(body["progress"].get("id").is_none());
+        assert!(body["progress"].get("last_progress_at").is_none());
+
+        let full = json!({
+            "session_status": "blocked",
+            "last_progress_at": "2026-06-28T10:30:00Z",
+            "progress_detail": { "step": "tests", "pct": 60 },
+            "unrelated": "ignored",
+        });
+        let body = progress_body(&full);
+        assert_eq!(body["progress"]["session_status"], "blocked");
+        assert_eq!(body["progress"]["last_progress_at"], "2026-06-28T10:30:00Z");
+        assert_eq!(body["progress"]["progress_detail"]["pct"], 60);
+        assert!(body["progress"].get("unrelated").is_none());
     }
 
     /// `claim_stolen` body carries `reason` + the runner's machine_id.

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -180,6 +180,13 @@ pub enum SessionEventKind {
     /// payload carries `{repo, branch, shas}` and NO session id (coord resolves
     /// the session server-side from `(repo, branch)`).
     CommitReport,
+    /// Work-progress report (plan
+    /// `2026-06-25-session-progress-reporting-and-agent-session-linkage.md`).
+    /// Drained to `PATCH /sessions/:id {progress:{…}}`, advancing
+    /// `coord.sessions.last_progress_at` on a *work-activity* boundary —
+    /// orthogonal to the liveness `Heartbeat`. Emitted on operator interaction
+    /// by [`crate::claude_session::coord_register::AiCoordRegistrar::progress_on_interaction`].
+    Progress,
 }
 
 impl SessionEventKind {
@@ -193,6 +200,7 @@ impl SessionEventKind {
             SessionEventKind::OutputChunk => "output_chunk",
             SessionEventKind::HandoffRequest => "handoff_request",
             SessionEventKind::CommitReport => "commit_report",
+            SessionEventKind::Progress => "progress",
         }
     }
 }


### PR DESCRIPTION
## What

Plan `2026-06-25-session-progress-reporting-and-agent-session-linkage.md`, Phase 2 (the runner half) — the **missing producer** for coord's session-stall watcher.

Coord's `last_progress_at` was never advanced by any caller, so the stall watcher (already merged) was starved of inputs and could never flag a stuck session. The runner now advances it on the same operator-interaction boundary the coord heartbeat already rides.

## Changes

- **`SessionEventKind::Progress`** (wire form `"progress"`) in `session/mod.rs`.
- **Drain mapping** in `session/coord_sync.rs` → `PATCH /sessions/:id {progress:{…}}` via a new `progress_body` helper that nests the flat work-progress fields (`session_status`, optional `last_progress_at` / `progress_detail`) into coord's `UpdateSessionRequest` shape. Reuses the existing auth/retry/409-idempotency drain — no new HTTP code.
- **`AiCoordRegistrar::progress_on_interaction`** — a sibling of `heartbeat_on_interaction`, keyed on the same registrar `session_id`. Minimal body (`{session_status:"working"}`); coord stamps `last_progress_at=now()`. No-op when the session isn't registered, which is also how the `QONTINUI_SESSION_AUTOMATION_REGISTER` kill switch disables it.
- **Emit** it alongside the heartbeat at the `send_user_message` work-activity boundary (`commands/ai_session.rs`) and at graceful drain (`drain.rs`) — so a session preserved across a planned restart isn't mistaken for stalled when it resumes.

This advances the work-progress axis (`last_progress_at`) **independently** of the liveness heartbeat (`last_heartbeat_at`). Best-effort throughout — a progress report that can't reach coord or resolve a session never disturbs the live agent.

## Testing
- `cargo test progress` — green. New tests: `progress_only_after_register_and_keyed_by_session`, `progress_disabled_gate_is_noop` (registrar), `progress_body_nests_known_fields_under_progress` (drain); full 35-test bin suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
