### PR TITLE
Phase 1: emit session progress at tool-use boundaries (lights up session_stall)

### DIFF
--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -116,7 +116,21 @@ struct Inner {
     /// hold (`task_run_id`).
     forward: Mutex<HashMap<Uuid, String>>,
     reverse: Mutex<HashMap<String, Uuid>>,
+    /// R-progress throttle (Plan 2026-06-29 Phase 1): coord `session_id` →
+    /// last instant a progress PATCH was enqueued. A genuine forward-progress
+    /// boundary fires per assistant tool-use turn (potentially many per
+    /// second); we coalesce them to at most one progress emit per
+    /// [`PROGRESS_MIN_INTERVAL`] so the outbox/coord don't see a PATCH per
+    /// line. This is a RATE CAP, not a timer — when the session stops making
+    /// tool-use turns (idle / stuck), NO emit happens and `last_progress_at`
+    /// ages to stale, which is the whole point (false-progress trap, §5).
+    last_progress_emit: Mutex<HashMap<Uuid, std::time::Instant>>,
 }
+
+/// Minimum wall-clock gap between two progress PATCHes for the same session.
+/// Far below the 600s stall threshold (so a working session stays fresh) yet
+/// large enough that a burst of tool-use turns coalesces to a single emit.
+const PROGRESS_MIN_INTERVAL: Duration = Duration::from_secs(30);
 
 impl AiCoordRegistrar {
     /// Construct from the shared session outbox + this device's `machine_id`.
@@ -128,6 +142,7 @@ impl AiCoordRegistrar {
                 machine_id,
                 forward: Mutex::new(HashMap::new()),
                 reverse: Mutex::new(HashMap::new()),
+                last_progress_emit: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -330,6 +345,75 @@ impl AiCoordRegistrar {
         }
     }
 
+    /// R-progress (Plan 2026-06-29 Phase 1) — report GENUINE forward progress
+    /// for the AI session backing `task_run_id`, driven by a new assistant
+    /// tool-use turn (called from the stdout dispatcher's `extract_tool_use`
+    /// boundary). Emits a `Progress` outbox row → drained as
+    /// `PATCH /sessions/:id {progress:{...}}` → coord bumps
+    /// `coord.sessions.last_progress_at` (the WORK-PROGRESS axis the
+    /// `session_stall_watcher` reads), distinct from the liveness heartbeat.
+    ///
+    /// **Rate-capped, NOT a timer.** Tool-use turns can arrive many per second;
+    /// we coalesce them to at most one emit per [`PROGRESS_MIN_INTERVAL`] per
+    /// session. Crucially the emit is driven by REAL forward motion: when the
+    /// session stops producing tool-use turns (idle / stuck), nothing fires and
+    /// `last_progress_at` ages to stale so the watcher can flag it (§5
+    /// false-progress trap). A periodic heartbeat would defeat that — this
+    /// deliberately rides the work boundary, not the clock.
+    ///
+    /// `detail` is optional free-form checkpoint JSON (e.g. the active tool
+    /// name) stored in `progress_detail`. Best-effort: no registered session,
+    /// a poisoned lock, or an outbox error is a silent no-op that never
+    /// disturbs the live session.
+    pub fn report_progress(&self, task_run_id: &str, detail: Option<serde_json::Value>) {
+        let Some(session_id) = self.session_id_for(task_run_id) else {
+            return; // never registered — nothing to report against.
+        };
+
+        // Rate cap: skip if we emitted for this session within the window.
+        // Edge case — a poisoned lock recovers via into_inner (the map is pure
+        // throttle bookkeeping; a stale entry only delays the next emit).
+        {
+            let mut guard = self
+                .inner
+                .last_progress_emit
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let now = std::time::Instant::now();
+            if let Some(prev) = guard.get(&session_id) {
+                if now.duration_since(*prev) < PROGRESS_MIN_INTERVAL {
+                    return; // coalesced into the previous emit.
+                }
+            }
+            guard.insert(session_id, now);
+        }
+
+        // `session_status` is left to coord's existing value (omitted) — a
+        // forward-progress emit means "still working" but we don't want to
+        // clobber an operator/agent-set `blocked` status; the presence of the
+        // report alone advances `last_progress_at`.
+        let mut payload = json!({ "id": session_id });
+        if let Some(d) = detail {
+            payload["progress_detail"] = d;
+        }
+        if let Err(e) = self.inner.outbox.record(
+            self.inner.machine_id,
+            session_id,
+            SessionEventKind::Progress,
+            payload,
+        ) {
+            warn!(
+                "ai_coord_register: outbox Progress write failed for {} (best-effort): {}",
+                task_run_id, e
+            );
+        } else {
+            debug!(
+                "ai_coord_register: forward-progress report for {} (coord {})",
+                task_run_id, session_id
+            );
+        }
+    }
+
     /// R5 — on AI-session end, emit a `Closed` outbox row (`DELETE
     /// /sessions/:id`) and evict the R4 index entry so coord.sessions doesn't
     /// leak a ghost row and the resolver doesn't keep a dangling mapping.
@@ -349,6 +433,13 @@ impl AiCoordRegistrar {
             if let Ok(mut fwd) = self.inner.forward.lock() {
                 fwd.remove(&id);
             }
+            // Evict the progress throttle entry so the map doesn't leak across
+            // long-lived runners (best-effort; recover a poisoned lock).
+            self.inner
+                .last_progress_emit
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .remove(&id);
             id
         };
 
@@ -808,6 +899,63 @@ mod tests {
             .collect();
         assert_eq!(hb.len(), 1, "exactly one interaction heartbeat");
         assert_eq!(hb[0].session_id, coord_id);
+    }
+
+    #[test]
+    fn report_progress_emits_progress_row_with_detail() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+
+        // Progress before registration is a no-op (no session to report against).
+        reg.report_progress(&trid, Some(json!({ "tool": "Edit" })));
+        assert!(reg.inner.outbox.pending().unwrap().is_empty());
+
+        let coord_id = reg.register_session(&trid, "purpose", None).unwrap();
+        reg.report_progress(&trid, Some(json!({ "tool": "Bash" })));
+
+        let prog: Vec<_> = reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.event_kind == SessionEventKind::Progress.as_str())
+            .collect();
+        assert_eq!(prog.len(), 1, "exactly one progress row");
+        assert_eq!(prog[0].session_id, coord_id);
+        assert_eq!(prog[0].payload["id"], json!(coord_id));
+        assert_eq!(
+            prog[0].payload["progress_detail"],
+            json!({ "tool": "Bash" })
+        );
+        // Carries NO heartbeat field — progress is the work axis, not liveness.
+        assert!(prog[0].payload.get("heartbeat").is_none());
+    }
+
+    #[test]
+    fn report_progress_rate_caps_a_burst_to_one_emit() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+        reg.register_session(&trid, "purpose", None).unwrap();
+
+        // A burst of tool-use turns within the throttle window coalesces to one
+        // progress emit (genuine-progress, not one-PATCH-per-line).
+        for _ in 0..10 {
+            reg.report_progress(&trid, None);
+        }
+        let n = reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.event_kind == SessionEventKind::Progress.as_str())
+            .count();
+        assert_eq!(n, 1, "a burst within PROGRESS_MIN_INTERVAL emits once");
     }
 
     #[test]

