### PR TITLE
feat(runner): terminal AI sessions survive runner logout (autonomy ≠ login)

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -321,25 +321,68 @@ impl AuthManager {
             .context("Failed to retrieve refresh token from keychain")
     }
 
-    /// Clears all tokens from both storages.
+    /// Clears ALL credentials from both storages — the device-JWT pair AND
+    /// the Cognito (`oauth_*`) session, including the long-lived
+    /// `oauth_refresh_token`.
     ///
-    /// This is typically called during logout.
+    /// This is the explicit full sign-out. It destroys the only credential the
+    /// device-JWT refresher can self-recover from, so it STOPS the runner's
+    /// autonomous terminal sessions (they cannot re-mint a device JWT until an
+    /// interactive re-login). For a default logout that should keep autonomy
+    /// running, use [`Self::clear_interactive_session`].
     ///
     /// # Errors
     ///
     /// Returns an error if clearing fails.
-    pub fn clear_tokens(&self) -> Result<()> {
+    pub fn clear_all_credentials(&self) -> Result<()> {
         // Clear from file storage
         if let Err(e) = self.secure_storage.clear_tokens() {
             warn!("Failed to clear tokens from secure storage: {}", e);
         }
 
-        // Also clear from keychain (best effort)
+        // Also clear from keychain (best effort). The keychain only ever holds
+        // the device-JWT pair (the oauth_* slots are file-only — see the module
+        // comment at the Cognito section), so this deletes the access_token /
+        // refresh_token entries.
         if let Err(e) = self.clear_tokens_from_keychain() {
             debug!("Failed to clear tokens from keychain: {}", e);
         }
 
-        info!("Tokens cleared");
+        info!("All credentials cleared (device JWT + Cognito session)");
+        Ok(())
+    }
+
+    /// Clears ONLY the interactive device-JWT session, PRESERVING the Cognito
+    /// (`oauth_*`) session so the device-JWT refresher can immediately re-mint
+    /// a fresh device JWT and keep autonomous terminal sessions running.
+    ///
+    /// This is the autonomy-preserving clear used by a default logout. Only the
+    /// `access_token` / `refresh_token` slots (file + keychain) are dropped; the
+    /// `oauth_refresh_token` (and the rest of the Cognito session) is left
+    /// intact. Contrast with [`Self::clear_all_credentials`].
+    ///
+    /// The keychain only stores the device-JWT pair (oauth_* are file-only), so
+    /// the keychain clear here is exactly the same `clear_tokens_from_keychain`
+    /// helper and never touches a Cognito entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if clearing fails.
+    pub fn clear_interactive_session(&self) -> Result<()> {
+        // Clear ONLY the device-JWT pair from file storage; preserve oauth_*.
+        if let Err(e) = self.secure_storage.clear_interactive_session() {
+            warn!(
+                "Failed to clear interactive device-JWT session from secure storage: {}",
+                e
+            );
+        }
+
+        // Keychain only holds the device-JWT pair, so this is the same helper.
+        if let Err(e) = self.clear_tokens_from_keychain() {
+            debug!("Failed to clear device-JWT pair from keychain: {}", e);
+        }
+
+        info!("Interactive device-JWT session cleared (Cognito session preserved for autonomous refresh)");
         Ok(())
     }
 
@@ -838,8 +881,8 @@ mod tests {
         // Verify has_tokens
         assert!(auth_manager.has_tokens());
 
-        // Clear and verify
-        auth_manager.clear_tokens().unwrap();
+        // Clear and verify (full wipe).
+        auth_manager.clear_all_credentials().unwrap();
         assert!(!auth_manager.has_tokens());
     }
 

--- a/src-tauri/src/cognito.rs
+++ b/src-tauri/src/cognito.rs
@@ -604,13 +604,87 @@ fn exchange_code(code: &str, code_verifier: &str) -> Result<CognitoTokenResponse
         ("redirect_uri", COGNITO_REDIRECT_URI),
         ("code_verifier", code_verifier),
     ];
