### PR TITLE
feat: register helper_task types in schema_export (codegen deadlock break)

### DIFF
--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -36,12 +36,12 @@ pub fn export_all_schemas() -> Value {
         accessibility as qa, ai_workflows as qaw, app_events as qae, apps as qap,
         completeness_verdict as qcv, config as qcfg, constraints as qc, discovery as qdc,
         execution as qe, findings as qfn, functional_spec as qfs, geometry as qg, git_ops as qgo,
-        ir as qir, mcp_config as qmc, memory as qmem, orchestration_config as qoc,
-        priorities_profile as qpp, process_management as qpm, rag as qr, runner as qrn,
-        scheduler as qs, spec_api_events as qsae, spec_check as qsc, state_machine as qsm,
-        targets as qt, task_run as qtr, terminal as qtm, ticket_system as qts, tree_events as qte,
-        ui_bridge as qub, verification as qv, worker_output as qwo, workflow as qw,
-        workflow_step as qws,
+        helper_task as qht, ir as qir, mcp_config as qmc, memory as qmem,
+        orchestration_config as qoc, priorities_profile as qpp, process_management as qpm,
+        rag as qr, runner as qrn, scheduler as qs, spec_api_events as qsae, spec_check as qsc,
+        state_machine as qsm, targets as qt, task_run as qtr, terminal as qtm,
+        ticket_system as qts, tree_events as qte, ui_bridge as qub, verification as qv,
+        worker_output as qwo, workflow as qw, workflow_step as qws,
     };
 
     // Built via a plain Map instead of `json!` to avoid the
@@ -804,6 +804,16 @@ pub fn export_all_schemas() -> Value {
     add!("RunnerStatusEvent", re::RunnerStatusEvent);
     add!("RunnerConnectedConnection", re::RunnerConnectedConnection);
 
+    // ── qontinui-types: helper_task (helper-task queue) ──
+    add!("HelperTask", qht::HelperTask);
+    add!("HelperAnswer", qht::HelperAnswer);
+    add!("HelperTaskKind", qht::HelperTaskKind);
+    add!("HelperTaskStatus", qht::HelperTaskStatus);
+    add!("HelperVerdict", qht::HelperVerdict);
+    add!("HelperTaskPayload", qht::HelperTaskPayload);
+    add!("HelperAnswerSchema", qht::HelperAnswerSchema);
+    add!("HelperTaskSource", qht::HelperTaskSource);
+
     Value::Object(m)
 }
 
@@ -839,7 +849,12 @@ mod tests {
             obj.contains_key("SpecApiEvent"),
             "Missing SpecApiEvent schema (Plan 06)"
         );
-        assert_eq!(obj.len(), 523, "Expected 523 schema entries");
+        assert!(obj.contains_key("HelperTask"), "Missing HelperTask schema");
+        assert!(
+            obj.contains_key("HelperAnswer"),
+            "Missing HelperAnswer schema"
+        );
+        assert_eq!(obj.len(), 531, "Expected 531 schema entries");
 
         // Sanity-check that qontinui_types re-exports are present
         assert!(


### PR DESCRIPTION
## What

Registers the 8 helper-task DTOs in `src-tauri/src/schema_export.rs` via `add!()` (+ a `helper_task as qht` alias) so `generate_types.sh` emits their `@qontinui/shared-types` TS + Python bindings: `HelperTask`, `HelperAnswer`, `HelperTaskKind`, `HelperTaskStatus`, `HelperVerdict`, `HelperTaskPayload`, `HelperAnswerSchema`, `HelperTaskSource`.

11-line change; the types already exist in `qontinui_types::helper_task` (qontinui-schemas#94, merged).

## Codegen deadlock break (land this FIRST)

This is the runner half of the one-time coordinated co-landing that breaks the two-sided drift-gate deadlock for adding a new codegen'd type:

- **This PR** registers the types. Its `qontinui-types drift` check goes **red** (schemas main doesn't yet have the regenerated bindings) — but that check is **non-required** on runner main, so this merges on the required checks.
- **qontinui-schemas#95** holds the regenerated bindings. Once this PR is on runner `main`, #95's (required) `check-drift` regenerates against runner@main, matches its committed bindings → **green** → merges.

Unblocks the helper-task runner owner-UI + web portal (Phase 1.3/1.4), which consume the TS `HelperTask` type.

## Verification

The registration compiled cleanly during the `export_schemas` build (used to regenerate #95's bindings). Local pre-commit/pre-push clippy hooks bypassed with `--no-verify` (operator-approved) because they can't build against the sibling schemas checkout in this environment; CI runs clippy authoritatively.