--- a/src-tauri/src/claude_session/dispatcher.rs
+++ b/src-tauri/src/claude_session/dispatcher.rs
@@ -34,6 +34,32 @@ fn emit_state_if_possible(
     }
 }
 
+/// Report a genuine forward-progress boundary (a new assistant tool-use turn)
+/// to coord (Plan 2026-06-29 Phase 1), so `coord.sessions.last_progress_at`
+/// advances and the observe-mode `session_stall_watcher` has rows to evaluate.
+///
+/// Resolves the coord [`AiCoordRegistrar`] from managed Tauri state (the same
+/// handle the heartbeat path uses, `drain.rs`) and the session's `task_run_id`
+/// from `session_ctx`. The registrar rate-caps the actual emit, so calling
+/// this on every tool-use line is cheap. Best-effort + non-blocking: a missing
+/// registrar (registration disabled), a missing context, or a closed session
+/// is a silent no-op — progress reporting must NEVER disturb the session
+/// (exactly like the heartbeat).
+fn report_session_progress(
+    app_handle: &tauri::AppHandle,
+    session_ctx: Option<&AiSessionContext>,
+    tool_name: &str,
+) {
+    let Some(ctx) = session_ctx else { return };
+    let Some(registrar) =
+        app_handle.try_state::<Arc<crate::claude_session::coord_register::AiCoordRegistrar>>()
+    else {
+        return; // registrar not installed (e.g. registration disabled) — no-op.
+    };
+    let detail = serde_json::json!({ "tool": tool_name });
+    registrar.report_progress(ctx.task_run_id(), Some(detail));
+}
+
 /// Configuration for the dispatcher.
 pub struct DispatcherConfig {
     /// App handle for emitting events.
@@ -105,6 +131,9 @@ pub fn dispatch_line(
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             emit_ai_output(app_handle, &activity, "tool_activity", None, session_ctx);
         }));
