### PR TITLE
fix(ci): ignore RUSTSEC-2026-0194 in cargo audit (quick-xml, no compatible fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,9 +506,18 @@ jobs:
         # attacker would need physical/local access AND the ability to
         # drive many timing-measured auth attempts. Revisit when rsa
         # ships a fix or adb_client switches RSA implementations.
+        #
+        # --ignore RUSTSEC-2026-0194: quadratic-time attribute-duplicate
+        # check in quick-xml < 0.41 (DoS on untrusted XML with many
+        # attributes in one start tag). The tree carries FOUR quick-xml
+        # versions (0.30/0.37/0.38/0.39), all pinned transitively by the
+        # tauri/gtk stack — none upgradeable to 0.41 from this repo. The
+        # runner does not parse untrusted network XML through these paths
+        # (build-time manifests/plists). Revisit when tauri/gtk bump to
+        # quick-xml >= 0.41.
         run: |
           cargo install cargo-audit
-          cargo audit --file Cargo.lock --ignore RUSTSEC-2023-0071
+          cargo audit --file Cargo.lock --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0194
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Problem
RUSTSEC-2026-0194 (quadratic-time duplicate-attribute check in quick-xml < 0.41, DoS class) entered the advisory DB today — main's `security` job passed at 06:01 and PR runs began failing by 08:37 with no dependency changes. **Main's next push will go red on `security`.**

## Why ignore instead of upgrade
The tree carries four quick-xml versions (0.30.0 / 0.37.5 / 0.38.4 / 0.39.2), all transitively pinned by the tauri/gtk stack; the patched 0.41.0 is not reachable from this repo. Same precedent as the existing `--ignore RUSTSEC-2023-0071` (rsa/adb_client, 'no fixed upgrade available'). The runner does not feed untrusted network XML through these parsers.

## Expected guard behavior
This PR edits `ci.yml`, a guarded gating workflow — the **CI-integrity guard will correctly go red** and this must be operator-reviewed and operator-merged. That is the designed flow for gate edits, not a CI failure to fix.

Unblocks: #668 (and every future PR / main push once the advisory propagates).