### PR TITLE
chore(release): bump version to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-runner"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "adb_client",
  "aes-gcm",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.1",
   "pnpm": {
     "overrides": {
       "@qontinui/shared-types": "^0.6.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qontinui-runner"
-version = "1.0.0"
-description = "Desktop application for running Qontinui automation projects"
+version = "1.0.1"
+description = "Desktop app for AI-assisted development: orchestrated AI coding sessions with visual feedback, self-verification, and real-time UI inspection"
 authors = ["Qontinui <contact@qontinui.org>"]
 edition = "2021"
 license = "AGPL-3.0-or-later"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Qontinui Runner",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.qontinui.runner",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
## What
Prepares the **v1.0.1** release (Windows). Bumps the app version `1.0.0 → 1.0.1` in:
- `src-tauri/tauri.conf.json` (drives the NSIS installer filename + embedded version)
- `src-tauri/Cargo.toml` + `Cargo.lock`
- `package.json`

Also refreshes the stale `Cargo.toml` package description ("Desktop application for running Qontinui automation projects") to reflect the current purpose: a desktop app for AI-assisted development (orchestrated AI coding sessions with visual feedback, self-verification, and real-time UI inspection).

## Release flow (after this lands)
Tagging `v1.0.1` on the merge commit triggers `.github/workflows/release.yml`, which builds the Windows NSIS installer, uploads it to a GitHub Release, and marks it "latest". The qontinui-web download pages resolve "latest" dynamically (`/api/v1/releases/runner/latest`), so they pick up the new asset with no further change.

Windows is already the sole hard gate in the release workflow (macOS/Linux legs are `continue-on-error`), so this publishes Windows-only as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)