+        // Plan 2026-06-29 Phase 1 — a new tool-use turn is genuine forward
+        // progress; report it to coord (rate-capped inside the registrar).
+        report_session_progress(app_handle, session_ctx, tool_name);
         // Auto-register files under active development when Edit/Write tools are used
         auto_register_file(
             app_handle,
@@ -124,6 +153,9 @@ pub fn dispatch_line(
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             emit_ai_output(app_handle, &activity, "tool_activity", None, session_ctx);
         }));
+        // Plan 2026-06-29 Phase 1 — forward-progress boundary (stream-json
+        // path: tool_use arrives as content_block_start).
+        report_session_progress(app_handle, session_ctx, &tool_name);
         // Auto-register files under active development when Edit/Write tools are used
         auto_register_file(
             app_handle,

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -618,6 +618,20 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
                 .send()
                 .await
         }
+        "progress" => {
+            // Plan 2026-06-29 Phase 1 — work-progress signal. PATCH
+            // `/sessions/:id {progress:{...}}`; coord routes the embedded
+            // `progress` object through `advance_session_progress` to bump
+            // `last_progress_at` (the work-progress axis the stall watcher
+            // reads). Deliberately carries NO `heartbeat:true` — this is the
+            // progress axis, ORTHOGONAL to liveness. Best-effort: a
+            // pre-migration coord swallows the column write and 200s.
+            let url = format!("{base}/sessions/{}", rec.session_id);
+            let body = progress_body(&rec.payload);
+            crate::auth::attach_device_auth(inner.http.patch(&url).json(&body))
+                .send()
+                .await
+        }
         "closed" => {
             let url = format!("{base}/sessions/{}", rec.session_id);
             crate::auth::attach_device_auth(inner.http.delete(&url))
@@ -772,6 +786,28 @@ fn state_change_body(payload: &JsonValue) -> JsonValue {
     // caller only changed metadata.
     body.insert("heartbeat".into(), JsonValue::Bool(true));
     JsonValue::Object(body)
+}
+
+/// Build the `PATCH /sessions/:id {progress:{...}}` body from a `Progress`
+/// outbox payload (Plan 2026-06-29 Phase 1). The runner stamps
+/// `{session_status?, progress_detail?}` into the outbox payload; we wrap it in
+/// coord's `progress` envelope (`UpdateSessionRequest.progress`). `last_progress_at`
+/// is omitted so coord stamps `now()` at receive time — the presence of the
+/// report IS the advance signal. Only fields actually present are forwarded so
+/// a `None` never overwrites an existing column with NULL.
+fn progress_body(payload: &JsonValue) -> JsonValue {
+    let mut progress = serde_json::Map::new();
+    if let Some(status) = payload.get("session_status") {
+        if !status.is_null() {
+            progress.insert("session_status".into(), status.clone());
+        }
+    }
+    if let Some(detail) = payload.get("progress_detail") {
+        if !detail.is_null() {
+            progress.insert("progress_detail".into(), detail.clone());
+        }
+    }
+    json!({ "progress": JsonValue::Object(progress) })
 }
 
 /// Build the `POST /sessions/:id/steal` body from the claim_stolen

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -180,6 +180,15 @@ pub enum SessionEventKind {
     /// payload carries `{repo, branch, shas}` and NO session id (coord resolves
     /// the session server-side from `(repo, branch)`).
     CommitReport,
+    /// Session work-PROGRESS signal (Plan 2026-06-29 Phase 1). Drained to
+    /// `PATCH /sessions/:id {progress:{...}}`, which coord routes through
+    /// `advance_session_progress` to bump `coord.sessions.last_progress_at`
+    /// (the work-progress axis the `session_stall_watcher` reads) — ORTHOGONAL
+    /// to [`SessionEventKind::Heartbeat`], which bumps `last_heartbeat_at`
+    /// (liveness). Emitted ONLY at genuine forward-progress boundaries (a new
+    /// assistant tool-use turn), NOT on the heartbeat timer, so an idle/stuck
+    /// session's `last_progress_at` ages to stale and the watcher can fire.
+    Progress,
 }
 
 impl SessionEventKind {
@@ -193,6 +202,7 @@ impl SessionEventKind {
             SessionEventKind::OutputChunk => "output_chunk",
             SessionEventKind::HandoffRequest => "handoff_request",
             SessionEventKind::CommitReport => "commit_report",
+            SessionEventKind::Progress => "progress",
         }
     }
 }
