### PR TITLE
feat(runner): markdown proxy defers to real agents on work-unit transitions

### DIFF
--- a/src-tauri/src/plan_workunit_adapter/push.rs
+++ b/src-tauri/src/plan_workunit_adapter/push.rs
@@ -34,6 +34,14 @@ use serde::Serialize;
 /// Actor stamped on adapter-driven upserts/transitions.
 pub const ADAPTER_ACTOR: &str = "harness-markdown-adapter";
 
+/// True when `by_actor` denotes a real (non-proxy) actor that owns the unit —
+/// i.e. anything other than this adapter's own actor (and not empty). Used to
+/// decide whether the markdown proxy should DEFER its transition so it does not
+/// collapse an agent-initiated transition back to the system actor.
+fn is_real_agent_actor(by_actor: &str) -> bool {
+    by_actor != ADAPTER_ACTOR && !by_actor.is_empty()
+}
+
 /// `POST /coord/work-units/upsert` body. Mirrors coord's `UpsertRequest`;
 /// `None` fields are omitted so an upsert that only refreshes title/metadata
 /// does not clobber `status`.
@@ -141,6 +149,10 @@ pub enum SetDepsOutcome {
 pub trait WorkUnitSink: Send + Sync {
     /// Current opaque status of the unit, or `None` if it doesn't exist yet.
     async fn current_status(&self, slug: &str) -> Result<Option<String>>;
+    /// The `by_actor` of the unit's most-recent status-history row, or None if
+    /// the unit has no history. Used to defer when a real (non-proxy) actor owns
+    /// the unit. Reads GET /coord/work-units/<slug>/history (newest-first).
+    async fn last_actor(&self, slug: &str) -> Result<Option<String>>;
     async fn upsert(&self, body: &UpsertBody) -> Result<()>;
     async fn transition(&self, slug: &str, body: &TransitionBody) -> Result<()>;
     /// Replace the complete upstream dependency set of `slug` in coord's
@@ -160,6 +172,33 @@ pub async fn push_work_unit<S: WorkUnitSink + ?Sized>(
     u: &ParsedWorkUnit,
     last_applied: Option<&str>,
 ) -> Result<PushOutcome> {
+    let metadata = build_metadata(u);
+    let action = decide_push(&u.status, last_applied);
+
+    // Deferral (graduation-bootstrap P2a): only a `Transition` would OVERWRITE
+    // an existing unit's status. Before emitting it, read the unit's latest
+    // status-history `by_actor`; if a real (non-adapter) actor last drove the
+    // unit, a real agent owns its lifecycle now — DEFER (skip this cycle's
+    // transition, emit nothing) so we don't collapse the agent's transition back
+    // to the system actor. A brand-new unit (`UpsertWithStatus`) or an idempotent
+    // `RefreshOnly` has no agent owner to defer to, so those are never gated.
+    if let PushAction::Transition { .. } = &action {
+        if let Some(actor) = sink.last_actor(&u.slug).await? {
+            if is_real_agent_actor(&actor) {
+                tracing::info!(
+                    slug = %u.slug,
+                    last_actor = %actor,
+                    "markdown proxy defers: real agent owns this unit"
+                );
+                return Ok(PushOutcome {
+                    slug: u.slug.clone(),
+                    kind: PushOutcomeKind::Refreshed,
+                    conflict: false,
+                });
+            }
+        }
+    }
+
     // Conflict detection: did the remote status diverge from what we last
     // applied? (A direct transition by someone else.) File wins, but loudly.
     let mut conflict = false;
@@ -179,8 +218,6 @@ pub async fn push_work_unit<S: WorkUnitSink + ?Sized>(
         }
     }
 
-    let metadata = build_metadata(u);
-    let action = decide_push(&u.status, last_applied);
     let kind = match &action {
         PushAction::UpsertWithStatus => {
             sink.upsert(&UpsertBody {
@@ -307,6 +344,40 @@ impl WorkUnitSink for HttpWorkUnitSink {
         Ok(None)
     }
 
+    async fn last_actor(&self, slug: &str) -> Result<Option<String>> {
+        // GET /coord/work-units/<slug>/history returns
+        // {"work_unit_id":..,"slug":..,"history":[{..,"by_actor":..,"to_status":..,
+        //  "transitioned_at":..}, ...]} ordered newest-first (coord's SQL
+        // `ORDER BY transitioned_at DESC`). We want the newest row's `by_actor`.
+        let url = format!("{}/coord/work-units/{}/history", self.base, slug);
+        let resp = crate::auth::attach_device_auth(self.client.get(&url))
+            .send()
+            .await
+            .context("GET /coord/work-units/:slug/history")?;
+        // No such unit yet ⇒ no history ⇒ no owner to defer to.
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            anyhow::bail!(
+                "GET /coord/work-units/:slug/history returned {}",
+                resp.status()
+            );
+        }
+        let body: serde_json::Value = resp.json().await.context("parse work-unit history")?;
+        // Newest-first: the first `history` element is the most-recent transition.
+        // `by_actor` is nullable (serialized as JSON null) — `as_str` yields None,
+        // and an empty history array yields None, both meaning "no owner".
+        let by_actor = body
+            .get("history")
+            .and_then(|h| h.as_array())
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("by_actor"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        Ok(by_actor)
+    }
+
     async fn upsert(&self, body: &UpsertBody) -> Result<()> {
         let url = format!("{}/coord/work-units/upsert", self.base);
         let resp = crate::auth::attach_device_auth(self.client.post(&url).json(body))
@@ -422,6 +493,8 @@ mod tests {
     #[derive(Default)]
     struct FakeSink {
         remote: Option<String>,
+        /// Configured `by_actor` of the unit's latest history row (default None).
+        last_actor: Option<String>,
         upserts: Mutex<Vec<UpsertBody>>,
         transitions: Mutex<Vec<(String, TransitionBody)>>,
         deps_calls: Mutex<Vec<(String, Vec<String>)>>,
@@ -431,6 +504,9 @@ mod tests {
     impl WorkUnitSink for FakeSink {
         async fn current_status(&self, _slug: &str) -> Result<Option<String>> {
             Ok(self.remote.clone())
+        }
+        async fn last_actor(&self, _slug: &str) -> Result<Option<String>> {
+            Ok(self.last_actor.clone())
         }
         async fn upsert(&self, body: &UpsertBody) -> Result<()> {
             self.upserts.lock().unwrap().push(body.clone());

--- a/src-tauri/src/plan_workunit_adapter/trigger.rs
+++ b/src-tauri/src/plan_workunit_adapter/trigger.rs
@@ -288,7 +288,7 @@ pub fn spawn_if_configured() -> Option<tokio::task::JoinHandle<()>> {
 #[cfg(test)]
 mod tests {
     use super::super::parser::ParsedWorkUnit;
-    use super::super::push::{SetDepsOutcome, TransitionBody, UpsertBody};
+    use super::super::push::{SetDepsOutcome, TransitionBody, UpsertBody, ADAPTER_ACTOR};
     use super::*;
     use anyhow::Result;
     use std::sync::Mutex;
@@ -322,6 +322,9 @@ mod tests {
     struct FakeSink {
         statuses: Mutex<HashMap<String, String>>,
         transitions: Mutex<u64>,
+        /// Configured `by_actor` of every unit's latest history row (default
+        /// None ⇒ no history ⇒ no owner to defer to).
+        last_actor: Option<String>,
         deps_behavior: DepsBehavior,
         deps_calls: Mutex<Vec<(String, Vec<String>)>>,
     }
@@ -329,6 +332,9 @@ mod tests {
     impl WorkUnitSink for FakeSink {
         async fn current_status(&self, slug: &str) -> Result<Option<String>> {
             Ok(self.statuses.lock().unwrap().get(slug).cloned())
+        }
+        async fn last_actor(&self, _slug: &str) -> Result<Option<String>> {
+            Ok(self.last_actor.clone())
         }
         async fn upsert(&self, body: &UpsertBody) -> Result<()> {
             if let Some(s) = &body.status {
@@ -392,6 +398,88 @@ mod tests {
 
         reconcile_once(&[unit("a", "vetted")], &mut mem, &mut deps, &sink, &metrics).await;
         // Plan edited: vetted -> shipped.
+        let s = reconcile_once(
+            &[unit("a", "shipped")],
+            &mut mem,
+            &mut deps,
+            &sink,
+            &metrics,
+        )
+        .await;
+        assert_eq!(s.transitions, 1);
+        assert_eq!(*sink.transitions.lock().unwrap(), 1);
+        assert_eq!(metrics.snapshot().transitions_total, 1);
+    }
+
+    // --- Graduation-bootstrap P2a: markdown proxy defers to real agents ------
+
+    #[tokio::test]
+    async fn defers_transition_when_real_agent_owns_unit() {
+        // A real agent last drove the unit (its own agent-scoped actor). The
+        // file's status edge (vetted -> shipped) WOULD transition, but the proxy
+        // must DEFER so it doesn't collapse the agent's transition to the system
+        // actor: ZERO transitions emitted.
+        let sink = FakeSink {
+            last_actor: Some("device:d:agent:a".to_string()),
+            ..Default::default()
+        };
+        let metrics = AdapterMetrics::default();
+        let mut mem = HashMap::new();
+        let mut deps = HashMap::new();
+
+        // Establish last-applied=vetted (create; UpsertWithStatus is never gated).
+        reconcile_once(&[unit("a", "vetted")], &mut mem, &mut deps, &sink, &metrics).await;
+        assert_eq!(*sink.transitions.lock().unwrap(), 0);
+
+        // File edited vetted -> shipped: transition WOULD fire, but defer.
+        let s = reconcile_once(
+            &[unit("a", "shipped")],
+            &mut mem,
+            &mut deps,
+            &sink,
+            &metrics,
+        )
+        .await;
+        assert_eq!(s.transitions, 0);
+        assert_eq!(*sink.transitions.lock().unwrap(), 0);
+        assert_eq!(metrics.snapshot().transitions_total, 0);
+    }
+
+    #[tokio::test]
+    async fn proceeds_when_last_actor_is_adapter() {
+        // The adapter itself last drove the unit ⇒ no real agent owns it ⇒ the
+        // proxy proceeds with its transition as normal.
+        let sink = FakeSink {
+            last_actor: Some(ADAPTER_ACTOR.to_string()),
+            ..Default::default()
+        };
+        let metrics = AdapterMetrics::default();
+        let mut mem = HashMap::new();
+        let mut deps = HashMap::new();
+
+        reconcile_once(&[unit("a", "vetted")], &mut mem, &mut deps, &sink, &metrics).await;
+        let s = reconcile_once(
+            &[unit("a", "shipped")],
+            &mut mem,
+            &mut deps,
+            &sink,
+            &metrics,
+        )
+        .await;
+        assert_eq!(s.transitions, 1);
+        assert_eq!(*sink.transitions.lock().unwrap(), 1);
+        assert_eq!(metrics.snapshot().transitions_total, 1);
+    }
+
+    #[tokio::test]
+    async fn proceeds_when_no_history() {
+        // No history (last_actor = None) ⇒ nobody owns the unit ⇒ proceed.
+        let sink = FakeSink::default();
+        let metrics = AdapterMetrics::default();
+        let mut mem = HashMap::new();
+        let mut deps = HashMap::new();
+
+        reconcile_once(&[unit("a", "vetted")], &mut mem, &mut deps, &sink, &metrics).await;
         let s = reconcile_once(
             &[unit("a", "shipped")],
             &mut mem,


### PR DESCRIPTION
## What

The markdown-sync proxy now **defers** its own work-unit transition when a real (non-adapter) agent last drove the unit — **P2a** of `plans/2026-06-30-graduation-bootstrap-workunit-lifecycle-autonomy.md`.

Before emitting a `Transition`, `push_work_unit` reads the unit's latest status-history `by_actor` via `GET /coord/work-units/<slug>/history` (newest-first) and, if that actor is a real agent (`!= "harness-markdown-adapter"` and non-empty), skips the transition this cycle (`Refreshed`, no `transition`/`upsert` call). This stops the proxy from collapsing an agent-initiated lifecycle transition back to the system actor — the prerequisite for the graduation-bootstrap adoption (agents owning `→in_progress` / reviewers attesting `→vetted` under their own identity).

Only `Transition` (an overwrite) is gated; brand-new `UpsertWithStatus` and idempotent `RefreshOnly` are never deferred (a new unit has no agent owner). The read reuses the proxy's existing device-JWT auth (`attach_device_auth`) — same operator sub-router as the shipped `current_status` read; on read error it fails **closed** (emits no transition), which is safe (never overwrites an agent-owned unit).

## Tests

Three new `#[tokio::test]`s on the `FakeSink` harness (34 adapter tests total, all green):
- `defers_transition_when_real_agent_owns_unit` — agent `by_actor` ⇒ 0 transitions emitted.
- `proceeds_when_last_actor_is_adapter` — adapter `by_actor` ⇒ transition emitted.
- `proceeds_when_no_history` — no history ⇒ transition emitted.

## CI note

Pushed with `QONTINUI_PREPUSH_SKIP=1` (the hook's own sanctioned "let CI gate" escape) because the local pre-push clippy can't complete in this environment — a **pre-existing, unrelated** `qontinui-schemas` cross-repo drift breaks the full-crate build on untouched origin/main too (spec-check `evaluator.rs`, `database/pg/apps.rs`). The adapter module has zero dependency on the drifted schemas; its logic + all 34 tests were verified green and clippy-clean on byte-for-byte copies of the real source. CI runs the authoritative fmt/clippy/build.