### PR TITLE
feat: bundle & auto-provision PostgreSQL so the runner opens standalone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -679,6 +679,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1647,6 +1656,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1750,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1934,7 +1967,7 @@ dependencies = [
  "cbc",
  "dbus",
  "fastrand",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "sha2 0.10.9",
@@ -2121,7 +2154,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2205,6 +2238,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast-rs"
@@ -2306,6 +2345,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2319,7 +2361,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2443,7 +2485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2451,6 +2493,16 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "event-listener"
@@ -2773,6 +2825,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3269,6 +3332,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,6 +3371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3465,6 +3546,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,7 +3578,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3516,7 +3613,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3889,7 +3986,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4809,7 +4906,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6092,6 +6189,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgresql_archive"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf41d656e8c357185ccab494989fad336a9eb16ebd689fcf4efce35a9a55726a"
+dependencies = [
+ "async-trait",
+ "flate2",
+ "futures-util",
+ "hex",
+ "regex-lite",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "reqwest-tracing",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tar",
+ "target-triple",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "postgresql_commands"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af4eb3d074b22c7f07e35ab891093c48dc1f9514a52e54b250a1ae47f311df3"
+dependencies = [
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "postgresql_embedded"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec95242c7e52d7a286f35f10cf143f5fb02255bbdd41b5b2eba05dbbcd79334"
+dependencies = [
+ "anyhow",
+ "postgresql_archive",
+ "postgresql_commands",
+ "rand 0.10.1",
+ "semver",
+ "sqlx",
+ "target-triple",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6273,7 +6427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6286,7 +6440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6446,6 +6600,7 @@ dependencies = [
  "opentelemetry_sdk",
  "petgraph",
  "portable-pty",
+ "postgresql_embedded",
  "proc-macro2",
  "qontinui-code-graph",
  "qontinui-db",
@@ -6538,7 +6693,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "hex",
@@ -6636,7 +6791,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6674,9 +6829,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6996,6 +7151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7088,11 +7249,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -7104,6 +7267,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -7114,6 +7278,58 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.2",
+ "serde",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5af0cd6fc3d3c8f703d597af70b6e4e62432c63157b49419fa1ffaf481702"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.17",
+ "http",
+ "matchit",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "tracing",
 ]
 
 [[package]]
@@ -7177,6 +7393,15 @@ dependencies = [
  "strum 0.27.2",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
+dependencies = [
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -7360,7 +7585,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7419,7 +7644,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7597,7 +7822,7 @@ dependencies = [
  "cbc",
  "futures-util",
  "generic-array",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "rand 0.8.6",
@@ -8185,6 +8410,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket-pktinfo"
@@ -8282,6 +8510,123 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-postgres",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "native-tls",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-postgres",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
 ]
 
 [[package]]
@@ -8570,6 +8915,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tauri"
@@ -9005,7 +9356,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10276,6 +10627,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10541,7 +10906,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -104,6 +104,15 @@ regex = "1.10"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
+# Embedded/managed PostgreSQL so the shipped desktop app is self-contained:
+# it starts a private Postgres under the app's data dir when no external DB is
+# configured/reachable (see src/embedded_pg.rs), instead of panicking on boot.
+# `bundled` embeds the PG archive at COMPILE time — no runtime download, offline
+# first run. Provisioning only; the tokio-postgres/clorinde query layer above is
+# unchanged. Version resolves via the POSTGRESQL_VERSION build env (defaults to
+# the crate's latest); keep it consistent across builds for on-disk cluster
+# compatibility.
+postgresql_embedded = { version = "0.20.2", features = ["bundled"] }
 qontinui-spec-check = { path = "../crates/spec-check" }
 qontinui-types = { path = "../../qontinui-schemas/rust", version = ">=0.1.2, <2.0.0" }
 qontinui-code-graph = { path = "../../qontinui-schemas/code-graph", version = ">=0.1.0, <2.0.0" }

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -265,12 +265,27 @@ impl PgDb {
         // table shape. The historical alembic migration
         // `f9d3e8a4c1b6_add_regression_tables.py` remains in
         // `qontinui-web/backend/alembic/versions/` as frozen history.
-        conn.batch_execute(
-            "CREATE SCHEMA IF NOT EXISTS runner; \
-             CREATE EXTENSION IF NOT EXISTS vector;",
-        )
-        .await
-        .map_err(|e| format!("Failed to bootstrap runner schema/extension: {}", e))?;
+        conn.batch_execute("CREATE SCHEMA IF NOT EXISTS runner;")
+            .await
+            .map_err(|e| format!("Failed to bootstrap runner schema: {}", e))?;
+
+        // pgvector is OPTIONAL. The runner stores embeddings as `bytea` blobs
+        // and computes cosine similarity in Rust (see `database::embeddings`
+        // and `database::hybrid_search`) — no column uses the `vector` type and
+        // no query uses pgvector distance operators. Creating the extension is
+        // therefore best-effort: a bundled/standalone Postgres (which does not
+        // ship pgvector) must still boot. A missing extension is logged, not
+        // fatal. Kept as a no-op on managed clusters that DO ship pgvector.
+        if let Err(e) = conn
+            .batch_execute("CREATE EXTENSION IF NOT EXISTS vector;")
+            .await
+        {
+            warn!(
+                "pgvector extension unavailable — continuing without it \
+                 (embeddings use bytea + in-Rust cosine similarity): {}",
+                e
+            );
+        }
 
         // CR-5 (Plan 03): convert `project.workflow_verification_phase_results
         // .result_json` from `text` to `jsonb` so design-context §5.16's

--- a/src-tauri/src/embedded_pg.rs
+++ b/src-tauri/src/embedded_pg.rs
@@ -72,12 +72,17 @@ fn free_loopback_port() -> Option<u16> {
 /// - `setup()` runs `initdb` (first launch only; a no-op on an existing
 ///   cluster). `start()` launches the server. `temporary=false` persists data.
 pub async fn bootstrap(data_root: PathBuf, db_name: &str) -> Result<ManagedPg, String> {
-    let mut settings = Settings::default();
-    settings.installation_dir = data_root.join("pg-install");
-    settings.data_dir = data_root.join("pg-data");
-    settings.password_file = data_root.join("pg-pass");
-    settings.host = "127.0.0.1".to_string();
-    settings.temporary = false; // persist the cluster across launches
+    // Struct-update form (not `default()` + field reassignment) to satisfy
+    // clippy::field_reassign_with_default.
+    let mut settings = Settings {
+        installation_dir: data_root.join("pg-install"),
+        data_dir: data_root.join("pg-data"),
+        password_file: data_root.join("pg-pass"),
+        host: "127.0.0.1".to_string(),
+        temporary: false, // persist the cluster across launches
+        ..Settings::default()
+    };
+    // Prefer an explicit free loopback port; fall back to whatever Default chose.
     if let Some(port) = free_loopback_port() {
         settings.port = port;
     }
@@ -142,13 +147,25 @@ pub async fn bootstrap(data_root: PathBuf, db_name: &str) -> Result<ManagedPg, S
 /// Applied once, only when the database was just created.
 async fn apply_canonical_schema(url: &str) -> Result<(), String> {
     const SCHEMA: &str = include_str!("../schema.pg.sql.generated");
-    let transformed: String = SCHEMA
+    let body: String = SCHEMA
         .replace("public.vector(384)", "bytea")
         .replace("public.vector(512)", "bytea")
+        // The dump emits `CREATE SCHEMA public;`, which errors on a fresh
+        // database (the `public` schema already exists). Make every schema
+        // creation idempotent so the one-shot apply cannot trip on it.
+        .replace("CREATE SCHEMA ", "CREATE SCHEMA IF NOT EXISTS ")
         .lines()
         .filter(|l| !l.contains("ivfflat") && !l.contains("public.vector_cosine_ops"))
         .collect::<Vec<_>>()
         .join("\n");
+
+    // pgcrypto is a STANDARD contrib extension shipped with Postgres (unlike
+    // pgvector). The schema uses `public.gen_random_bytes()` / `digest()` in
+    // column DEFAULTs, which must exist before the CREATE TABLEs. The dump
+    // doesn't emit the extension (the dev/CI Postgres already has it), so
+    // provision it into `public` for the fresh embedded cluster.
+    let transformed =
+        format!("CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;\n{body}");
 
     let (client, connection) = tokio_postgres::connect(url, tokio_postgres::NoTls)
         .await
@@ -159,10 +176,21 @@ async fn apply_canonical_schema(url: &str) -> Result<(), String> {
         }
     });
 
-    let result = client
-        .batch_execute(&transformed)
-        .await
-        .map_err(|e| format!("applying canonical schema to embedded PG failed: {e}"));
+    let result = client.batch_execute(&transformed).await.map_err(|e| {
+        let detail = e
+            .as_db_error()
+            .map(|db| {
+                format!(
+                    "{} (SQLSTATE {}){}{}",
+                    db.message(),
+                    db.code().code(),
+                    db.detail().map(|d| format!("; detail: {d}")).unwrap_or_default(),
+                    db.where_().map(|w| format!("; where: {w}")).unwrap_or_default(),
+                )
+            })
+            .unwrap_or_else(|| e.to_string());
+        format!("applying canonical schema to embedded PG failed: {detail}")
+    });
 
     drop(client); // closes the connection so the driver task can finish
     let _ = conn_task.await;
@@ -204,5 +232,64 @@ pub fn stop_on_exit() {
 async fn stop(mut handle: PostgreSQL) {
     if let Err(e) = handle.stop().await {
         tracing::warn!("embedded Postgres stop failed (non-fatal on exit): {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end: initdb → start → create db → apply the transformed canonical
+    /// schema → connect → verify. Runs offline (the `bundled` archive is
+    /// embedded at compile time, so `setup()` extracts from bytes, no network).
+    /// Guards the whole pgvector-free schema-apply path against runtime
+    /// restore errors (the reason this fix exists).
+    #[tokio::test]
+    async fn boots_and_applies_transformed_schema() {
+        let root =
+            std::env::temp_dir().join(format!("qr-embedded-pg-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root); // clean any prior run
+
+        let managed = bootstrap(root.clone(), "qontinui_test")
+            .await
+            .expect("embedded PG should boot and apply the schema");
+
+        let (client, connection) = tokio_postgres::connect(&managed.url, tokio_postgres::NoTls)
+            .await
+            .expect("connect to embedded PG");
+        let conn = tokio::spawn(async move {
+            let _ = connection.await;
+        });
+
+        // The pgvector-free transform applied: the former `public.vector`
+        // column is now `bytea`.
+        let dtype: String = client
+            .query_one(
+                "SELECT data_type FROM information_schema.columns \
+                 WHERE table_schema = 'project' AND table_name = 'domain_knowledge' \
+                   AND column_name = 'content_embedding'",
+                &[],
+            )
+            .await
+            .expect("domain_knowledge.content_embedding should exist after schema apply")
+            .get(0);
+        assert_eq!(dtype, "bytea", "vector column should be transformed to bytea");
+
+        // The full schema applied (not just a handful of self-heal tables).
+        let n: i64 = client
+            .query_one(
+                "SELECT count(*)::bigint FROM information_schema.tables \
+                 WHERE table_schema IN ('project','agent','coord','auth','cloud','public')",
+                &[],
+            )
+            .await
+            .unwrap()
+            .get(0);
+        assert!(n > 100, "expected the full canonical schema (>100 tables), got {n}");
+
+        drop(client);
+        let _ = conn.await;
+        stop(managed.handle).await;
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/embedded_pg.rs
+++ b/src-tauri/src/embedded_pg.rs
@@ -1,0 +1,121 @@
+//! Managed (embedded) PostgreSQL for standalone end-user runs.
+//!
+//! ## Why
+//!
+//! The runner connects to PostgreSQL via `PgDb::new(&url)`. Historically that
+//! URL pointed at a developer's docker-compose Postgres (`localhost:5432`); on
+//! a machine without it, boot hard-panicked (`main.rs`) before the window was
+//! ever created — so the shipped app "installed but didn't open" for every
+//! end-user who lacked a database (task #5).
+//!
+//! This module starts a **private PostgreSQL owned by the app** under its
+//! per-user data dir when no external DB is configured/reachable, so the
+//! installer is self-contained. The binaries ride inside the app via the
+//! `postgresql_embedded` crate's `bundled` feature (embedded at *compile* time
+//! — no runtime download / no network on first launch).
+//!
+//! ## Scope
+//!
+//! This is **purely a provisioning concern**. The entire query layer
+//! (`tokio-postgres`, `deadpool-postgres`, clorinde-generated queries) is
+//! unchanged: this module only produces a connection URL that is handed to the
+//! existing `PgDb::new`. Dev machines with a configured profile or a reachable
+//! docker-compose DB never reach this module — the caller falls back here only
+//! when the resolved URL is the *unconfigured* localhost default AND is
+//! unreachable (see `main.rs`).
+//!
+//! ## Lifecycle
+//!
+//! [`bootstrap`] runs `initdb` on first launch (idempotent thereafter) and
+//! starts the server on an ephemeral loopback port. The returned
+//! [`ManagedPg::handle`] owns the server process and MUST be kept alive for the
+//! process lifetime and stopped on app exit (`RunEvent::Exit`) so no orphaned
+//! `postgres` process lingers holding the port.
+
+use postgresql_embedded::{PostgreSQL, Settings};
+use std::path::PathBuf;
+
+/// A running managed PostgreSQL instance plus the connection URL for the
+/// runner's database. Keep [`Self::handle`] alive for the whole process; call
+/// [`stop`] on app exit.
+pub struct ManagedPg {
+    /// Owns the `postgres` server process. Dropping/stopping it shuts the
+    /// server down.
+    pub handle: PostgreSQL,
+    /// `postgres://user:password@127.0.0.1:<ephemeral>/<db_name>` — hand
+    /// straight to `PgDb::new`.
+    pub url: String,
+}
+
+/// Best-effort free loopback TCP port. Small TOCTOU window between probe and
+/// `start()`; acceptable for a local single-user server (the crate would also
+/// pick a port, but choosing it here lets us log/report it deterministically).
+fn free_loopback_port() -> Option<u16> {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .ok()
+        .and_then(|l| l.local_addr().ok())
+        .map(|a| a.port())
+}
+
+/// Boot a managed PostgreSQL under `data_root`, provision the cluster on first
+/// run, ensure `db_name` exists, and return the running handle + connection URL.
+///
+/// - `data_root` should be the app's per-user data dir (e.g. Tauri's
+///   `app_local_data_dir()`), NOT a temp dir — the cluster persists across
+///   launches.
+/// - `setup()` runs `initdb` (first launch only; a no-op on an existing
+///   cluster). `start()` launches the server. `temporary=false` persists data.
+pub async fn bootstrap(data_root: PathBuf, db_name: &str) -> Result<ManagedPg, String> {
+    let mut settings = Settings::default();
+    settings.installation_dir = data_root.join("pg-install");
+    settings.data_dir = data_root.join("pg-data");
+    settings.password_file = data_root.join("pg-pass");
+    settings.host = "127.0.0.1".to_string();
+    settings.temporary = false; // persist the cluster across launches
+    if let Some(port) = free_loopback_port() {
+        settings.port = port;
+    }
+
+    // Build the URL before `settings` is moved into `PostgreSQL::new`. The port
+    // and generated password are fixed on `settings` at this point, so the URL
+    // is stable for the lifetime of the started server.
+    let url = settings.url(db_name);
+    let port = settings.port;
+
+    let mut handle = PostgreSQL::new(settings);
+    handle
+        .setup()
+        .await
+        .map_err(|e| format!("embedded Postgres setup (initdb) failed: {e}"))?;
+    handle
+        .start()
+        .await
+        .map_err(|e| format!("embedded Postgres start failed: {e}"))?;
+
+    let exists = handle
+        .database_exists(db_name)
+        .await
+        .map_err(|e| format!("embedded Postgres database_exists({db_name}) failed: {e}"))?;
+    if !exists {
+        handle
+            .create_database(db_name)
+            .await
+            .map_err(|e| format!("embedded Postgres create_database({db_name}) failed: {e}"))?;
+    }
+
+    tracing::info!(
+        port,
+        db = db_name,
+        "Embedded PostgreSQL ready (standalone mode — no external DB configured)"
+    );
+
+    Ok(ManagedPg { handle, url })
+}
+
+/// Stop a managed PostgreSQL instance on app exit. Best-effort: logs on
+/// failure rather than propagating (shutdown must not hang the app).
+pub async fn stop(mut handle: PostgreSQL) {
+    if let Err(e) = handle.stop().await {
+        tracing::warn!("embedded Postgres stop failed (non-fatal on exit): {e}");
+    }
+}

--- a/src-tauri/src/embedded_pg.rs
+++ b/src-tauri/src/embedded_pg.rs
@@ -34,6 +34,12 @@
 
 use postgresql_embedded::{PostgreSQL, Settings};
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+/// Holds the running managed instance for the process lifetime so it is not
+/// dropped early (which would stop the server); stopped explicitly on exit via
+/// [`stop_on_exit`].
+static MANAGED_PG: OnceLock<Mutex<Option<PostgreSQL>>> = OnceLock::new();
 
 /// A running managed PostgreSQL instance plus the connection URL for the
 /// runner's database. Keep [`Self::handle`] alive for the whole process; call
@@ -97,10 +103,14 @@ pub async fn bootstrap(data_root: PathBuf, db_name: &str) -> Result<ManagedPg, S
         .await
         .map_err(|e| format!("embedded Postgres database_exists({db_name}) failed: {e}"))?;
     if !exists {
+        // Fresh cluster: create the database and apply the canonical schema
+        // once. An existing database is left untouched (the schema was applied
+        // on a prior launch).
         handle
             .create_database(db_name)
             .await
             .map_err(|e| format!("embedded Postgres create_database({db_name}) failed: {e}"))?;
+        apply_canonical_schema(&url).await?;
     }
 
     tracing::info!(
@@ -112,9 +122,86 @@ pub async fn bootstrap(data_root: PathBuf, db_name: &str) -> Result<ManagedPg, S
     Ok(ManagedPg { handle, url })
 }
 
-/// Stop a managed PostgreSQL instance on app exit. Best-effort: logs on
-/// failure rather than propagating (shutdown must not hang the app).
-pub async fn stop(mut handle: PostgreSQL) {
+/// Apply the bundled canonical schema to a freshly-created embedded database.
+///
+/// The schema (`schema.pg.sql.generated`, a `pg_dump`-style dump of the full
+/// 362-table canonical schema) is embedded at compile time. Two transforms make
+/// it apply to a **pgvector-free** Postgres:
+///
+///   1. `public.vector(N)` column types → `bytea`. The runner stores every
+///      embedding as `bytea` and computes cosine similarity in Rust
+///      (`database::embeddings`), and none of the six `vector` columns
+///      (in `project.domain_knowledge` / `execution_issues` /
+///      `project_embeddings`) are ever read or written as a vector by the
+///      runner — so `bytea` is behaviourally identical here and needs no
+///      extension.
+///   2. Drop the three `ivfflat`/`vector_cosine_ops` indexes on those columns
+///      (they require pgvector and only accelerate similarity queries the
+///      runner never issues).
+///
+/// Applied once, only when the database was just created.
+async fn apply_canonical_schema(url: &str) -> Result<(), String> {
+    const SCHEMA: &str = include_str!("../schema.pg.sql.generated");
+    let transformed: String = SCHEMA
+        .replace("public.vector(384)", "bytea")
+        .replace("public.vector(512)", "bytea")
+        .lines()
+        .filter(|l| !l.contains("ivfflat") && !l.contains("public.vector_cosine_ops"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let (client, connection) = tokio_postgres::connect(url, tokio_postgres::NoTls)
+        .await
+        .map_err(|e| format!("connect to embedded PG for schema apply failed: {e}"))?;
+    let conn_task = tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::warn!("embedded PG schema-apply connection closed with error: {e}");
+        }
+    });
+
+    let result = client
+        .batch_execute(&transformed)
+        .await
+        .map_err(|e| format!("applying canonical schema to embedded PG failed: {e}"));
+
+    drop(client); // closes the connection so the driver task can finish
+    let _ = conn_task.await;
+    result
+}
+
+/// Store the managed handle so it is kept alive for the process lifetime and
+/// can be stopped cleanly on exit. Call once, right after [`bootstrap`].
+pub fn store_handle(handle: PostgreSQL) {
+    let slot = MANAGED_PG.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = slot.lock() {
+        *guard = Some(handle);
+    }
+}
+
+/// Stop the managed PostgreSQL (if one was started) so no orphaned `postgres`
+/// process lingers. Call from the Tauri `RunEvent::Exit` hook. Best-effort and
+/// self-contained (uses its own short-lived runtime so it does not depend on
+/// any other runtime still being alive at shutdown).
+pub fn stop_on_exit() {
+    let Some(slot) = MANAGED_PG.get() else {
+        return;
+    };
+    let handle = slot.lock().ok().and_then(|mut g| g.take());
+    let Some(handle) = handle else {
+        return;
+    };
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt.block_on(stop(handle)),
+        Err(e) => tracing::warn!("embedded Postgres stop skipped — runtime build failed: {e}"),
+    }
+}
+
+/// Stop a managed PostgreSQL instance. Best-effort: logs on failure rather than
+/// propagating (shutdown must not hang the app).
+async fn stop(mut handle: PostgreSQL) {
     if let Err(e) = handle.stop().await {
         tracing::warn!("embedded Postgres stop failed (non-fatal on exit): {e}");
     }

--- a/src-tauri/src/embedded_pg.rs
+++ b/src-tauri/src/embedded_pg.rs
@@ -184,8 +184,12 @@ async fn apply_canonical_schema(url: &str) -> Result<(), String> {
                     "{} (SQLSTATE {}){}{}",
                     db.message(),
                     db.code().code(),
-                    db.detail().map(|d| format!("; detail: {d}")).unwrap_or_default(),
-                    db.where_().map(|w| format!("; where: {w}")).unwrap_or_default(),
+                    db.detail()
+                        .map(|d| format!("; detail: {d}"))
+                        .unwrap_or_default(),
+                    db.where_()
+                        .map(|w| format!("; where: {w}"))
+                        .unwrap_or_default(),
                 )
             })
             .unwrap_or_else(|| e.to_string());
@@ -246,8 +250,7 @@ mod tests {
     /// restore errors (the reason this fix exists).
     #[tokio::test]
     async fn boots_and_applies_transformed_schema() {
-        let root =
-            std::env::temp_dir().join(format!("qr-embedded-pg-test-{}", std::process::id()));
+        let root = std::env::temp_dir().join(format!("qr-embedded-pg-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root); // clean any prior run
 
         let managed = bootstrap(root.clone(), "qontinui_test")
@@ -273,7 +276,10 @@ mod tests {
             .await
             .expect("domain_knowledge.content_embedding should exist after schema apply")
             .get(0);
-        assert_eq!(dtype, "bytea", "vector column should be transformed to bytea");
+        assert_eq!(
+            dtype, "bytea",
+            "vector column should be transformed to bytea"
+        );
 
         // The full schema applied (not just a handful of self-heal tables).
         let n: i64 = client
@@ -285,7 +291,10 @@ mod tests {
             .await
             .unwrap()
             .get(0);
-        assert!(n > 100, "expected the full canonical schema (>100 tables), got {n}");
+        assert!(
+            n > 100,
+            "expected the full canonical schema (>100 tables), got {n}"
+        );
 
         drop(client);
         let _ = conn.await;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -63,6 +63,7 @@ mod display;
 mod doctor;
 mod dom_capture;
 mod drain;
+mod embedded_pg;
 mod error;
 mod error_monitor; // Must be declared before error (error re-exports ErrorSeverity from error_monitor)
 mod event_system;
@@ -461,12 +462,76 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                 } else {
-                    error!(
-                        "PostgreSQL connection failed: {}. Ensure docker-compose PG is running \
-                         (or set QONTINUI_ALLOW_NO_DB=1 to boot DB-less in degraded mode).",
+                    // No external PostgreSQL reachable. If the DB was never
+                    // explicitly configured (the unconfigured end-user case: the
+                    // resolved URL is the hardcoded localhost default), start a
+                    // private BUNDLED PostgreSQL under the app data dir instead
+                    // of aborting before the window is ever shown — the root fix
+                    // for "installs but doesn't open" on machines with no DB.
+                    //
+                    // An explicitly configured URL (a profile or
+                    // RUNNER_DATABASE_URL) is NOT overridden: the operator meant
+                    // that specific database, and silently using a fresh empty
+                    // one would hide the misconfiguration. `QONTINUI_DISABLE_EMBEDDED_PG`
+                    // forces the legacy behaviour.
+                    let explicitly_configured = profile.source != "legacy-env"
+                        || std::env::var("RUNNER_DATABASE_URL").is_ok();
+                    let embedded_disabled = std::env::var("QONTINUI_DISABLE_EMBEDDED_PG")
+                        .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes"))
+                        .unwrap_or(false);
+
+                    if explicitly_configured || embedded_disabled {
+                        error!(
+                            "PostgreSQL connection failed: {}. The database is explicitly \
+                             configured but unreachable — start it, or unset the config to use \
+                             the bundled embedded PostgreSQL.",
+                            e
+                        );
+                        panic!("PostgreSQL connection required — {}", e);
+                    }
+
+                    warn!(
+                        "No external PostgreSQL reachable ({}). Starting the bundled embedded \
+                         PostgreSQL (standalone mode).",
                         e
                     );
-                    panic!("PostgreSQL connection required — {}", e);
+                    let data_root = dirs::data_local_dir()
+                        .unwrap_or_else(std::env::temp_dir)
+                        .join("com.qontinui.runner")
+                        .join("embedded-pg");
+
+                    let degrade = |reason: String| {
+                        error!("{reason} Booting degraded — DB-backed routes return 503.");
+                        let pg = Arc::new(
+                            crate::database::pg::PgDb::new_degraded(&pg_url)
+                                .expect("degraded PG pool construction failed"),
+                        );
+                        crate::database::pg::PgDb::set_global(pg.clone());
+                        crate::database::pg::set_pg_available(false);
+                        pg
+                    };
+
+                    match rt.block_on(crate::embedded_pg::bootstrap(data_root, "qontinui_db")) {
+                        Ok(managed) => {
+                            let url = managed.url.clone();
+                            crate::embedded_pg::store_handle(managed.handle);
+                            match rt.block_on(crate::database::pg::PgDb::new(&url)) {
+                                Ok(pg) => {
+                                    info!("Connected to embedded PostgreSQL (standalone mode)");
+                                    let pg = Arc::new(pg);
+                                    crate::database::pg::PgDb::set_global(pg.clone());
+                                    crate::database::pg::set_pg_available(true);
+                                    pg
+                                }
+                                Err(conn_err) => degrade(format!(
+                                    "Embedded PostgreSQL started but connection failed: {conn_err}."
+                                )),
+                            }
+                        }
+                        Err(boot_err) => degrade(format!(
+                            "Failed to start bundled embedded PostgreSQL: {boot_err}."
+                        )),
+                    }
                 }
             }
         }
@@ -4053,6 +4118,10 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             // a programmatic `app.exit(0)` that didn't route through the main
             // window's close handler), so pop-out teardown preserves records.
             commands::terminal_windows::mark_app_quitting();
+            // Stop the bundled embedded PostgreSQL (if we started one) so no
+            // orphaned `postgres` process lingers holding the data dir / port.
+            // No-op when running against an external DB.
+            crate::embedded_pg::stop_on_exit();
         }
     });
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       "icons/icon.ico"
     ],
     "resources": {
-      "resources/qontinui-setup-mcp/src/qontinui_setup_mcp/**/*": "qontinui-setup-mcp/src/qontinui_setup_mcp"
+      "resources/qontinui-setup-mcp/src/qontinui_setup_mcp": "qontinui-setup-mcp/src/qontinui_setup_mcp"
     },
     "createUpdaterArtifacts": false
   },


### PR DESCRIPTION
## Problem
The shipped runner **panicked on startup when no PostgreSQL was reachable** — before the window was ever created — so it "installed but didn't open" on any machine without a developer's docker-compose database (`main.rs:469`). Every clean end-user machine hit this.

## Fix (Option B — self-contained)
Boot a **private bundled PostgreSQL** under the app's per-user data dir when no external DB is configured/reachable, so the installer is self-contained. The entire query layer (`tokio-postgres`/`deadpool`/clorinde) is unchanged — this is purely startup provisioning.

- **`embedded_pg.rs`**: `postgresql_embedded` (`bundled` feature — archive embedded at compile time, offline first run) → `initdb`/start on an ephemeral loopback port under `%LOCALAPPDATA%\com.qontinui.runner\embedded-pg`, apply the canonical schema once, stop cleanly on exit.
- **Schema apply** (`schema.pg.sql.generated`, 362 tables) is transformed for a stock, extension-light Postgres:
  - the 6 unused `public.vector(N)` columns → `bytea` and the 3 `ivfflat` indexes dropped — **no pgvector needed** (the runner stores embeddings as `bytea` + Rust cosine similarity and never queries those columns as vectors);
  - `CREATE SCHEMA` → `IF NOT EXISTS` (dump emits `CREATE SCHEMA public;`);
  - `CREATE EXTENSION pgcrypto` (standard contrib) for the `gen_random_bytes`/`digest` column defaults.
- **`main.rs` wiring**: try the resolved external URL first (dev/docker-compose unchanged) → fall back to embedded **only** when the DB was never explicitly configured (`source == "legacy-env"` && no `RUNNER_DATABASE_URL`) → **degrade with a window instead of panicking** if it can't start → stop on `RunEvent::Exit`. `QONTINUI_DISABLE_EMBEDDED_PG` opts out.

## Validation
- `cargo check` ✅, `cargo clippy -D warnings` (incl. tests) ✅
- **Offline integration test** (`embedded_pg::tests::boots_and_applies_transformed_schema`): real `initdb` → apply full transformed schema → connect → verify `vector`→`bytea` + table count. Passes (~16s). It caught and fixed two real restore errors (`CREATE SCHEMA public`, missing pgcrypto).

## Also folds in (so a tagged build actually works)
- **Resources-glob fix** (`tauri.conf.json`): revert the `**/*` glob that breaks the Windows NSIS bundle (was #679).
- Rebased onto main, which already carries the quick-xml `cargo audit` security ignores.

## Supersedes #679
#679's security half landed on main independently (`ace63a71`/`52ef6be9`); its resources half is folded in here. Closing #679.

⚠️ Follow-up before publishing v1.0.1: verify the built installer opens on a clean machine (runtime path validated by the integration test, but not yet on a fresh end-user box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)