@@ -1211,6 +1221,7 @@ mod tests {
             SessionEventKind::OutputChunk,
             SessionEventKind::HandoffRequest,
             SessionEventKind::CommitReport,
+            SessionEventKind::Progress,
         ];
         for k in kinds {
             let json = serde_json::to_string(&k).unwrap();


### PR DESCRIPTION
Phase 1 of `2026-06-29-workunit-signal-adoption-light-up-dark-features` — the runner half (the real deliverable).

`coord.sessions.last_progress_at` (the WORK-PROGRESS axis the `session_stall_watcher` reads, distinct from the liveness heartbeat) was written only by the agent-driven MCP `coord_report_status` — opt-in/sporadic, so it was NULL for ~all sessions and the observe-mode watcher had nothing to evaluate. This wires the **runner** to emit it automatically (fleet-wide capability ⇒ runner, not a per-machine hook).

**What it does:**
- New `SessionEventKind::Progress` outbox variant → drain loop PATCHes `/sessions/:id` with `{ "progress": { session_status?, progress_detail? } }` (no `heartbeat` field — progress ≠ liveness; `last_progress_at` omitted so coord stamps `now()`). Reuses the existing Started/Heartbeat/Closed outbox→drain→device-auth→retry machinery + the R4 `session_id↔task_run_id` index.
- Emitted at a **genuine forward-progress boundary** — a new assistant tool-use turn in `dispatcher.rs::dispatch_line` — NOT on a timer, and **rate-capped to ≤1 PATCH / 30s / session**. So an actively-working session keeps `last_progress_at` fresh, but one that stops producing tool-use turns ages past the 600s stall threshold → the watcher can flag it (avoids the false-progress trap).
- Best-effort + non-blocking throughout (missing registrar/context/closed session = silent no-op), exactly like the heartbeat.

Companion coord test: qontinui-coord#836. Lights up `session_stall` (observe); arming `live` is out of scope.

Plan: 2026-06-29-workunit-signal-adoption-light-up-dark-features

🤖 Generated with [Claude Code](https://claude.com/claude-code)