### PR TITLE
fix(spec-check): adopt qontinui-types 0.7.0 required fields — unbreak runner build/CI

### DIFF
--- a/crates/spec-check/src/confidence.rs
+++ b/crates/spec-check/src/confidence.rs
@@ -139,11 +139,7 @@ pub fn recommend_state(
     // Either zero or multiple initials — narrow the pool then fall through
     // to the lexical tiebreak. If multiple states are flagged initial, we
     // tiebreak among them; otherwise we tiebreak among all ties.
-    let pool: Vec<&StateMatchResult> = if initials.len() > 1 {
-        initials
-    } else {
-        tied
-    };
+    let pool: Vec<&StateMatchResult> = if initials.len() > 1 { initials } else { tied };
 
     // Tiebreak 2: lexically smallest state_id.
     let winner = pool
@@ -181,6 +177,7 @@ mod tests {
             state_id: id.to_string(),
             state_name: id.to_string(),
             match_rate: rate,
+            classification: crate::ThresholdConfig::default().classify_match_rate(rate),
             assertions: vec![],
         }
     }
@@ -256,7 +253,11 @@ mod tests {
         // Repeat to guard against accidental nondeterminism (the plan
         // calls out 100 runs).
         for _ in 0..100 {
-            let states = vec![state("zebra", 0.60), state("alpha", 0.60), state("mango", 0.60)];
+            let states = vec![
+                state("zebra", 0.60),
+                state("alpha", 0.60),
+                state("mango", 0.60),
+            ];
             let rec = recommend_state(&states, |_| false).expect("a winner");
             assert_eq!(rec.state_id, "alpha");
             assert!(rec.reason.contains("state_id ordering"));
@@ -271,8 +272,7 @@ mod tests {
             state("alpha", 0.80),
             state("mango", 0.80),
         ];
-        let rec = recommend_state(&states, |id| id == "zebra" || id == "mango")
-            .expect("a winner");
+        let rec = recommend_state(&states, |id| id == "zebra" || id == "mango").expect("a winner");
         // Both zebra and mango are initial; lex-smallest is mango.
         assert_eq!(rec.state_id, "mango");
     }

--- a/crates/spec-check/src/evaluator.rs
+++ b/crates/spec-check/src/evaluator.rs
@@ -29,7 +29,7 @@ use crate::snapshot::{ElementIdx, IndexedSnapshot};
 use crate::{
     AssertionMiss, AssertionOutcome, AssertionResult, AssertionSeverityCounts, BridgeFingerprint,
     MatchOutcome, MatchedElement, SpecCheckResult, SpecCheckSummary, SpecValidation,
-    StateMatchResult, UIBridgeSnapshot,
+    StateMatchResult, ThresholdConfig, UIBridgeSnapshot,
 };
 
 /// `recommendation_reason` value set when the matcher refuses to recommend
@@ -128,7 +128,14 @@ pub fn evaluate_with_identity(
     snapshot_id: String,
     content_sha256: String,
 ) -> SpecCheckResult {
-    evaluate_with_identity_and_validation(snapshot, spec, fingerprint, snapshot_id, content_sha256, None)
+    evaluate_with_identity_and_validation(
+        snapshot,
+        spec,
+        fingerprint,
+        snapshot_id,
+        content_sha256,
+        None,
+    )
 }
 
 pub fn evaluate_with_identity_and_validation(
@@ -145,8 +152,7 @@ pub fn evaluate_with_identity_and_validation(
     // index computed it from the same snapshot; they must agree. Warn (don't
     // panic) on mismatch in debug builds; release trusts the caller.
     #[cfg(debug_assertions)]
-    if fingerprint.element_count != snapshot.elements.len() as u32
-        && fingerprint.element_count != 0
+    if fingerprint.element_count != snapshot.elements.len() as u32 && fingerprint.element_count != 0
     {
         tracing::warn!(
             "evaluate_with_identity: caller fp.element_count={} disagrees with snapshot.elements.len={}; using caller's value",
@@ -216,6 +222,11 @@ fn evaluate_with_indexed(
     let evaluated_at = now_iso8601();
     let spec_content_hash = hash_spec(spec);
 
+    // No per-app threshold config is threaded into the in-process evaluator,
+    // so classify the overall match rate against the default thresholds.
+    let thresholds_used = ThresholdConfig::default();
+    let classification = thresholds_used.classify_match_rate(summary.overall_match_rate);
+
     SpecCheckResult {
         result_schema_version: RESULT_SCHEMA_VERSION,
         snapshot_id: SENTINEL_SNAPSHOT_ID.to_string(),
@@ -228,6 +239,8 @@ fn evaluate_with_indexed(
         bridge_fingerprint,
         evaluated_at,
         warnings: Vec::new(),
+        classification,
+        thresholds_used,
     }
 }
 
@@ -261,6 +274,7 @@ fn evaluate_state(indexed: &IndexedSnapshot, state: &IrState) -> StateMatchResul
         state_id: state.id.clone(),
         state_name: state.name.clone(),
         match_rate,
+        classification: ThresholdConfig::default().classify_match_rate(match_rate),
         assertions,
     }
 }
@@ -469,8 +483,7 @@ fn build_internal_fingerprint(indexed: &IndexedSnapshot) -> BridgeFingerprint {
 /// a fixed sentinel hash so callers can still observe the result.
 fn hash_spec(spec: &IrPageSpec) -> String {
     match serde_json::to_value(spec) {
-        Ok(value) => compute_content_sha256(&value)
-            .unwrap_or_else(|_| "sha256-".to_string()),
+        Ok(value) => compute_content_sha256(&value).unwrap_or_else(|_| "sha256-".to_string()),
         Err(_) => "sha256-".to_string(),
     }
 }
@@ -578,12 +591,7 @@ mod tests {
         }
     }
 
-    fn assertion(
-        id: &str,
-        severity: &str,
-        crit: serde_json::Value,
-        enabled: bool,
-    ) -> IrAssertion {
+    fn assertion(id: &str, severity: &str, crit: serde_json::Value, enabled: bool) -> IrAssertion {
         IrAssertion {
             id: id.to_string(),
             description: format!("desc-{id}"),
@@ -602,7 +610,12 @@ mod tests {
         }
     }
 
-    fn state(id: &str, name: &str, is_initial: Option<bool>, assertions: Vec<IrAssertion>) -> IrState {
+    fn state(
+        id: &str,
+        name: &str,
+        is_initial: Option<bool>,
+        assertions: Vec<IrAssertion>,
+    ) -> IrState {
         IrState {
             id: id.to_string(),
             name: name.to_string(),
@@ -687,10 +700,13 @@ mod tests {
 
     #[test]
     fn evaluate_no_match_when_nothing_passes() {
-        let s = snap(vec![elem(
-            "e0", "#e0", Some("link"), Some("Cancel"), true,
-        )]);
-        let a = assertion("a1", "critical", json!({ "role": "button", "text": "Save" }), true);
+        let s = snap(vec![elem("e0", "#e0", Some("link"), Some("Cancel"), true)]);
+        let a = assertion(
+            "a1",
+            "critical",
+            json!({ "role": "button", "text": "Save" }),
+            true,
+        );
         let st = state("s1", "Loaded", Some(true), vec![a]);
         let spec = page_spec("page-1", vec![st]);
 
@@ -709,7 +725,12 @@ mod tests {
             elem("ok", "#ok", Some("button"), Some("Save"), true),
             elem("nope", "#nope", Some("link"), Some("Other"), true),
         ]);
-        let a1 = assertion("a1", "critical", json!({ "role": "button", "text": "Save" }), true);
+        let a1 = assertion(
+            "a1",
+            "critical",
+            json!({ "role": "button", "text": "Save" }),
+            true,
+        );
         let a2 = assertion("a2", "error", json!({ "role": "checkbox" }), true);
         let st = state("s1", "Loaded", Some(true), vec![a1, a2]);
         let spec = page_spec("page-1", vec![st]);
@@ -739,9 +760,7 @@ mod tests {
 
     #[test]
     fn evaluate_skips_disabled_assertions() {
-        let s = snap(vec![elem(
-            "ok", "#ok", Some("button"), Some("Save"), true,
-        )]);
+        let s = snap(vec![elem("ok", "#ok", Some("button"), Some("Save"), true)]);
         let a_pass = assertion("pass", "info", json!({ "role": "button" }), true);
         let a_skip = assertion("skip", "critical", json!({ "role": "nope" }), false);
         let st = state("s1", "Loaded", Some(true), vec![a_skip, a_pass]);
@@ -758,9 +777,7 @@ mod tests {
     fn evaluate_preserves_declaration_order_across_reruns() {
         // Plan §Step 4 determinism rule: per-state assertion order in
         // `state_results[*].assertions` matches the IR's authoring order.
-        let s = snap(vec![elem(
-            "ok", "#ok", Some("button"), Some("Save"), true,
-        )]);
+        let s = snap(vec![elem("ok", "#ok", Some("button"), Some("Save"), true)]);
         let a1 = assertion("a1", "info", json!({ "role": "button" }), true);
         let a2 = assertion("a2", "info", json!({ "role": "button" }), true);
         let a3 = assertion("a3", "info", json!({ "role": "button" }), true);
@@ -781,9 +798,7 @@ mod tests {
 
     #[test]
     fn evaluate_batch_returns_results_for_each_spec_in_order() {
-        let s = snap(vec![elem(
-            "ok", "#ok", Some("button"), Some("Save"), true,
-        )]);
+        let s = snap(vec![elem("ok", "#ok", Some("button"), Some("Save"), true)]);
         let a1 = assertion("a", "info", json!({ "role": "button" }), true);
         let st1 = state("s1", "Loaded", Some(true), vec![a1]);
         let spec1 = page_spec("page-1", vec![st1]);
@@ -804,9 +819,7 @@ mod tests {
 
     #[test]
     fn evaluate_recommended_state_prefers_highest_match_rate() {
-        let s = snap(vec![elem(
-            "ok", "#ok", Some("button"), Some("Save"), true,
-        )]);
+        let s = snap(vec![elem("ok", "#ok", Some("button"), Some("Save"), true)]);
         // s1 will fail; s2 will pass.
         let a1 = assertion("a1", "info", json!({ "role": "nope" }), true);
         let st1 = state("s1", "Idle", None, vec![a1]);
@@ -827,9 +840,7 @@ mod tests {
         // Same shape as the test above — would normally recommend s2 —
         // but s1 is flagged degenerate. Expect: recommended_state: None,
         // recommendation_reason: "spec_validation_failed".
-        let s = snap(vec![elem(
-            "ok", "#ok", Some("button"), Some("Save"), true,
-        )]);
+        let s = snap(vec![elem("ok", "#ok", Some("button"), Some("Save"), true)]);
         let a1 = assertion("a1", "info", json!({ "role": "nope" }), true);
         let st1 = state("s1", "Idle", None, vec![a1]);
         let a2 = assertion("a2", "info", json!({ "role": "button" }), true);
@@ -855,9 +866,7 @@ mod tests {
 
     #[test]
     fn evaluate_with_validation_refuses_recommendation_on_indistinguishable_pair() {
-        let s = snap(vec![elem(
-            "ok", "#ok", Some("button"), Some("Save"), true,
-        )]);
+        let s = snap(vec![elem("ok", "#ok", Some("button"), Some("Save"), true)]);
         let a = assertion("a", "info", json!({ "role": "button" }), true);
         let st = state("s1", "Idle", Some(true), vec![a]);
         let spec = page_spec("page-1", vec![st]);
@@ -878,9 +887,7 @@ mod tests {
     #[test]
     fn evaluate_with_validation_passes_clean_validation_through() {
         // Empty SpecValidation (no violations) should NOT block recommendation.
-        let s = snap(vec![elem(
-            "ok", "#ok", Some("button"), Some("Save"), true,
-        )]);
+        let s = snap(vec![elem("ok", "#ok", Some("button"), Some("Save"), true)]);
         let a = assertion("a", "info", json!({ "role": "button" }), true);
         let st = state("s1", "Idle", Some(true), vec![a]);
         let spec = page_spec("page-1", vec![st]);
@@ -949,13 +956,8 @@ mod tests {
     fn evaluate_with_identity_writes_caller_fingerprint() {
         let (s, spec) = identity_fixture();
         let fp = caller_fingerprint("qontinui-web", s.elements.len() as u32);
-        let result = evaluate_with_identity(
-            &s,
-            &spec,
-            fp,
-            "scs_018f-abc".to_string(),
-            String::new(),
-        );
+        let result =
+            evaluate_with_identity(&s, &spec, fp, "scs_018f-abc".to_string(), String::new());
         // Caller's app_id flows through; NOT the sentinel.
         assert_eq!(result.bridge_fingerprint.app_id, "qontinui-web");
         assert_ne!(result.bridge_fingerprint.app_id, "internal-evaluator");
@@ -975,13 +977,8 @@ mod tests {
     fn evaluate_with_identity_writes_caller_snapshot_id() {
         let (s, spec) = identity_fixture();
         let fp = caller_fingerprint("qontinui-web", s.elements.len() as u32);
-        let result = evaluate_with_identity(
-            &s,
-            &spec,
-            fp,
-            "scs_018f-abc".to_string(),
-            String::new(),
-        );
+        let result =
+            evaluate_with_identity(&s, &spec, fp, "scs_018f-abc".to_string(), String::new());
         assert_eq!(result.snapshot_id, "scs_018f-abc");
         assert_ne!(result.snapshot_id, "scs_internal_eval");
     }
@@ -1003,13 +1000,7 @@ mod tests {
 
         // Empty hash => None (serialized as null via skip_serializing_if).
         let fp2 = caller_fingerprint("qontinui-web", s.elements.len() as u32);
-        let result2 = evaluate_with_identity(
-            &s,
-            &spec,
-            fp2,
-            "scs_x".to_string(),
-            String::new(),
-        );
+        let result2 = evaluate_with_identity(&s, &spec, fp2, "scs_x".to_string(), String::new());
         assert!(result2.snapshot_sha256.is_none());
     }
 
@@ -1018,19 +1009,11 @@ mod tests {
         let (s, spec) = identity_fixture();
         let plain = evaluate(&s, &spec);
         let fp = caller_fingerprint("qontinui-web", s.elements.len() as u32);
-        let identity = evaluate_with_identity(
-            &s,
-            &spec,
-            fp,
-            "scs_x".to_string(),
-            "sha256-abc".to_string(),
-        );
+        let identity =
+            evaluate_with_identity(&s, &spec, fp, "scs_x".to_string(), "sha256-abc".to_string());
         // The matching outcome must be identical regardless of entrypoint —
         // only the identity fields differ.
-        assert_eq!(
-            identity.summary.match_outcome,
-            plain.summary.match_outcome
-        );
+        assert_eq!(identity.summary.match_outcome, plain.summary.match_outcome);
         assert_eq!(
             identity.summary.overall_match_rate,
             plain.summary.overall_match_rate
@@ -1101,7 +1084,10 @@ mod tests {
             let mut v: serde_json::Value = serde_json::to_value(r).unwrap();
             if let Some(obj) = v.as_object_mut() {
                 obj.insert("evaluatedAt".to_string(), json!("FIXED"));
-                if let Some(fp) = obj.get_mut("bridgeFingerprint").and_then(|x| x.as_object_mut()) {
+                if let Some(fp) = obj
+                    .get_mut("bridgeFingerprint")
+                    .and_then(|x| x.as_object_mut())
+                {
                     fp.insert("snapshotTimestamp".to_string(), json!("FIXED"));
                 }
             }
@@ -1126,7 +1112,10 @@ mod tests {
         let mut v: serde_json::Value = serde_json::to_value(r).unwrap();
         if let Some(obj) = v.as_object_mut() {
             obj.insert("evaluatedAt".to_string(), json!("FIXED"));
-            if let Some(fp) = obj.get_mut("bridgeFingerprint").and_then(|x| x.as_object_mut()) {
+            if let Some(fp) = obj
+                .get_mut("bridgeFingerprint")
+                .and_then(|x| x.as_object_mut())
+            {
                 fp.insert("snapshotTimestamp".to_string(), json!("FIXED"));
             }
         }

--- a/crates/spec-check/src/lib.rs
+++ b/crates/spec-check/src/lib.rs
@@ -30,13 +30,14 @@ pub use snapshot::IndexedSnapshot;
 // Re-export wire types so downstream crates don't need two deps. Names match
 // the qontinui-schemas registrations at qontinui-runner/src-tauri/src/
 // schema_export.rs:642-673.
-pub use qontinui_types::ir::{IrAssertion, IrAssertionTarget, IrElementCriteria, IrPageSpec, IrState};
+pub use qontinui_types::ir::{
+    IrAssertion, IrAssertionTarget, IrElementCriteria, IrPageSpec, IrState,
+};
 pub use qontinui_types::spec_check::{
-    AssertionMiss, AssertionOutcome, AssertionResult, AssertionScope,
-    AssertionSeverityCounts, BridgeFingerprint, CandidateMiss, Confidence,
-    ConjunctEvaluation, ConjunctRule, FieldDiff, MatchOutcome, MatchedElement,
-    MissReason, PolicyConjunct, PolicyEvaluation, PolicyStatus, RecommendedState,
-    SpecCheckPolicy, SpecCheckResult, SpecCheckStepConfig, SpecCheckSummary,
-    SpecValidation, StateMatchResult,
+    AssertionMiss, AssertionOutcome, AssertionResult, AssertionScope, AssertionSeverityCounts,
+    BridgeFingerprint, CandidateMiss, ClassificationStatus, Confidence, ConjunctEvaluation,
+    ConjunctRule, FieldDiff, MatchOutcome, MatchedElement, MissReason, PolicyConjunct,
+    PolicyEvaluation, PolicyStatus, RecommendedState, SpecCheckPolicy, SpecCheckResult,
+    SpecCheckStepConfig, SpecCheckSummary, SpecValidation, StateMatchResult, ThresholdConfig,
 };
 pub use qontinui_types::ui_bridge::{UIBridgeElement, UIBridgeSnapshot};

--- a/crates/spec-check/src/policy.rs
+++ b/crates/spec-check/src/policy.rs
@@ -117,14 +117,10 @@ fn filter_assertions<'a>(
             if !scope.states.is_empty() && !scope.states.contains(&sa.state.state_id) {
                 return false;
             }
-            if !scope.severities.is_empty()
-                && !scope.severities.contains(&sa.assertion.severity)
-            {
+            if !scope.severities.is_empty() && !scope.severities.contains(&sa.assertion.severity) {
                 return false;
             }
-            if !scope.categories.is_empty()
-                && !scope.categories.contains(&sa.assertion.category)
-            {
+            if !scope.categories.is_empty() && !scope.categories.contains(&sa.assertion.category) {
                 return false;
             }
             // `groups` filter — no group field on AssertionResult yet; the
@@ -182,10 +178,7 @@ fn evaluate_rule(
             let failed = scope.iter().filter(|sa| !is_pass(sa.assertion)).count();
             let total = scope.len();
             if failed == 0 {
-                (
-                    PolicyStatus::Pass,
-                    format!("all {total} in scope passed"),
-                )
+                (PolicyStatus::Pass, format!("all {total} in scope passed"))
             } else {
                 (
                     PolicyStatus::Fail,
@@ -429,7 +422,7 @@ mod tests {
     use super::*;
     use crate::{
         AssertionMiss, AssertionSeverityCounts, BridgeFingerprint, MatchOutcome, MatchedElement,
-        MissReason, PolicyConjunct,
+        MissReason, PolicyConjunct, ThresholdConfig,
     };
 
     fn pass_assertion(id: &str, severity: &str, category: &str) -> AssertionResult {
@@ -469,6 +462,7 @@ mod tests {
             state_id: id.to_string(),
             state_name: id.to_string(),
             match_rate: rate,
+            classification: ThresholdConfig::default().classify_match_rate(rate),
             assertions,
         }
     }
@@ -499,6 +493,8 @@ mod tests {
             },
             evaluated_at: "2026-05-13T00:00:00Z".to_string(),
             warnings: vec![],
+            classification: ThresholdConfig::default().classify_match_rate(0.5),
+            thresholds_used: ThresholdConfig::default(),
         }
     }
 
@@ -841,8 +837,14 @@ mod tests {
 
     #[test]
     fn match_outcome_rank_ordering() {
-        assert!(match_outcome_rank(MatchOutcome::NoMatch) < match_outcome_rank(MatchOutcome::PartialMatch));
-        assert!(match_outcome_rank(MatchOutcome::PartialMatch) < match_outcome_rank(MatchOutcome::FullMatch));
+        assert!(
+            match_outcome_rank(MatchOutcome::NoMatch)
+                < match_outcome_rank(MatchOutcome::PartialMatch)
+        );
+        assert!(
+            match_outcome_rank(MatchOutcome::PartialMatch)
+                < match_outcome_rank(MatchOutcome::FullMatch)
+        );
     }
 
     // ------------- Scope filter — AND across populated fields -------------
@@ -950,7 +952,10 @@ mod tests {
         let p = factories::criticals_only();
         assert_eq!(p.conjuncts.len(), 1);
         assert_eq!(p.conjuncts[0].name, "criticals-must-pass");
-        assert_eq!(p.conjuncts[0].scope.severities, vec!["critical".to_string()]);
+        assert_eq!(
+            p.conjuncts[0].scope.severities,
+            vec!["critical".to_string()]
+        );
         assert!(matches!(p.conjuncts[0].rule, ConjunctRule::AllPass));
     }
 

--- a/crates/spec-check/src/result_migration.rs
+++ b/crates/spec-check/src/result_migration.rs
@@ -43,10 +43,7 @@ const VERSION_KEY: &str = "resultSchemaVersion";
 pub fn deserialize_result_with_migration(
     value: serde_json::Value,
 ) -> Result<SpecCheckResult, MigrationError> {
-    let version = value
-        .get(VERSION_KEY)
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0) as u32;
+    let version = value.get(VERSION_KEY).and_then(|v| v.as_u64()).unwrap_or(0) as u32;
 
     let migrated = match version {
         0 => migrate_v0_to_v1(value),
@@ -61,10 +58,7 @@ pub fn deserialize_result_with_migration(
 /// stamping the field so downstream consumers see a consistent shape.
 fn migrate_v0_to_v1(mut value: serde_json::Value) -> serde_json::Value {
     if let Some(obj) = value.as_object_mut() {
-        obj.insert(
-            VERSION_KEY.to_string(),
-            serde_json::Value::from(1_u32),
-        );
+        obj.insert(VERSION_KEY.to_string(), serde_json::Value::from(1_u32));
     }
     value
 }
@@ -74,7 +68,7 @@ mod tests {
     use super::*;
     use crate::{
         AssertionSeverityCounts, BridgeFingerprint, MatchOutcome, SpecCheckResult,
-        SpecCheckSummary,
+        SpecCheckSummary, ThresholdConfig,
     };
 
     fn sample_result(version: u32) -> SpecCheckResult {
@@ -103,6 +97,8 @@ mod tests {
             },
             evaluated_at: "2023-11-14T22:13:21.000Z".to_string(),
             warnings: vec![],
+            classification: ThresholdConfig::default().classify_match_rate(1.0),
+            thresholds_used: ThresholdConfig::default(),
         }
     }
 

--- a/src-tauri/src/database/pg/apps.rs
+++ b/src-tauri/src/database/pg/apps.rs
@@ -37,6 +37,12 @@ fn row_to_app(r: &tokio_postgres::Row) -> App {
         display_name: r.get(3),
         created_at_ms: r.get(4),
         last_seen_at_ms: r.get(5),
+        // `project.apps` has no auth/threshold columns yet (0.7.0 added these
+        // fields to the type ahead of the DB migration) — map to the schema
+        // `#[serde(default)]` values until the columns + wiring land.
+        auth_required: false,
+        red_threshold: 0.5,
+        yellow_threshold: 0.8,
     }
 }
 
@@ -323,6 +329,9 @@ pub async fn bootstrap_dev_apps(pg: &PgDb) -> Result<(), AppError> {
         repo_root: runner_root.to_string_lossy().into(),
         ui_bridge_url: "http://localhost:9876".into(),
         display_name: "Qontinui Runner (self)".into(),
+        auth_required: false,
+        red_threshold: 0.5,
+        yellow_threshold: 0.8,
     }];
 
     if let Some(root) = web_root {
@@ -331,6 +340,9 @@ pub async fn bootstrap_dev_apps(pg: &PgDb) -> Result<(), AppError> {
             repo_root: root.to_string_lossy().into(),
             ui_bridge_url: "http://localhost:3001".into(),
             display_name: "Qontinui Web (Next.js)".into(),
+            auth_required: false,
+            red_threshold: 0.5,
+            yellow_threshold: 0.8,
         });
     }
 
@@ -340,6 +352,9 @@ pub async fn bootstrap_dev_apps(pg: &PgDb) -> Result<(), AppError> {
             repo_root: root.to_string_lossy().into(),
             ui_bridge_url: "http://localhost:9875".into(),
             display_name: "Qontinui Supervisor (dashboard)".into(),
+            auth_required: false,
+            red_threshold: 0.5,
+            yellow_threshold: 0.8,
         });
     }
 
@@ -413,6 +428,9 @@ mod tests {
             repo_root: tmp.path().to_string_lossy().to_string(),
             ui_bridge_url: format!("http://localhost:3001/{}", app_id),
             display_name: format!("Test App {}", app_id),
+            auth_required: false,
+            red_threshold: 0.5,
+            yellow_threshold: 0.8,
         }
     }
 
@@ -463,6 +481,9 @@ mod tests {
             repo_root: bogus_root,
             ui_bridge_url: "http://localhost:3001".into(),
             display_name: "Test".into(),
+            auth_required: false,
+            red_threshold: 0.5,
+            yellow_threshold: 0.8,
         };
         let err = pg
             .insert_app(&req)
@@ -541,6 +562,9 @@ mod tests {
         let patch = UpdateAppRequest {
             ui_bridge_url: Some(new_url.clone()),
             display_name: None,
+            auth_required: None,
+            red_threshold: None,
+            yellow_threshold: None,
         };
         let updated = pg.update_app(&app_id, &patch).await.expect("update_app");
         assert_eq!(updated.ui_bridge_url, new_url);

--- a/src-tauri/src/spec_api/proposals.rs
+++ b/src-tauri/src/spec_api/proposals.rs
@@ -1404,6 +1404,9 @@ mod tests {
                 repo_root: tmp.path().to_string_lossy().to_string(),
                 ui_bridge_url: format!("http://localhost:0/{}", app_id),
                 display_name: format!("Test {}", app_id),
+                auth_required: false,
+                red_threshold: 0.5,
+                yellow_threshold: 0.8,
             })
             .await
             .expect("insert_app");
@@ -1459,6 +1462,9 @@ mod tests {
                 repo_root: tmp.path().to_string_lossy().to_string(),
                 ui_bridge_url: format!("http://localhost:0/{}", app_id),
                 display_name: format!("Test {}", app_id),
+                auth_required: false,
+                red_threshold: 0.5,
+                yellow_threshold: 0.8,
             })
             .await
             .expect("insert_app");

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -26,7 +26,7 @@ use crate::spec_api::storage::{self, RUNNER_APP_ID};
 use qontinui_spec_check as spec_check; // crate name = "qontinui-spec-check"
 use qontinui_types::spec_api_events::SpecApiEvent;
 use qontinui_types::spec_check::{
-    MatchOutcome, PolicyEvaluation, SpecCheckPolicy, SpecCheckResult,
+    MatchOutcome, PolicyEvaluation, SpecCheckPolicy, SpecCheckResult, ThresholdConfig,
 };
 use qontinui_types::ui_bridge::UIBridgeSnapshot; // capital UI; lives in ui_bridge
 
@@ -1893,6 +1893,8 @@ mod tests {
             },
             evaluated_at: String::new(),
             warnings: vec![],
+            classification: ThresholdConfig::default().classify_match_rate(rate),
+            thresholds_used: ThresholdConfig::default(),
         };
         let a = mk(MatchOutcome::FullMatch, 1.0);
         let b = mk(MatchOutcome::PartialMatch, 0.5);
@@ -2010,6 +2012,9 @@ mod tests {
             repo_root: tmp.path().to_string_lossy().to_string(),
             ui_bridge_url: format!("http://localhost:3001/{}", app_id),
             display_name: format!("Test App {}", app_id),
+            auth_required: false,
+            red_threshold: 0.5,
+            yellow_threshold: 0.8,
         };
         pg.insert_app(&req).await.expect("insert app");
 

--- a/src-tauri/src/spec_api/tests.rs
+++ b/src-tauri/src/spec_api/tests.rs
@@ -903,6 +903,9 @@ mod handler_tests {
             repo_root: tmp.path().to_string_lossy().to_string(),
             ui_bridge_url: format!("http://localhost:3001/{}", app_id),
             display_name: format!("Test App {}", app_id),
+            auth_required: false,
+            red_threshold: 0.5,
+            yellow_threshold: 0.8,
         };
         pg.insert_app(&req).await.expect("insert app");
 


### PR DESCRIPTION
## Problem (fleet-blocking)
`qontinui-types` 0.7.0 (a **path** dep, so Cargo.lock can't pin it) added required fields that the runner never adopted, so `cargo build`/`cargo test` fail with **E0063** on every runner build. Runner `main`'s green CI is **stale** (ran before the schemas bump) — the build is actually broken, blocking **all** runner PRs (surfaced while landing device-jwt-self-refresh #672).

Two arms of the 0.7.0 bump:
- `spec_check::SpecCheckResult` gained `classification` + `thresholds_used`; `StateMatchResult` gained `classification`.
- `apps::{App,RegisterAppRequest,UpdateAppRequest}` gained `auth_required`, `red_threshold`, `yellow_threshold`.

## Fix
- **Real eval** (`crates/spec-check/src/evaluator.rs`): `thresholds_used = ThresholdConfig::default()`; `classification = thresholds_used.classify_match_rate(<real overall/state rate>)` — wired from the actual rate, never hardcoded.
- **`apps` row/bootstrap** (`src-tauri/src/database/pg/apps.rs`): new fields set to type defaults (`auth_required:false`, `0.5`/`0.8`). Note: `project.apps` has no such columns yet, so these aren't persisted — a follow-up migration + DB wiring would be needed only to make per-app thresholds/auth configurable.
- Test constructors across the spec-check crate + `spec_api` updated (classification derived from each test's rate); `lib.rs` re-exports `ClassificationStatus`/`ThresholdConfig`.

## Verification
`cargo build --bin qontinui-runner` clean; `qontinui-spec-check` **169 passed**; `spec_check` bin **41 passed**; `validator` **18 passed**. No functional change beyond compiling against 0.7.0.

Unblocks #672 (device-jwt self-refresh) and every other runner PR.