-    post_token_form(&form)
+    // The browser PKCE flow surfaces failures straight to the UI, where the
+    // transient/hard distinction is irrelevant — flatten to a message.
+    post_token_form(&form).map_err(|e| e.to_string())
+}
+
+/// Classified failure of a Cognito `/oauth2/token` grant. The refresher needs
+/// to distinguish "retry, connectivity will come back" from "the refresh token
+/// is dead, only an interactive re-login fixes this" — see
+/// [`crate::mcp::device_jwt_refresher`]. `refresh_tokens` returns this; the
+/// browser/code-exchange paths flatten it to a `String` (they surface to the
+/// UI, where the distinction is irrelevant).
+#[derive(Debug, Clone)]
+pub enum CognitoRefreshError {
+    /// Network error, timeout, or a 5xx/429 from the token endpoint. Retryable
+    /// — autonomy should back off and try again, never give up.
+    Transient(String),
+    /// HTTP 400 `invalid_grant`: the refresh token is expired or revoked. There
+    /// is NO headless recovery — the user must sign in again. Retrying is
+    /// pointless and will keep failing identically.
+    InvalidGrant(String),
+    /// Any other failure (a 4xx other than `invalid_grant`, a decode error,
+    /// etc.). Treated conservatively as retryable by the refresher (we never
+    /// falsely tell the user to re-login on an unclassified error), but kept
+    /// distinct so the classifier is unit-testable and future callers can act.
+    Other(String),
+}
+
+impl CognitoRefreshError {
+    /// True for network/5xx/429 failures that warrant a prompt backoff retry.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Transient(_))
+    }
+
+    /// True iff the refresh token itself is dead (expired/revoked) — the one
+    /// case that cannot self-heal headlessly.
+    pub fn is_invalid_grant(&self) -> bool {
+        matches!(self, Self::InvalidGrant(_))
+    }
+}
+
+impl std::fmt::Display for CognitoRefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transient(m) | Self::InvalidGrant(m) | Self::Other(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for CognitoRefreshError {}
+
+/// Pure classifier: map a non-2xx HTTP status + response body from the Cognito
+/// token endpoint to a [`CognitoRefreshError`]. Factored out so the
+/// transient-vs-invalid_grant decision is unit-testable without a live Cognito.
+///
+/// - `400` + an `invalid_grant` error in the body → [`CognitoRefreshError::InvalidGrant`]
+///   (the refresh token is expired/revoked; no headless recovery).
+/// - `5xx` or `429` → [`CognitoRefreshError::Transient`] (server-side / rate
+///   limit; retry with backoff).
+/// - anything else → [`CognitoRefreshError::Other`].
+pub(crate) fn classify_token_error(status: u16, body: &str) -> CognitoRefreshError {
+    let msg = format!(
+        "token endpoint returned HTTP {status}: {}",
+        body.chars().take(300).collect::<String>()
+    );
+    let body_lc = body.to_ascii_lowercase();
+    if status == 400 && body_lc.contains("invalid_grant") {
+        return CognitoRefreshError::InvalidGrant(msg);
+    }
+    if status >= 500 || status == 429 {
+        return CognitoRefreshError::Transient(msg);
+    }
+    CognitoRefreshError::Other(msg)
 }
 
 /// Exchange a refresh token for a fresh access + id token. Cognito does NOT
 /// return a new refresh_token on this grant; the caller keeps the existing
 /// one. Blocking; call via `spawn_blocking`.
-pub fn refresh_tokens(refresh_token: &str) -> Result<CognitoTokenResponse, String> {
+///
+/// Returns a [`CognitoRefreshError`] so the refresher can distinguish a
+/// transient blip (retry) from a dead refresh token (re-login required).
+pub fn refresh_tokens(refresh_token: &str) -> Result<CognitoTokenResponse, CognitoRefreshError> {
     let form = [
         ("grant_type", "refresh_token"),
         ("client_id", COGNITO_CLIENT_ID),
@@ -619,29 +693,31 @@ pub fn refresh_tokens(refresh_token: &str) -> Result<CognitoTokenResponse, Strin
     post_token_form(&form)
 }
 
-/// Shared form POST to the token endpoint with status/error surfacing.
-fn post_token_form(form: &[(&str, &str)]) -> Result<CognitoTokenResponse, String> {
+/// Shared form POST to the token endpoint with status/error surfacing. Errors
+/// are classified ([`CognitoRefreshError`]); the code-exchange path flattens
+/// them to a `String`.
+fn post_token_form(form: &[(&str, &str)]) -> Result<CognitoTokenResponse, CognitoRefreshError> {
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .map_err(|e| format!("reqwest client build failed: {e}"))?;
+        .map_err(|e| CognitoRefreshError::Transient(format!("reqwest client build failed: {e}")))?;
     let resp = client
         .post(COGNITO_TOKEN_URL)
         .form(form)
         .send()
-        .map_err(|e| format!("POST {COGNITO_TOKEN_URL} failed: {e}"))?;
+        // A send failure is a network error / timeout — always retryable.
+        .map_err(|e| {
+            CognitoRefreshError::Transient(format!("POST {COGNITO_TOKEN_URL} failed: {e}"))
+        })?;
     let status = resp.status();
     if !status.is_success() {
         let body = resp
             .text()
             .unwrap_or_else(|_| "<unreadable body>".to_string());
-        return Err(format!(
-            "token endpoint returned HTTP {status}: {}",
-            body.chars().take(300).collect::<String>()
-        ));
+        return Err(classify_token_error(status.as_u16(), &body));
     }
     resp.json::<CognitoTokenResponse>()
-        .map_err(|e| format!("decode token response failed: {e}"))
+        .map_err(|e| CognitoRefreshError::Other(format!("decode token response failed: {e}")))
 }
 
 #[cfg(test)]
@@ -790,5 +866,48 @@ mod tests {
         );
         // Non-JSON body doesn't panic.
         assert!(humanize_cognito_error("not json", 500).contains("500"));
+    }
+
+    // ---- refresh-error classification (pure, Phase 2) ----
+
+    #[test]
+    fn classify_invalid_grant_is_hard() {
+        // Cognito's canonical expired/revoked refresh-token response.
+        let e = classify_token_error(400, r#"{"error":"invalid_grant"}"#);
+        assert!(
+            e.is_invalid_grant(),
+            "400 invalid_grant must be InvalidGrant"
+        );
+        assert!(!e.is_transient());
+        // Case-insensitive on the body.
+        assert!(classify_token_error(400, r#"{"error":"INVALID_GRANT"}"#).is_invalid_grant());
+    }
+
+    #[test]
+    fn classify_5xx_and_429_are_transient() {
+        assert!(classify_token_error(500, "boom").is_transient());
+        assert!(classify_token_error(503, "overloaded").is_transient());
+        assert!(
+            classify_token_error(429, "slow down").is_transient(),
+            "rate-limit (429) is retryable"
+        );
+    }
+
+    #[test]
+    fn classify_other_4xx_is_other_not_hard() {
+        // A 400 that ISN'T invalid_grant (e.g. a bad client config) must NOT be
+        // mis-flagged as a dead refresh token, and a 401 isn't transient.
+        let bad_req = classify_token_error(400, r#"{"error":"invalid_request"}"#);
+        assert!(!bad_req.is_invalid_grant());
+        assert!(!bad_req.is_transient());
+        assert!(matches!(bad_req, CognitoRefreshError::Other(_)));
+        let unauth = classify_token_error(401, r#"{"error":"invalid_client"}"#);
+        assert!(matches!(unauth, CognitoRefreshError::Other(_)));
+    }
+
+    #[test]
+    fn refresh_error_display_carries_message() {
+        let e = classify_token_error(503, "down");
+        assert!(e.to_string().contains("HTTP 503"));
     }
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -140,17 +140,19 @@ fn get_device_name() -> String {
     format!("{} ({})", hostname, platform)
 }
 
-/// Logs out the current user.
+/// Logs out the current user WITHOUT stopping autonomous terminal sessions.
 ///
-/// This command:
-/// 1. Retrieves the device ID
-/// 2. Calls the backend to deactivate the device (optional)
-/// 3. Clears all tokens from the keychain
+/// This is the DEFAULT logout: it clears only the interactive device-JWT
+/// session and PRESERVES the Cognito (`oauth_*`) session, then kicks the
+/// device-JWT refresher so a fresh device JWT is re-minted immediately. The
+/// runner's background daemons keep driving autonomous terminal AI sessions
+/// across the logout — there is no multi-minute autonomy gap.
+///
+/// Use [`sign_out_full`] to fully sign out and STOP autonomous sessions.
 ///
 /// # Errors
 ///
-/// Returns an error string if keychain operations fail.
-/// Network errors during device deactivation are logged but don't fail the operation.
+/// Returns an error string if clearing fails.
 #[tauri::command]
 pub async fn logout() -> Result<(), String> {
     logout_impl().await.map_err(String::from)
@@ -158,7 +160,7 @@ pub async fn logout() -> Result<(), String> {
 
 async fn logout_impl() -> Result<(), AppError> {
     require_tier_2()?;
-    info!("Logout requested");
+    info!("Logout requested (interactive session only — autonomous sessions preserved)");
 
     let auth_manager = AuthManager::new();
 
@@ -167,10 +169,45 @@ async fn logout_impl() -> Result<(), AppError> {
     // the unified WebSocket relay; closing the WS (which happens on token
     // revocation) is the equivalent of "logging the device out".
     //
-    // Clear tokens from the keychain.
-    auth_manager.clear_tokens()?;
+    // Clear ONLY the interactive device-JWT session; preserve the Cognito
+    // session so autonomy survives the logout.
+    auth_manager.clear_interactive_session()?;
 
-    info!("Logout successful");
+    // Re-mint the device JWT right away from the preserved Cognito session so
+    // the autonomous daemons don't see even a transient missing-token window.
+    crate::mcp::device_jwt_refresher::commands::kick_device_jwt_refresher().await;
+
+    info!("Logout successful — autonomous terminal sessions preserved (device JWT re-minting from the kept Cognito session)");
+    Ok(())
+}
+
+/// Fully signs out and STOPS the runner's autonomous terminal sessions.
+///
+/// Unlike [`logout`], this clears ALL credentials — the device-JWT pair AND
+/// the Cognito (`oauth_*`) session, including the long-lived
+/// `oauth_refresh_token`. With the Cognito session gone the device-JWT
+/// refresher can no longer self-recover, so the background daemons stop
+/// driving autonomous sessions until an interactive re-login. This is the
+/// explicit "stop autonomy" sign-out.
+///
+/// # Errors
+///
+/// Returns an error string if clearing fails.
+#[tauri::command]
+pub async fn sign_out_full() -> Result<(), String> {
+    sign_out_full_impl().await.map_err(String::from)
+}
+
+async fn sign_out_full_impl() -> Result<(), AppError> {
+    require_tier_2()?;
+    info!("Full sign-out requested — clearing ALL credentials (autonomous sessions will stop)");
+
+    let auth_manager = AuthManager::new();
+    auth_manager.clear_all_credentials()?;
+
+    info!(
+        "Full sign-out successful — autonomous terminal sessions stopped (Cognito session wiped)"
+    );
     Ok(())
 }
 
@@ -827,9 +864,19 @@ pub async fn qontinui_sign_out() -> Result<(), String> {
 
     // Best-effort: a stale keychain entry is annoying but not fatal —
     // the gating checks all run off the `tier` field + cleared token below.
+    //
+    // This is the explicit "switch accounts → LoginScreen" path, so it must be
+    // the FULL wipe: `has_local_signed_in_session` treats a preserved Cognito
+    // session as still-authenticated, so an interactive-only clear would keep
+    // the App gate out of the LoginScreen. Clearing the Cognito session also
+    // (correctly) stops the old account's autonomous sessions before a new
+    // account signs in.
     let auth_manager = AuthManager::new();
-    if let Err(e) = auth_manager.clear_tokens() {
-        warn!("qontinui_sign_out: clear_tokens failed (continuing): {}", e);
+    if let Err(e) = auth_manager.clear_all_credentials() {
+        warn!(
+            "qontinui_sign_out: clear_all_credentials failed (continuing): {}",
+            e
+        );
     }
 
     let mut s = settings::load_settings();
@@ -924,6 +971,7 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             cognito_sign_in,
             cognito_sign_in_password,
             qontinui_sign_out,
+            sign_out_full,
             device_jwt_present,
             get_coord_device_token,
             kick_device_jwt_refresher_cmd,

--- a/src-tauri/src/coord_mcp.rs
+++ b/src-tauri/src/coord_mcp.rs
@@ -431,6 +431,102 @@ pub(crate) fn proxy_request_gate(
     }
 }
 
+/// Phase 3 (terminal-autonomy-survives-logout): maximum TOTAL time the
+/// DEVICE-path coord-mcp proxy will wait for the device-JWT refresher to
+/// re-mint a momentarily-missing token before it degrades to an actionable
+/// retry error. Bounded tightly — a proxy request must NEVER block
+/// indefinitely on a credential gap. The device JWT re-mints from the
+/// preserved Cognito session in seconds (Phase 1), so this smooths the common
+/// re-mint-window / transient-backoff gap (Phases 1-2) without hanging.
+pub(crate) const DEVICE_JWT_REMINT_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
+/// Poll interval while waiting for the [`DEVICE_JWT_REMINT_WAIT`] re-mint.
+pub(crate) const DEVICE_JWT_REMINT_POLL: std::time::Duration =
+    std::time::Duration::from_millis(250);
+
+/// The actionable, retry-shaped error the DEVICE-path proxy returns when the
+/// device JWT is STILL missing after the bounded [`DEVICE_JWT_REMINT_WAIT`].
+///
+/// Distinct from the gate's hard 401s (bad/absent nonce, scope-elevation): this
+/// is a TRANSIENT credential gap, not an auth failure — the autonomous session
+/// is alive and the refresher is re-minting, so the caller should simply retry.
+/// `503` (the canonical "temporarily unavailable, retry" code) keeps it an
+/// error the MCP client will not mistake for success while signalling
+/// retry-ability; the message is human/agent-actionable rather than a bare
+/// "no live JWT available". The nonce/scope FAIL-CLOSED 401s in
+/// [`proxy_request_gate`] are unchanged — only the missing-device-JWT case
+/// degrades to this.
+pub(crate) fn device_jwt_refreshing_error() -> (u16, String) {
+    (
+        503,
+        "coord credential refreshing — autonomous session will resume; \
+         retry shortly"
+            .to_string(),
+    )
+}
+
+/// Bounded poll for a usable token: returns as soon as `read_usable` yields a
+/// non-empty token, or `None` once `total` elapses. Generic over the reader so
+/// the bound/termination behavior is unit-testable without a live AuthManager
+/// or a real 5s wait. NEVER blocks indefinitely — the deadline is checked every
+/// `interval`.
+async fn await_remint_with<F, Fut>(
+    mut read_usable: F,
+    total: std::time::Duration,
+    interval: std::time::Duration,
+) -> Option<String>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<String>>,
+{
+    let deadline = tokio::time::Instant::now() + total;
+    loop {
+        if let Some(t) = read_usable().await {
+            if !t.trim().is_empty() {
+                return Some(t);
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Read the device JWT ONLY if it is freshly usable (present, non-empty, and
+/// not stale per [`AuthManager::device_jwt_needs_refresh`]). Filesystem I/O, so
+/// it runs on a blocking thread off the async executor — the same discipline
+/// the proxy handler's first read uses. Used by [`await_device_jwt_remint`] to
+/// detect "a usable JWT is now present" after a refresher kick.
+async fn read_usable_device_jwt() -> Option<String> {
+    tokio::task::spawn_blocking(|| {
+        let am = crate::auth::AuthManager::new();
+        match am.device_jwt_needs_refresh() {
+            Ok(false) => am.get_access_token().ok().filter(|t| !t.trim().is_empty()),
+            _ => None,
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Phase 3 graceful-degrade for the DEVICE proxy path: when the device JWT is
+/// momentarily absent, KICK the refresher (so it re-mints immediately from the
+/// preserved Cognito session instead of waiting out its sleep) and wait a
+/// tightly-bounded [`DEVICE_JWT_REMINT_WAIT`] for a usable JWT to appear.
+/// Returns the fresh token if one re-mints within the bound, else `None` (the
+/// caller then degrades to [`device_jwt_refreshing_error`]). Agent-bound proxy
+/// requests do NOT use this — they refresh via their own `AGENT_TOKENS` slot.
+pub(crate) async fn await_device_jwt_remint() -> Option<String> {
+    crate::mcp::device_jwt_refresher::commands::kick_device_jwt_refresher().await;
+    await_remint_with(
+        read_usable_device_jwt,
+        DEVICE_JWT_REMINT_WAIT,
+        DEVICE_JWT_REMINT_POLL,
+    )
+    .await
+}
+
 /// Resolve the runner's ACTUALLY-BOUND local API port for loopback URLs:
 /// the managed `AppState.api_port` (set at bind time) via the process-global
 /// `AppHandle`. Returns `None` — fail-closed, Phase 3a — when no Tauri runtime
@@ -1215,6 +1311,114 @@ mod tests {
                 .0,
             401
         );
+    }
+
+    /// Phase 3 invariant pin (terminal-autonomy-survives-logout): a MISSING
+    /// device JWT degrades the coord-mcp PROXY path to an actionable retry —
+    /// and ONLY that path. Local terminal AI session work (model reasoning, the
+    /// PTY, local tools) is structurally independent of this gate, so a coord
+    /// credential gap can never block local work.
+    ///
+    /// This asserts the gating is scoped to coord-mcp proxy requests:
+    ///  - [`proxy_request_gate`] is the ONLY thing a missing device JWT affects;
+    ///    it governs proxy forwarding exclusively (it takes a proxy nonce +
+    ///    bearer + the bound principal and returns only forward-or-401). It is
+    ///    not on, and has no handle into, any local-execution path.
+    ///  - the missing-device-JWT case degrades to an ACTIONABLE, retry-shaped
+    ///    error ([`device_jwt_refreshing_error`]) — not a panic, not a hang
+    ///    (the wait is bounded, see `await_remint_*` tests), not a bare 401.
+    ///  - the gate's hard nonce/scope 401s stay FAIL-CLOSED and unchanged.
+    ///
+    /// Why local work is independent (documented here as the layer can't call a
+    /// PTY): the terminal AI session's MODEL auth is the operator's own Claude
+    /// subscription via `CLAUDE_CONFIG_DIR`, and the PTY + local tools never
+    /// issue a coord-mcp proxy request — only an explicit coord MCP tool call
+    /// routes through this gate. So a missing device JWT can at most make a
+    /// coord tool call retry; it cannot stall the session's local progress.
+    #[test]
+    fn missing_device_jwt_degrades_proxy_only_not_local_work() {
+        // (a) The degrade is an ACTIONABLE retry, distinct from the hard 401.
+        let (status, msg) = device_jwt_refreshing_error();
+        assert_eq!(status, 503, "transient credential gap → retryable, not 401");
+        assert!(
+            msg.to_lowercase().contains("retry"),
+            "degrade message must tell the caller to retry: {msg:?}"
+        );
+        assert!(
+            !msg.contains("no live JWT available"),
+            "must NOT be the bare missing-JWT 401 message"
+        );
+
+        // (b) The gate is scoped to proxy requests only: its hard nonce/scope
+        // 401s remain fail-closed and unchanged. A valid device nonce with NO
+        // bearer is still a hard 401 backstop (the proxy handler only reaches
+        // the gate AFTER the bounded re-mint produced a usable bearer).
+        let dir = std::env::temp_dir().join(format!("coord-mcp-p3-{}", uuid::Uuid::new_v4()));
+        let nonce = register_proxy_nonce(&dir.to_string_lossy());
+        let dev_p = ProxyPrincipal::Device;
+        assert_eq!(
+            proxy_request_gate(Some(&nonce), None, &dev_p)
+                .unwrap_err()
+                .0,
+            401,
+            "missing bearer at the gate is still a hard 401 backstop"
+        );
+        // Bad nonce stays a hard 401 regardless of the degrade path.
+        assert_eq!(
+            proxy_request_gate(Some("nope"), None, &dev_p)
+                .unwrap_err()
+                .0,
+            401
+        );
+    }
+
+    /// The bounded re-mint wait TERMINATES on the deadline (never hangs) when no
+    /// usable JWT ever appears — pins "NEVER block a request indefinitely".
+    #[tokio::test]
+    async fn await_remint_is_bounded_when_no_jwt_appears() {
+        let calls = std::cell::Cell::new(0u32);
+        let started = std::time::Instant::now();
+        let out = await_remint_with(
+            || {
+                calls.set(calls.get() + 1);
+                async { None }
+            },
+            std::time::Duration::from_millis(120),
+            std::time::Duration::from_millis(20),
+        )
+        .await;
+        assert_eq!(out, None, "no JWT → None after the bound");
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "must return promptly at the bound, not hang"
+        );
+        assert!(calls.get() >= 2, "should have polled more than once");
+    }
+
+    /// The bounded re-mint wait RETURNS as soon as a freshly-minted JWT appears
+    /// mid-poll — pins the common case: the refresher re-mints within the bound
+    /// and the in-flight tool call proceeds normally.
+    #[tokio::test]
+    async fn await_remint_returns_jwt_once_it_appears() {
+        let calls = std::cell::Cell::new(0u32);
+        let out = await_remint_with(
+            || {
+                calls.set(calls.get() + 1);
+                let n = calls.get();
+                async move {
+                    if n >= 3 {
+                        Some("h.payload.s".to_string())
+                    } else {
+                        None
+                    }
+                }
+            },
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+        assert_eq!(out.as_deref(), Some("h.payload.s"));
+        assert_eq!(calls.get(), 3, "returns on the first usable read, no more");
     }
 
     /// `AGENT_TOKENS` register / lookup / remove round-trip.

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -33,11 +33,21 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use tauri::Emitter;
 use tokio::sync::{watch, Mutex};
 use tracing::{info, warn};
 
 use crate::mcp::types::ApiState;
 use crate::settings::{self, RunnerTier};
+
+/// Frontend event fired when the runner goes credential-dark on a HARD Cognito
+/// refresh failure (the refresh token is expired/revoked — no headless
+/// recovery). Carries `{ dark: bool, message: String }`: `dark:true` on the
+/// dark transition (the operator must sign in again to resume autonomy),
+/// `dark:false` when a later refresh succeeds and autonomy resumes. The UI can
+/// surface this as a banner/toast; fired once per transition (deduped via
+/// [`RefreshBackoff::dark_notified`]).
+pub const AUTONOMY_CREDENTIAL_DARK_EVENT: &str = "autonomy-credential-dark";
 
 /// Outcome of a single refresh attempt. Tests assert on this variant
 /// directly; the runtime loop in [`refresher_loop`] consumes it via
@@ -72,6 +82,145 @@ pub(crate) enum RefreshOutcome {
 /// How often the loop wakes to check whether the JWT is approaching
 /// expiry. 5 minutes is plenty given the refresh threshold is 80 min.
 const REFRESH_CHECK_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Floor of the transient-failure backoff. When a Cognito refresh fails
+/// transiently (network/5xx/429) we retry far sooner than the 5m steady
+/// cadence so parked autonomy self-recovers within seconds of connectivity
+/// returning — not up to 5 minutes later.
+const TRANSIENT_BACKOFF_MIN: Duration = Duration::from_secs(15);
+
+/// Ceiling of the transient-failure backoff. Kept well under
+/// [`REFRESH_CHECK_INTERVAL`] so even a long outage retries every 2 min (fast
+/// recovery) without hot-looping on a persistent error.
+const TRANSIENT_BACKOFF_MAX: Duration = Duration::from_secs(120);
+
+/// Classification of a Cognito-bearer refresh attempt, used to drive the loop's
+/// backoff + credential-dark notification. Produced by [`refresh_cognito_bearer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RefreshClass {
+    /// No refresh was needed, or the refresh succeeded — healthy.
+    Ok,
+    /// Refresh failed transiently (network, timeout, 5xx, 429) OR with an
+    /// unclassified error. Retry promptly with capped-exponential backoff;
+    /// autonomy self-recovers once connectivity returns.
+    Transient,
+    /// Refresh failed because the refresh token is expired/revoked
+    /// (`invalid_grant`). No headless recovery — fire the credential-dark
+    /// notification and fall to the steady cadence (don't hot-retry a grant
+    /// that will keep failing identically).
+    Hard,
+    /// No Cognito session at all (no refresh token stored) — legacy/local-login
+    /// install or a full sign-out. Not a Cognito-refresh episode; the caller
+    /// falls back to the device-JWT slot bearer.
+    NoSession,
+}
+
+/// Carried across loop iterations so the backoff can grow then reset and the
+/// credential-dark notification fires exactly once per dark transition.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct RefreshBackoff {
+    /// Consecutive transient failures so far — drives the exponential growth.
+    consecutive_transient: u32,
+    /// True once we've emitted the credential-dark notification for the current
+    /// dark episode. Reset on recovery so we notify once per transition, not
+    /// every 5m tick.
+    dark_notified: bool,
+}
+
+/// What the loop should do after a Cognito-bearer attempt this tick: how long
+/// to wait, and which (if any) notification to emit. Pure output of
+/// [`plan_refresh_wait`] so the decision is unit-testable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RefreshLoopAction {
+    pub wait: Duration,
+    /// Emit the credential-dark notification this tick (deduped to once per
+    /// dark transition).
+    pub notify_dark: bool,
+    /// Emit the autonomy-resumed notification this tick (fired once, when a
+    /// previously-dark runner recovers).
+    pub notify_recovered: bool,
+}
+
+/// Capped exponential backoff for transient failures: 15s, 30s, 60s, 120s, then
+/// pinned at the 120s ceiling. `consecutive` is the count of prior consecutive
+/// transient failures (0 on the first failure).
+fn transient_backoff(consecutive: u32) -> Duration {
+    let min = TRANSIENT_BACKOFF_MIN.as_secs();
+    let max = TRANSIENT_BACKOFF_MAX.as_secs();
+    // min * 2^consecutive, saturating, clamped to [min, max].
+    let scaled = min.saturating_mul(1u64 << consecutive.min(20));
+    Duration::from_secs(scaled.clamp(min, max))
+}
+
+/// Pure transition: fold this tick's [`RefreshClass`] into the backoff state and
+/// decide the wait duration + which notification to fire. Mutates `state` so the
+/// loop carries the backoff + dark-dedup across iterations.
+///
+/// - `Transient` → shortened [`transient_backoff`] that grows each consecutive
+///   failure; the counter resets on any non-transient outcome.
+/// - `Hard` → steady [`REFRESH_CHECK_INTERVAL`] + the credential-dark
+///   notification (once per dark transition).
+/// - `Ok` → steady cadence; if we were dark, emit the recovered notification.
+/// - `NoSession` → steady cadence; not a Cognito-refresh episode (no dark/
+///   recovered signal — a full sign-out shouldn't claim "resumed").
+pub(crate) fn plan_refresh_wait(
+    state: &mut RefreshBackoff,
+    class: RefreshClass,
+) -> RefreshLoopAction {
+    match class {
+        RefreshClass::Transient => {
+            let wait = transient_backoff(state.consecutive_transient);
+            state.consecutive_transient = state.consecutive_transient.saturating_add(1);
+            RefreshLoopAction {
+                wait,
+                notify_dark: false,
+                notify_recovered: false,
+            }
+        }
+        RefreshClass::Hard => {
+            state.consecutive_transient = 0;
+            let first = !state.dark_notified;
+            state.dark_notified = true;
+            RefreshLoopAction {
+                wait: REFRESH_CHECK_INTERVAL,
+                notify_dark: first,
+                notify_recovered: false,
+            }
+        }
+        RefreshClass::Ok => {
+            let was_dark = state.dark_notified;
+            state.consecutive_transient = 0;
+            state.dark_notified = false;
+            RefreshLoopAction {
+                wait: REFRESH_CHECK_INTERVAL,
+                notify_dark: false,
+                notify_recovered: was_dark,
+            }
+        }
+        RefreshClass::NoSession => {
+            state.consecutive_transient = 0;
+            RefreshLoopAction {
+                wait: REFRESH_CHECK_INTERVAL,
+                notify_dark: false,
+                notify_recovered: false,
+            }
+        }
+    }
+}
+
+/// Emit the credential-dark / recovered notification to the frontend. Best-
+/// effort: an emit failure only `warn!`s — telemetry must never break the loop.
+fn emit_credential_dark(app: &tauri::AppHandle, dark: bool) {
+    let message = if dark {
+        "Autonomous sessions paused — sign in again to resume."
+    } else {
+        "Autonomous sessions resumed — credentials refreshed."
+    };
+    let payload = serde_json::json!({ "dark": dark, "message": message });
+    if let Err(e) = app.emit(AUTONOMY_CREDENTIAL_DARK_EVENT, &payload) {
+        warn!("device_jwt_refresher: failed to emit {AUTONOMY_CREDENTIAL_DARK_EVENT}: {e}");
+    }
+}
 
 /// What action the loop should take this iteration. Factored out of
 /// [`refresher_loop`] so unit tests can exercise the branching without
@@ -579,11 +728,35 @@ pub(crate) async fn try_refresh_once(
 pub(crate) async fn ensure_fresh_cognito_bearer(
     auth_manager: &crate::auth::AuthManager,
 ) -> Option<String> {
+    refresh_cognito_bearer(auth_manager).await.0
+}
+
+/// The classifying core behind [`ensure_fresh_cognito_bearer`]. Returns the
+/// bearer to present (same value the wrapper yields) AND a [`RefreshClass`] the
+/// refresher loop uses to drive backoff + the credential-dark notification.
+///
+/// Phase 2: a failed Cognito refresh is no longer an opaque `warn!`-and-fall-
+/// through. We classify the failure so the loop can:
+///   - retry transient failures (network/5xx/429/unclassified) on a tightened
+///     backoff (autonomy self-recovers fast), and
+///   - treat a dead refresh token (`invalid_grant`) as terminal-headless:
+///     notify the operator instead of silently retrying a grant that will keep
+///     failing.
+///
+/// The bearer-returning contract is identical to the historical
+/// `ensure_fresh_cognito_bearer`: a fresh token on success, the stored
+/// (possibly stale) token on a refresh failure, `None` when there is no Cognito
+/// session — so the REPLACE-not-REVOKE invariant holds (we never clear a stored
+/// token on a transient error; `try_refresh_once` independently preserves the
+/// device JWT).
+pub(crate) async fn refresh_cognito_bearer(
+    auth_manager: &crate::auth::AuthManager,
+) -> (Option<String>, RefreshClass) {
     // No Cognito session → legacy/local-login install; let the caller use its
     // existing bearer source.
     let refresh_token = match auth_manager.get_oauth_refresh_token() {
         Ok(t) if !t.trim().is_empty() => t,
-        _ => return None,
+        _ => return (None, RefreshClass::NoSession),
     };
 
     if auth_manager.cognito_token_needs_refresh() {
@@ -608,30 +781,54 @@ pub(crate) async fn ensure_fresh_cognito_bearer(
                 } else {
                     info!("device_jwt_refresher: Cognito access token refreshed");
                 }
-                return Some(resp.access_token);
+                return (Some(resp.access_token), RefreshClass::Ok);
             }
             Ok(Err(e)) => {
-                warn!(
-                    "device_jwt_refresher: Cognito token refresh failed: {e} — using stored token"
-                );
+                // Classify: a dead refresh token is terminal-headless; anything
+                // else is retryable. We still fall through with the stored
+                // token (REPLACE-not-REVOKE).
+                let class = if e.is_invalid_grant() {
+                    warn!(
+                        "device_jwt_refresher: Cognito refresh token expired/revoked \
+                         (invalid_grant) — autonomy is credential-dark until the operator \
+                         signs in again: {e}"
+                    );
+                    RefreshClass::Hard
+                } else {
+                    warn!(
+                        "device_jwt_refresher: Cognito token refresh failed transiently: {e} \
+                         — using stored token, will retry on backoff"
+                    );
+                    RefreshClass::Transient
+                };
+                return (auth_manager.get_oauth_access_token().ok(), class);
             }
             Err(join_err) => {
+                // A spawn_blocking join failure is an internal/transient fault.
                 warn!("device_jwt_refresher: Cognito refresh task join failed: {join_err}");
+                return (
+                    auth_manager.get_oauth_access_token().ok(),
+                    RefreshClass::Transient,
+                );
             }
         }
     }
 
-    // Fresh enough (or refresh failed) — use whatever access token is stored.
-    auth_manager.get_oauth_access_token().ok()
+    // Fresh enough — use whatever access token is stored.
+    (auth_manager.get_oauth_access_token().ok(), RefreshClass::Ok)
 }
 
 async fn refresher_loop(
-    _api_state: Arc<ApiState>,
+    api_state: Arc<ApiState>,
     mut shutdown_rx: watch::Receiver<bool>,
     mut kick_rx: watch::Receiver<u64>,
 ) {
     let auth_manager = crate::auth::AuthManager::new();
     info!("Device-JWT refresher started (check interval = 5m, threshold = 80m)");
+
+    // Phase 2: carries the transient-failure backoff + the credential-dark
+    // notify-once dedup across iterations.
+    let mut backoff = RefreshBackoff::default();
 
     loop {
         if *shutdown_rx.borrow() {
@@ -699,7 +896,13 @@ async fn refresher_loop(
                 // valid user token). For legacy/local-login installs there's
                 // no Cognito session, so we fall back to the device-JWT slot
                 // bearer (the historical Phase-2 source).
-                let bearer_token = match ensure_fresh_cognito_bearer(&auth_manager).await {
+                // Phase 2: classify the Cognito refresh so we can back off on a
+                // transient blip and fire the credential-dark notification on a
+                // dead refresh token (`invalid_grant`) instead of silently
+                // stalling. `refresh_class` drives the wait + notification at
+                // each exit below.
+                let (cognito_bearer, refresh_class) = refresh_cognito_bearer(&auth_manager).await;
+                let bearer_token = match cognito_bearer {
                     Some(t) if !t.trim().is_empty() => t.trim().to_string(),
                     _ => match auth_manager.get_access_token() {
                         Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
@@ -717,12 +920,16 @@ async fn refresher_loop(
                                 ),
                             )
                             .await;
-                            if wait_with_signals(
-                                REFRESH_CHECK_INTERVAL,
-                                &mut shutdown_rx,
-                                &mut kick_rx,
-                            )
-                            .await
+                            // Phase 2: if the refresh token is dead
+                            // (`invalid_grant`) and we also have no device-JWT
+                            // bearer, fire the credential-dark notification +
+                            // back off per classification; otherwise (no session)
+                            // fall to the steady cadence.
+                            let action = plan_refresh_wait(&mut backoff, refresh_class);
+                            if action.notify_dark {
+                                emit_credential_dark(&api_state.app_handle, true);
+                            }
+                            if wait_with_signals(action.wait, &mut shutdown_rx, &mut kick_rx).await
                             {
                                 return;
                             }
@@ -849,9 +1056,19 @@ async fn refresher_loop(
                 )
                 .await;
 
-                // Brief sleep before next iteration (success or failure)
-                // so we don't hammer coord on persistent errors.
-                if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx).await {
+                // Phase 2: drive the wait + credential-dark notification off the
+                // Cognito-refresh classification. Transient → shortened backoff
+                // (autonomy self-recovers fast once connectivity returns); Hard
+                // (`invalid_grant`) → steady cadence + notify-once; Ok → steady
+                // cadence, emitting "resumed" if we were previously dark.
+                let action = plan_refresh_wait(&mut backoff, refresh_class);
+                if action.notify_dark {
+                    emit_credential_dark(&api_state.app_handle, true);
+                }
+                if action.notify_recovered {
+                    emit_credential_dark(&api_state.app_handle, false);
+                }
+                if wait_with_signals(action.wait, &mut shutdown_rx, &mut kick_rx).await {
                     return;
                 }
                 continue;
@@ -1120,6 +1337,120 @@ mod tests {
         // Pin the constant so a future refactor that "tunes" it has to
         // update this test (and explain why in review).
         assert_eq!(REFRESH_CHECK_INTERVAL, Duration::from_secs(300));
+    }
+
+    // ---- Phase 2: transient backoff + credential-dark notify decision ----
+
+    #[test]
+    fn transient_backoff_is_capped_exponential() {
+        // 15s, 30s, 60s, 120s, then pinned at the 120s ceiling.
+        assert_eq!(transient_backoff(0), Duration::from_secs(15));
+        assert_eq!(transient_backoff(1), Duration::from_secs(30));
+        assert_eq!(transient_backoff(2), Duration::from_secs(60));
+        assert_eq!(transient_backoff(3), Duration::from_secs(120));
+        assert_eq!(transient_backoff(4), Duration::from_secs(120));
+        // Never panics / overflows for a large failure count, stays at ceiling.
+        assert_eq!(transient_backoff(1000), Duration::from_secs(120));
+        // And the ceiling is well under the steady cadence (fast recovery).
+        assert!(TRANSIENT_BACKOFF_MAX < REFRESH_CHECK_INTERVAL);
+    }
+
+    #[test]
+    fn transient_grows_then_resets_on_success() {
+        let mut s = RefreshBackoff::default();
+        // Each consecutive transient failure grows the wait...
+        let a0 = plan_refresh_wait(&mut s, RefreshClass::Transient);
+        assert_eq!(a0.wait, Duration::from_secs(15));
+        assert!(
+            !a0.notify_dark && !a0.notify_recovered,
+            "transient never notifies"
+        );
+        let a1 = plan_refresh_wait(&mut s, RefreshClass::Transient);
+        assert_eq!(a1.wait, Duration::from_secs(30));
+        let a2 = plan_refresh_wait(&mut s, RefreshClass::Transient);
+        assert_eq!(a2.wait, Duration::from_secs(60));
+        // ...then a success resets to the steady cadence AND the counter.
+        let ok = plan_refresh_wait(&mut s, RefreshClass::Ok);
+        assert_eq!(ok.wait, REFRESH_CHECK_INTERVAL);
+        assert!(
+            !ok.notify_recovered,
+            "Ok with no prior dark episode emits nothing"
+        );
+        // The next transient starts again from the floor (counter reset).
+        let again = plan_refresh_wait(&mut s, RefreshClass::Transient);
+        assert_eq!(again.wait, Duration::from_secs(15));
+    }
+
+    #[test]
+    fn hard_failure_uses_steady_wait_and_notifies_once() {
+        let mut s = RefreshBackoff::default();
+        // First hard failure → steady cadence + the dark notification.
+        let first = plan_refresh_wait(&mut s, RefreshClass::Hard);
+        assert_eq!(
+            first.wait, REFRESH_CHECK_INTERVAL,
+            "hard must NOT hot-retry"
+        );
+        assert!(
+            first.notify_dark,
+            "first dark transition fires the notification"
+        );
+        assert!(!first.notify_recovered);
+        // Subsequent hard ticks must NOT re-notify (deduped per dark episode).
+        let second = plan_refresh_wait(&mut s, RefreshClass::Hard);
+        assert!(
+            !second.notify_dark,
+            "credential-dark notify is once per transition"
+        );
+        assert_eq!(second.wait, REFRESH_CHECK_INTERVAL);
+    }
+
+    #[test]
+    fn recovery_after_dark_emits_recovered_once() {
+        let mut s = RefreshBackoff::default();
+        let _ = plan_refresh_wait(&mut s, RefreshClass::Hard); // go dark
+                                                               // A later success emits the recovered notification exactly once.
+        let recovered = plan_refresh_wait(&mut s, RefreshClass::Ok);
+        assert!(
+            recovered.notify_recovered,
+            "recovery from dark emits resumed"
+        );
+        assert!(!recovered.notify_dark);
+        // A second consecutive Ok no longer re-emits recovered.
+        let steady = plan_refresh_wait(&mut s, RefreshClass::Ok);
+        assert!(
+            !steady.notify_recovered,
+            "recovered fires once per transition"
+        );
+        // And a fresh hard transition can fire dark again (state was cleared).
+        let dark_again = plan_refresh_wait(&mut s, RefreshClass::Hard);
+        assert!(dark_again.notify_dark);
+    }
+
+    #[test]
+    fn no_session_is_steady_and_silent() {
+        // A full sign-out / legacy install must not claim "resumed" and must
+        // not fast-retry — there's no Cognito session to refresh.
+        let mut s = RefreshBackoff::default();
+        let _ = plan_refresh_wait(&mut s, RefreshClass::Hard); // was dark
+        let ns = plan_refresh_wait(&mut s, RefreshClass::NoSession);
+        assert_eq!(ns.wait, REFRESH_CHECK_INTERVAL);
+        assert!(
+            !ns.notify_dark && !ns.notify_recovered,
+            "no-session is silent"
+        );
+    }
+
+    #[test]
+    fn transient_after_dark_does_not_emit_recovered() {
+        // A transient blip while dark must NOT prematurely signal "resumed"
+        // (we only recovered once a refresh actually succeeds → Ok).
+        let mut s = RefreshBackoff::default();
+        let _ = plan_refresh_wait(&mut s, RefreshClass::Hard);
+        let t = plan_refresh_wait(&mut s, RefreshClass::Transient);
+        assert!(!t.notify_recovered && !t.notify_dark);
+        // Still dark → a subsequent success emits recovered.
+        let ok = plan_refresh_wait(&mut s, RefreshClass::Ok);
+        assert!(ok.notify_recovered);
     }
 }
 

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -478,10 +478,47 @@ async fn coord_mcp_proxy_handler(
     //    too. An absent slot (torn-down / restarted agent) is a hard 401.
     let bearer = match &principal {
         crate::coord_mcp::ProxyPrincipal::Device => {
-            tokio::task::spawn_blocking(|| crate::auth::AuthManager::new().get_access_token().ok())
-                .await
-                .ok()
-                .flatten()
+            // Read the live device JWT (filesystem I/O → off the async executor),
+            // the same fresh token `backend_relay` reads.
+            let mut tok = tokio::task::spawn_blocking(|| {
+                crate::auth::AuthManager::new().get_access_token().ok()
+            })
+            .await
+            .ok()
+            .flatten();
+            // Phase 3 (terminal-autonomy-survives-logout): a momentarily-missing
+            // device JWT is almost always the refresher's re-mint window or a
+            // transient-backoff gap (Phases 1-2) — NOT a dead session. Kick the
+            // refresher and wait a tightly-bounded time for a re-mint before
+            // degrading, so an in-flight tool call the AI makes mid-turn rides
+            // through the gap instead of erroring on a bare 401.
+            if tok.as_deref().map(str::trim).unwrap_or("").is_empty() {
+                tok = crate::coord_mcp::await_device_jwt_remint().await;
+            }
+            match tok {
+                Some(t) if !t.trim().is_empty() => Some(t),
+                _ => {
+                    // STILL no JWT after the bounded wait: degrade to an
+                    // actionable, retry-shaped error (NOT the bare 401, NOT a
+                    // hang) so the autonomous caller knows to retry shortly.
+                    let (status, msg) = crate::coord_mcp::device_jwt_refreshing_error();
+                    warn!(
+                        "coord-mcp proxy: device JWT still missing after bounded \
+                         re-mint wait — degrading to retry ({status})"
+                    );
+                    return (
+                        axum::http::StatusCode::from_u16(status)
+                            .unwrap_or(axum::http::StatusCode::SERVICE_UNAVAILABLE),
+                        Json(serde_json::json!({
+                            "success": false,
+                            "error": msg,
+                            "code": "COORD_MCP_PROXY_CREDENTIAL_REFRESHING",
+                            "retryable": true,
+                        })),
+                    )
+                        .into_response();
+                }
+            }
         }
         crate::coord_mcp::ProxyPrincipal::Agent { agent_id } => {
             match crate::coord_mcp::lookup_agent_token(*agent_id) {

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -263,6 +263,13 @@ impl SecureStorage {
     /// Clears all tokens from storage (device-JWT slot AND the Cognito
     /// user-token slots). `device_id` is preserved — it is a stable local
     /// identifier, not a credential.
+    ///
+    /// This is the FULL wipe — it destroys `oauth_refresh_token`, the only
+    /// credential the device-JWT refresher can self-recover from. After this
+    /// call the runner's autonomous terminal sessions can no longer re-mint a
+    /// device JWT and will park until an interactive re-login. Use
+    /// [`Self::clear_interactive_session`] for a default logout that should
+    /// keep autonomy alive.
     pub fn clear_tokens(&self) -> Result<()> {
         let mut tokens = self.load_tokens().unwrap_or_default();
         tokens.access_token = None;
@@ -273,6 +280,28 @@ impl SecureStorage {
         tokens.oauth_expires_at = None;
         self.save_tokens(&tokens)?;
         info!("Tokens cleared from secure file storage");
+        Ok(())
+    }
+
+    /// Clears ONLY the device-JWT pair (`access_token` / `refresh_token`),
+    /// PRESERVING the four Cognito (`oauth_*`) slots and `device_id`.
+    ///
+    /// This is the autonomy-preserving clear used by a default logout: the
+    /// device JWT is dropped, but the long-lived `oauth_refresh_token` (and the
+    /// rest of the Cognito session) is left intact so the supervised device-JWT
+    /// refresher can immediately re-mint a fresh device JWT and keep the
+    /// runner's autonomous terminal sessions running. Contrast with
+    /// [`Self::clear_tokens`], which wipes everything.
+    pub fn clear_interactive_session(&self) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens.access_token = None;
+        tokens.refresh_token = None;
+        // oauth_* slots and device_id are intentionally preserved.
+        self.save_tokens(&tokens)?;
+        info!(
+            "Device-JWT pair cleared from secure file storage (Cognito session preserved for \
+             autonomous refresh)"
+        );
         Ok(())
     }
 
@@ -515,6 +544,53 @@ mod tests {
         storage.clear_oauth_tokens().unwrap();
         assert!(storage.get_oauth_access_token().is_err());
         assert_eq!(storage.get_access_token().unwrap(), "device.jwt.here");
+    }
+
+    /// `clear_interactive_session` drops ONLY the device-JWT pair and PRESERVES
+    /// the Cognito session (`oauth_refresh_token` et al.) so the refresher can
+    /// re-mint autonomously, whereas the full `clear_tokens` wipe destroys the
+    /// `oauth_refresh_token` too. This is the core Phase-1 invariant.
+    #[test]
+    fn test_interactive_clear_preserves_oauth_full_clear_wipes() {
+        let storage = create_test_storage("test_interactive_vs_full_clear");
+
+        // Seed both the device-JWT pair and a Cognito session.
+        storage
+            .store_tokens("device.jwt", "device.refresh")
+            .unwrap();
+        storage
+            .store_oauth_tokens("cog.access", "cog.id", "cog.refresh", 1_700_000_000)
+            .unwrap();
+
+        // Interactive clear: device JWT gone, Cognito session intact.
+        storage.clear_interactive_session().unwrap();
+        assert!(
+            storage.get_access_token().is_err(),
+            "interactive clear must drop the device JWT"
+        );
+        assert!(
+            storage.get_refresh_token().is_err(),
+            "interactive clear must drop the device refresh token"
+        );
+        assert_eq!(
+            storage.get_oauth_refresh_token().unwrap(),
+            "cog.refresh",
+            "interactive clear MUST preserve oauth_refresh_token (the autonomy credential)"
+        );
+        assert_eq!(storage.get_oauth_access_token().unwrap(), "cog.access");
+        assert_eq!(storage.get_oauth_expires_at(), Some(1_700_000_000));
+
+        // Re-seed and prove the full wipe destroys the Cognito session too.
+        storage
+            .store_oauth_tokens("cog.access2", "cog.id2", "cog.refresh2", 1_700_000_001)
+            .unwrap();
+        storage.clear_tokens().unwrap();
+        assert!(
+            storage.get_oauth_refresh_token().is_err(),
+            "full clear_tokens MUST wipe oauth_refresh_token"
+        );
+        assert!(storage.get_oauth_access_token().is_err());
+        assert_eq!(storage.get_oauth_expires_at(), None);
     }
 
     /// A pre-Phase-5 `StoredTokens` JSON (only the original three keys) must

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -137,6 +137,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   /**
    * Logout and clear local auth state.
+   *
+   * This is the DEFAULT logout: the Rust `logout` command clears only the
+   * interactive device-JWT session and PRESERVES the Cognito session, so the
+   * runner's autonomous terminal AI sessions keep running (the device JWT is
+   * re-minted in the background). Use {@link signOutFull} to fully sign out and
+   * stop autonomous sessions.
    */
   const logout = useCallback(async () => {
     try {
@@ -150,6 +156,38 @@ export function AuthProvider({ children }: AuthProviderProps) {
       });
     } catch (err) {
       log.error("Logout failed:", err);
+      setError(err as string);
+      // Clear local state even if backend call fails
+      setAuthStatus({
+        authenticated: false,
+        user: null,
+        device_info: null,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * Full sign-out that STOPS autonomous terminal sessions.
+   *
+   * The Rust `sign_out_full` command clears ALL credentials (device JWT AND the
+   * Cognito session, including the long-lived refresh token), so the
+   * device-JWT refresher can no longer self-recover and the background daemons
+   * stop driving autonomous sessions until an interactive re-login.
+   */
+  const signOutFull = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      await invoke("sign_out_full");
+      setAuthStatus({
+        authenticated: false,
+        user: null,
+        device_info: null,
+      });
+    } catch (err) {
+      log.error("Full sign-out failed:", err);
       setError(err as string);
       // Clear local state even if backend call fails
       setAuthStatus({
@@ -274,6 +312,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     devAutoLoginPending: false,
     tier,
     logout,
+    signOutFull,
     refreshAuth,
   };
 

--- a/src/components/WebIntegrationAuthBanner.tsx
+++ b/src/components/WebIntegrationAuthBanner.tsx
@@ -111,6 +111,17 @@ export function WebIntegrationAuthBanner() {
   const [reKicking, setReKicking] = useState(false);
   const [reKickError, setReKickError] = useState<string | null>(null);
 
+  // Phase 2 (terminal-autonomy-survives-logout): credential-dark signal. The
+  // device-JWT refresher emits `autonomy-credential-dark` with
+  // `{ dark, message }` when a HARD Cognito refresh failure (expired/revoked
+  // refresh token — no headless recovery) parks the coord-dependent autonomy
+  // driver, and again with `dark:false` when a later refresh succeeds. We hold
+  // the latest signal and surface a distinct, top-precedence banner so the
+  // operator knows autonomy needs a re-auth instead of silently stalling.
+  const [credentialDark, setCredentialDark] = useState<{ dark: boolean; message: string } | null>(
+    null,
+  );
+
   const { ref: rootRef } = useUIElement({
     id: "web-integration-banner",
     label: "Web integration authorization banner",
@@ -200,6 +211,28 @@ export function WebIntegrationAuthBanner() {
     };
   }, []);
 
+  // Phase 2 (terminal-autonomy-survives-logout): subscribe to the refresher's
+  // `autonomy-credential-dark` event. `dark:true` reveals the credential-dark
+  // banner; `dark:false` (autonomy resumed) clears it. setState is only called
+  // inside the event callback, satisfying react-hooks/set-state-in-effect.
+  useEffect(() => {
+    let cancelled = false;
+    const unlisten = listen<{ dark: boolean; message: string }>(
+      "autonomy-credential-dark",
+      (event) => {
+        if (!cancelled) setCredentialDark(event.payload);
+      },
+    );
+    return () => {
+      cancelled = true;
+      unlisten
+        .then((fn) => fn())
+        .catch(() => {
+          /* listener cleanup is best-effort */
+        });
+    };
+  }, []);
+
   // Phase 4 — record the first-detected-at timestamp when the migration
   // state first qualifies, and schedule a one-shot re-render at
   // detectedAt + RE_PAIR_CTA_GRACE_MS so the CTA reveal isn't gated on
@@ -275,6 +308,76 @@ export function WebIntegrationAuthBanner() {
   }, [status, deviceJwtPresent]);
 
   if (tier !== "qontinui_account") return null;
+
+  // Phase 2 (terminal-autonomy-survives-logout): credential-dark banner takes
+  // TOP precedence — when the refresher reports a dead Cognito refresh token,
+  // the coord-dependent autonomy driver is parked and only an interactive
+  // re-login fixes it. The "Sign in" CTA reuses the canonical Cognito flow.
+  if (credentialDark?.dark) {
+    return (
+      <div
+        ref={rootRef}
+        role="alert"
+        aria-live="assertive"
+        style={{
+          position: "fixed",
+          top: 16,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 9999,
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "10px 14px",
+          background: "var(--bg-tertiary, #242837)",
+          color: "var(--text-primary, #e4e4e7)",
+          border: "1px solid hsl(var(--destructive, 0 84% 60%))",
+          borderRadius: 8,
+          boxShadow: "0 4px 16px rgba(0, 0, 0, 0.35)",
+          fontSize: "0.875rem",
+          maxWidth: "min(640px, calc(100vw - 32px))",
+        }}
+      >
+        <AlertCircle
+          className="w-4 h-4 shrink-0"
+          style={{ color: "hsl(var(--destructive, 0 84% 60%))" }}
+          aria-hidden="true"
+        />
+        <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
+          <div style={{ fontWeight: 600 }}>Autonomous sessions paused</div>
+          <div style={{ fontSize: "0.8125rem", opacity: 0.85 }}>
+            {credentialDark.message || "Sign in again to resume autonomous sessions."}
+            {authorizeError ? (
+              <>
+                <br />
+                <span style={{ color: "hsl(var(--destructive, 0 84% 60%))" }}>{authorizeError}</span>
+              </>
+            ) : null}
+          </div>
+        </div>
+        <button
+          ref={authorizeButtonRef}
+          type="button"
+          onClick={handleAuthorize}
+          disabled={authorizing}
+          style={{
+            background: "var(--accent, #6366f1)",
+            color: "#fff",
+            border: "none",
+            borderRadius: 4,
+            padding: "4px 10px",
+            fontSize: "0.8125rem",
+            fontWeight: 600,
+            cursor: authorizing ? "wait" : "pointer",
+            opacity: authorizing ? 0.7 : 1,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {authorizing ? "Opening…" : "Sign in"}
+        </button>
+      </div>
+    );
+  }
 
   // Phase 4 (unified-devices migration): re-pair CTA takes precedence over
   // the "needs first pair" banner. When this runner WAS paired pre-upgrade

--- a/src/components/settings/AccountSettings.tsx
+++ b/src/components/settings/AccountSettings.tsx
@@ -61,7 +61,7 @@ interface DoctorReport {
 
 export function AccountSettings({ onLog }: AccountSettingsProps) {
   const { tier, loading: tierLoading, refresh: refreshTier } = useRunnerTier();
-  const { authStatus, logout: clearAuthState } = useAuth();
+  const { authStatus, signOutFull } = useAuth();
   const [flowError, setFlowError] = useState<string | null>(null);
   const [signingOut, setSigningOut] = useState(false);
 
@@ -163,12 +163,16 @@ export function AccountSettings({ onLog }: AccountSettingsProps) {
       window.dispatchEvent(new CustomEvent("runner-tier-changed"));
       await refreshTier();
       // Clear the local JWT-flow auth state immediately so the gate flips
-      // to the LoginScreen without waiting for the re-check round-trip.
+      // to the LoginScreen without waiting for the re-check round-trip. Use
+      // `signOutFull` (not the autonomy-preserving `logout`): this is the
+      // STOP-autonomy path, so it must NOT kick the device-JWT refresher.
+      // `sign_out_full` is an idempotent full wipe — the credentials were
+      // already cleared by `qontinui_sign_out` above, so this only flips state.
       try {
-        await clearAuthState();
+        await signOutFull();
       } catch {
-        // clearAuthState invokes the `logout` command, which may error now
-        // that the token is already cleared; that's expected and harmless.
+        // signOutFull re-invokes the full-wipe command, which may error now
+        // that the credentials are already cleared; that's expected and harmless.
       }
       onLog("info", "Signed out — sign in again on the login screen");
     } catch (err) {
@@ -178,7 +182,7 @@ export function AccountSettings({ onLog }: AccountSettingsProps) {
     } finally {
       setSigningOut(false);
     }
-  }, [onLog, refreshTier, clearAuthState]);
+  }, [onLog, refreshTier, signOutFull]);
 
   if (tierLoading) {
     return (
@@ -347,11 +351,18 @@ function SignedInPanel({ email, userId, name, signingOut, onSignOut }: SignedInP
         className="inline-flex items-center gap-2 rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       >
         {signingOut ? <Loader2 className="w-4 h-4 animate-spin" /> : <LogOut className="w-4 h-4" />}
-        Sign out
+        Sign out &amp; stop autonomous sessions
       </button>
       <p className="text-xs text-muted-foreground">
-        Signing out clears the runner token and returns you to the sign-in screen, where you can sign
-        in again or switch accounts.
+        This fully signs out: it clears your account session and returns you to the sign-in screen,
+        where you can sign in again or switch accounts. It also <strong>stops this runner&apos;s
+        autonomous terminal sessions</strong> — they cannot keep running without your account
+        session.
+      </p>
+      <p className="text-xs text-muted-foreground">
+        To stop using the app while keeping autonomous terminal sessions running, just close this
+        window instead of signing out — the runner keeps refreshing its device credential in the
+        background.
       </p>
     </div>
   );

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -47,7 +47,18 @@ export interface AuthContextValue {
    * local-guest auth.
    */
   tier: RunnerTier;
+  /**
+   * Default logout — clears only the interactive device-JWT session and keeps
+   * the Cognito session, so the runner's autonomous terminal sessions keep
+   * running (the device JWT is re-minted in the background).
+   */
   logout: () => Promise<void>;
+  /**
+   * Full sign-out that STOPS autonomous terminal sessions — clears ALL
+   * credentials (device JWT + the Cognito session). The runner cannot
+   * self-recover its device JWT until an interactive re-login.
+   */
+  signOutFull: () => Promise<void>;
   /** Re-validate the current auth status (no token-refresh side effect). */
   refreshAuth: () => Promise<void>;
 }


### PR DESCRIPTION
## Problem
The runner was logged out overnight and its running **terminal AI sessions paused** until re-login. Root cause: the autonomous driver (session_message_poller, coord-mcp proxy, backend_relay) all depend on the **device JWT**, which is re-minted *only* from the Cognito session — and `logout`/`clear_tokens` wiped the Cognito **refresh token**, the one credential the refresher could self-recover from. (The AI's model reasoning was never affected — it uses the operator's own Claude subscription via `CLAUDE_CONFIG_DIR`; only the coord-dependent driver was coupled to login.)

## Changes
**Phase 1 — credential split** (`auth.rs`, `secure_storage.rs`, `commands/auth.rs`, FE)
- `clear_interactive_session()` drops only the device-JWT pair and **preserves** the Cognito `oauth_*` session; `clear_tokens()` stays the full wipe (renamed `clear_all_credentials()` in `auth.rs`).
- Default `logout` now interactive-clears + kicks the refresher (immediate re-mint, no autonomy gap); new `sign_out_full` command does the full wipe. Account-switch `qontinui_sign_out` stays a full wipe (required for the LoginScreen gate). Account Settings relabeled + honest copy ("close the window to keep autonomous sessions running").

**Phase 2 — refresher hardening** (`cognito.rs`, `device_jwt_refresher.rs`, FE banner)
- Classify Cognito refresh failures (`CognitoRefreshError`): `invalid_grant`→Hard, 5xx/429/network→Transient. Transient → capped-exponential backoff that self-recovers; Hard → steady cadence + a once-per-transition `autonomy-credential-dark` banner with a Sign-in CTA. REPLACE-not-REVOKE preserved.

**Phase 3 — coord-mcp proxy graceful degrade** (`coord_mcp.rs`, `mcp_api.rs`)
- On a momentarily-missing device JWT, the DEVICE proxy path kicks the refresher and waits a bounded 5s for a re-mint before degrading to an actionable **503 retry** (instead of a bare 401 that fails a mid-turn coord tool call). Nonce/scope fail-closed 401s and the agent-bearer path unchanged. Regression test pins that local terminal-session work is never blocked by missing coord auth.

## Tests
- `cargo check` clean; module tests green: secure_storage 7, auth 39, cognito 15 (+4 new), device_jwt_refresher 29 (+6 new), coord_mcp 18 (+3 new), proxy 25 (+1 new). `cargo fmt`/clippy clean. FE `tsc` clean.
- Temp-runner smoke: Account Settings page family renders cleanly, credential-dark banner correctly absent in the normal state (no false positive). The exact relabeled copy is on this branch + requires an authenticated SignedInPanel, so it's visually confirmable post-merge (the supervisor builds main).

## Deferred (follow-on)
Phase 4 — a login-independent machine credential (reusing the `mk_<token>` enroll pattern), the only defense against the Cognito **refresh token itself** expiring. Out of this PR's runner-only scope.

Plan: `plans/2026-06-28-runner-terminal-autonomy-survives-logout.md`