### PR TITLE
feat: helper-task queue runner layer — emit, consume, owner UI (Phase 1.3)

### DIFF
--- a/src-tauri/src/commands/helper_tasks.rs
+++ b/src-tauri/src/commands/helper_tasks.rs
@@ -1,0 +1,57 @@
+//! Helper Task Queue commands (plan `2026-06-29-helper-task-queue`, Phase 1.3).
+//!
+//! Frontend surface for the Helper Tasks page:
+//! - `get_helper_tasks_settings` / `save_helper_tasks_settings` — the owner
+//!   emit toggle + allowed kinds (Config tab).
+//! - `get_helper_answers` — the answers collected by the background poll
+//!   (`helper_tasks::poller`), for the Review tab.
+
+use tracing::info;
+
+use crate::settings::{self, HelperTasksSettings};
+
+use super::CommandResponse;
+
+/// Get the current Helper Task Queue settings.
+#[tauri::command]
+pub fn get_helper_tasks_settings() -> Result<CommandResponse, String> {
+    let helper_settings = settings::get_helper_tasks_settings();
+    Ok(CommandResponse {
+        success: true,
+        message: Some("Helper Task settings retrieved".to_string()),
+        data: Some(
+            serde_json::to_value(&helper_settings)
+                .map_err(|e| format!("serialize helper task settings: {e}"))?,
+        ),
+    })
+}
+
+/// Save Helper Task Queue settings (owner emit toggle + allowed kinds).
+#[tauri::command]
+pub fn save_helper_tasks_settings(
+    helper_tasks_settings: HelperTasksSettings,
+) -> Result<CommandResponse, String> {
+    info!(
+        "Saving Helper Task settings (emit_enabled={}, kinds={:?})",
+        helper_tasks_settings.emit_enabled, helper_tasks_settings.emit_kinds
+    );
+    settings::save_helper_tasks_settings(helper_tasks_settings)?;
+    Ok(CommandResponse {
+        success: true,
+        message: Some("Helper Task settings saved".to_string()),
+        data: None,
+    })
+}
+
+/// Get the helper answers collected by the background poll (oldest first).
+#[tauri::command]
+pub fn get_helper_answers() -> Result<CommandResponse, String> {
+    let answers = crate::helper_tasks::recent_answers();
+    Ok(CommandResponse {
+        success: true,
+        message: Some(format!("{} helper answer(s)", answers.len())),
+        data: Some(
+            serde_json::to_value(&answers).map_err(|e| format!("serialize helper answers: {e}"))?,
+        ),
+    })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -192,6 +192,7 @@ pub mod file_browser; // Safe read-only filesystem browsing for mobile
 pub mod findings;
 pub mod flow; // Flow designer commands
 pub mod global_log_sources; // Global log source management
+pub mod helper_tasks; // Helper Task Queue settings + collected answers (plan 2026-06-29)
 pub mod hooks;
 pub mod instances; // Runner instance management (dev feature)
 pub mod interaction;

--- a/src-tauri/src/config_facade.rs
+++ b/src-tauri/src/config_facade.rs
@@ -255,6 +255,20 @@ impl SettingsField for crate::step_output::script_emitter::ScriptedOutputSetting
     }
 }
 
+impl SettingsField for crate::settings::HelperTasksSettings {
+    fn get_from(settings: &Settings) -> &Self {
+        &settings.helper_tasks
+    }
+
+    fn set_in(settings: &mut Settings, value: Self) {
+        settings.helper_tasks = value;
+    }
+
+    fn field_name() -> &'static str {
+        "helper_tasks"
+    }
+}
+
 // ============================================================================
 // Generic Settings Functions
 // ============================================================================

--- a/src-tauri/src/helper_tasks/mod.rs
+++ b/src-tauri/src/helper_tasks/mod.rs
@@ -1,0 +1,196 @@
+//! Helper Task Queue — runner emit + consume surfaces (plan
+//! `2026-06-29-helper-task-queue-non-programmer-dev.md`, Phase 1.3).
+//!
+//! A *helper task* brokers a small unit of human judgment the runner cannot
+//! make on its own ("does this page look right?"). Phase 1 ships the
+//! `spot_check` kind end-to-end:
+//!
+//! - **Emit** — [`HelperTaskRegistrar`] records a `CreateHelperTaskRequest`
+//!   on the shared session outbox (`SessionEventKind::HelperTaskCreated`); the
+//!   `CoordSync` drain POSTs it to `POST /coord/helper-tasks` with the device
+//!   JWT, reusing the existing drain → auth → retry machinery. The emit hook
+//!   lives in `spec_api::spec_check` and fires on a Yellow (partial-match)
+//!   classification when the owner setting
+//!   (`settings.helper_tasks.emit_enabled`, default OFF) allows it.
+//! - **Consume** — [`poller`] periodically GETs
+//!   `/coord/helper-tasks/answers?since=<cursor>` (device JWT), folds returned
+//!   [`HelperAnswer`]s into the in-memory store here, and persists the cursor
+//!   next to `settings.json`. [`reflection_context_section`] renders the
+//!   collected verdicts as a small additive section for the reflection
+//!   agent's prompt (an approve = confirmation; a reject with reasons = a
+//!   high-signal fix target).
+//!
+//! Everything here is best-effort: a coord 503 (helper-task tables not
+//! migrated yet) is treated as "feature not available yet" and never blocks
+//! or crash-loops the runner.
+
+pub mod poller;
+pub mod registrar;
+
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
+
+use qontinui_types::helper_task::HelperAnswer;
+use tracing::debug;
+
+pub use registrar::HelperTaskRegistrar;
+
+/// Cap on answers retained in memory. Old answers age out FIFO; the reflection
+/// section and Review tab only ever need the recent tail.
+const MAX_STORED_ANSWERS: usize = 200;
+
+fn answers_store() -> &'static Mutex<VecDeque<HelperAnswer>> {
+    static ANSWERS: OnceLock<Mutex<VecDeque<HelperAnswer>>> = OnceLock::new();
+    ANSWERS.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+/// Fold newly polled answers into the store, deduplicating by answer `id`
+/// (the `since` cursor is inclusive-boundary-safe this way) and trimming to
+/// [`MAX_STORED_ANSWERS`] FIFO.
+pub fn record_answers(new_answers: Vec<HelperAnswer>) {
+    if new_answers.is_empty() {
+        return;
+    }
+    let Ok(mut store) = answers_store().lock() else {
+        return;
+    };
+    for a in new_answers {
+        if store.iter().any(|existing| existing.id == a.id) {
+            continue;
+        }
+        if store.len() >= MAX_STORED_ANSWERS {
+            store.pop_front();
+        }
+        store.push_back(a);
+    }
+}
+
+/// Snapshot of the retained answers, oldest first (poll order).
+pub fn recent_answers() -> Vec<HelperAnswer> {
+    answers_store()
+        .lock()
+        .map(|s| s.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Max verdict lines rendered into the reflection prompt — keep the section
+/// small and additive (newest answers win).
+const MAX_REFLECTION_VERDICTS: usize = 20;
+
+/// Render collected helper verdicts as a concise reflection-prompt section.
+/// Returns `None` when no answers have been collected — the reflection prompt
+/// is then unchanged (zero cost for the common no-helpers case).
+pub fn reflection_context_section() -> Option<String> {
+    let answers = recent_answers();
+    if answers.is_empty() {
+        return None;
+    }
+
+    let mut section = String::from(
+        "\n\n## Human helper verdicts\n\n\
+         Human helpers reviewed spot-check tasks emitted by this runner (Helper \
+         Task Queue). An `approve` is confirmation the page looked right to a \
+         human; a `reject` with reasons is a high-signal fix target — weigh it \
+         above automated heuristics for the page it names.\n\n",
+    );
+    // Newest first, capped.
+    for a in answers.iter().rev().take(MAX_REFLECTION_VERDICTS) {
+        let verdict = serde_json::to_value(a.verdict)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_string))
+            .unwrap_or_else(|| "unknown".to_string());
+        let mut line = format!("- task {}: {}", a.task_id, verdict);
+        if !a.reasons.is_empty() {
+            line.push_str(&format!(" (reasons: {})", a.reasons.join(", ")));
+        }
+        if let Some(text) = a.free_text.as_deref().filter(|t| !t.trim().is_empty()) {
+            line.push_str(&format!(" — \"{}\"", text.trim()));
+        }
+        section.push_str(&line);
+        section.push('\n');
+    }
+    Some(section)
+}
+
+/// Emit-hook entrypoint for the yellow-band spec-check classification
+/// (`spec_api::spec_check`). Resolves the managed [`HelperTaskRegistrar`]
+/// from Tauri state and emits a `spot_check` task for the page. Best-effort:
+/// a missing registrar (early boot, tests) or a disabled owner setting is a
+/// silent no-op — the spec-check response is never affected.
+///
+/// `screenshot_url` is `None` at this call site: the runner's screenshot
+/// upload path (`commands::screenshot::capture_and_upload_screenshot`)
+/// requires the Python-bridge compartment plus a qontinui-web `project_id`
+/// and user auth, none of which exist in the spec-check HTTP context. The
+/// helper portal renders the prompt without an image, so the answer flow
+/// still works end-to-end.
+pub fn maybe_emit_spot_check(
+    app_handle: &tauri::AppHandle,
+    app_id: &str,
+    page_id: &str,
+    match_rate: f64,
+) {
+    use tauri::Manager;
+    let Some(registrar) = app_handle.try_state::<HelperTaskRegistrar>() else {
+        debug!("helper_tasks: registrar not managed yet — skipping spot-check emit");
+        return;
+    };
+    let prompt = format!("Does this page look right? Page: {page_id} (app: {app_id})");
+    registrar.emit_spot_check(
+        app_id,
+        &prompt,
+        None,
+        Some(page_id.to_string()),
+        Some(match_rate),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qontinui_types::helper_task::HelperVerdict;
+
+    fn answer(id: &str, verdict: HelperVerdict, reasons: Vec<&str>) -> HelperAnswer {
+        HelperAnswer {
+            id: id.to_string(),
+            task_id: format!("task-for-{id}"),
+            helper_user_id: "helper-1".to_string(),
+            verdict,
+            reasons: reasons.into_iter().map(String::from).collect(),
+            free_text: None,
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+        }
+    }
+
+    /// The store + section render are process-global; run the assertions in
+    /// one test body so parallel test threads don't interleave.
+    #[test]
+    fn store_dedups_and_section_renders_verdicts() {
+        record_answers(vec![
+            answer("a1", HelperVerdict::Approve, vec![]),
+            answer(
+                "a2",
+                HelperVerdict::Reject,
+                vec!["text_cut_off", "overlapping"],
+            ),
+        ]);
+        // Re-recording the same ids is a no-op (cursor boundary safety).
+        record_answers(vec![answer("a1", HelperVerdict::Approve, vec![])]);
+
+        let all = recent_answers();
+        assert_eq!(all.iter().filter(|a| a.id == "a1").count(), 1);
+        assert_eq!(all.iter().filter(|a| a.id == "a2").count(), 1);
+
+        let section = reflection_context_section().expect("answers present → section");
+        assert!(section.contains("## Human helper verdicts"));
+        assert!(section.contains("task task-for-a1: approve"));
+        assert!(section.contains("task task-for-a2: reject (reasons: text_cut_off, overlapping)"));
+    }
+
+    #[test]
+    fn helper_tasks_settings_default_off() {
+        let s = crate::settings::HelperTasksSettings::default();
+        assert!(!s.emit_enabled, "emit must default OFF — opt-in only");
+        assert_eq!(s.emit_kinds, vec!["spot_check".to_string()]);
+    }
+}

--- a/src-tauri/src/helper_tasks/mod.rs
+++ b/src-tauri/src/helper_tasks/mod.rs
@@ -11,65 +11,280 @@
 //!   JWT, reusing the existing drain → auth → retry machinery. The emit hook
 //!   lives in `spec_api::spec_check` and fires on a Yellow (partial-match)
 //!   classification when the owner setting
-//!   (`settings.helper_tasks.emit_enabled`, default OFF) allows it.
+//!   (`settings.helper_tasks.emit_enabled`, default OFF) allows it. A
+//!   per-(app, page) emit cooldown ([`EMIT_COOLDOWN`]) stops a still-yellow
+//!   page from re-emitting on every evaluation.
 //! - **Consume** — [`poller`] periodically GETs
 //!   `/coord/helper-tasks/answers?since=<cursor>` (device JWT), folds returned
-//!   [`HelperAnswer`]s into the in-memory store here, and persists the cursor
-//!   next to `settings.json`. [`reflection_context_section`] renders the
-//!   collected verdicts as a small additive section for the reflection
-//!   agent's prompt (an approve = confirmation; a reject with reasons = a
-//!   high-signal fix target).
+//!   [`HelperAnswer`]s into the store here, and persists the cursor next to
+//!   `settings.json`. [`reflection_context_section`] renders the collected
+//!   verdicts as a small additive section for the reflection agent's prompt
+//!   (an approve = confirmation; a reject with reasons = a high-signal fix
+//!   target).
 //!
-//! Everything here is best-effort: a coord 503 (helper-task tables not
-//! migrated yet) is treated as "feature not available yet" and never blocks
-//! or crash-loops the runner.
+//! The store (answers + task metadata + emit cooldowns) is persisted as one
+//! JSON file next to the poll cursor ([`STORE_FILE`]) so a runner restart
+//! keeps the collected human verdicts; [`load_persisted_store`] restores it
+//! at boot (called from `main.rs` setup).
+//!
+//! Everything here is best-effort: a coord `helper_task_queue_unavailable`
+//! 503 (helper-task tables not migrated yet) is treated as "feature not
+//! available yet" and never blocks or crash-loops the runner.
 
 pub mod poller;
 pub mod registrar;
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 use qontinui_types::helper_task::HelperAnswer;
-use tracing::debug;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
 
 pub use registrar::HelperTaskRegistrar;
 
-/// Cap on answers retained in memory. Old answers age out FIFO; the reflection
-/// section and Review tab only ever need the recent tail.
+/// Cap on answers retained in the store. Old answers age out FIFO; the
+/// reflection section and Review tab only ever need the recent tail.
 const MAX_STORED_ANSWERS: usize = 200;
 
-fn answers_store() -> &'static Mutex<VecDeque<HelperAnswer>> {
-    static ANSWERS: OnceLock<Mutex<VecDeque<HelperAnswer>>> = OnceLock::new();
-    ANSWERS.get_or_init(|| Mutex::new(VecDeque::new()))
+/// Cap on task-metadata entries retained in the store. When exceeded, entries
+/// not referenced by any retained answer are pruned first (metadata for a task
+/// whose answers already aged out is dead weight).
+const MAX_TASK_META: usize = 500;
+
+/// Persisted store file, co-located with `settings.json` (honors the
+/// per-instance `QONTINUI_CONFIG_DIR` override, so temp runners don't share
+/// the primary's store). Same atomic-write posture as the poll cursor.
+const STORE_FILE: &str = "helper-tasks-store.json";
+
+/// Minimum interval between spot-check emissions for the same
+/// `(app_id, page_id)`. A still-yellow page re-classifies on every spec-check
+/// evaluation; without a cooldown each evaluation re-emits a duplicate task
+/// and floods the helper queue. 24h keeps at most one task per page per day.
+pub(crate) const EMIT_COOLDOWN: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Max age of a verdict rendered into the reflection prompt. Verdicts age out
+/// naturally so the same stale verdicts are not re-injected into every
+/// reflection for the whole process lifetime — a day-old human judgment about
+/// a page that has since been rebuilt is noise, not signal.
+const REFLECTION_VERDICT_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Per-task provenance captured from the drain's `POST /coord/helper-tasks`
+/// 201 response (`id` / `appId` / `source.pageId`), keyed by task id in the
+/// store. Lets reflection verdict lines name the page/app instead of an
+/// unactionable coord task UUID.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskMeta {
+    pub app_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_id: Option<String>,
 }
 
-/// Fold newly polled answers into the store, deduplicating by answer `id`
-/// (the `since` cursor is inclusive-boundary-safe this way) and trimming to
-/// [`MAX_STORED_ANSWERS`] FIFO.
+/// The persisted helper-task store: collected answers, task provenance, and
+/// per-page emit cooldowns. Serialized as one JSON document ([`STORE_FILE`]).
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct StoreState {
+    #[serde(default)]
+    answers: VecDeque<HelperAnswer>,
+    /// task_id → provenance from the drain's 201 responses.
+    #[serde(default)]
+    task_meta: HashMap<String, TaskMeta>,
+    /// `cooldown_key(app_id, page_id)` → last spot-check emit (unix seconds).
+    #[serde(default)]
+    emit_cooldowns: HashMap<String, u64>,
+}
+
+fn store() -> &'static Mutex<StoreState> {
+    static STORE: OnceLock<Mutex<StoreState>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(StoreState::default()))
+}
+
+fn store_path() -> Option<std::path::PathBuf> {
+    crate::settings::get_config_dir()
+        .ok()
+        .map(|d| d.join(STORE_FILE))
+}
+
+/// Restore the persisted store at boot (answers + task metadata + emit
+/// cooldowns) so a runner restart does not discard collected human verdicts —
+/// coord only serves answers with `created_at > since`, so anything already
+/// polled is otherwise gone for good. Best-effort: a missing file is first
+/// boot, a corrupt file is logged and ignored.
+pub fn load_persisted_store() {
+    let Some(path) = store_path() else {
+        return;
+    };
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(r) => r,
+        Err(_) => return, // first boot — nothing persisted yet
+    };
+    match serde_json::from_str::<StoreState>(&raw) {
+        Ok(mut loaded) => {
+            while loaded.answers.len() > MAX_STORED_ANSWERS {
+                loaded.answers.pop_front();
+            }
+            let (answers, tasks) = (loaded.answers.len(), loaded.task_meta.len());
+            if let Ok(mut s) = store().lock() {
+                *s = loaded;
+            }
+            info!("helper_tasks: restored persisted store ({answers} answer(s), {tasks} task(s))");
+        }
+        Err(e) => warn!("helper_tasks: persisted store unreadable — starting empty: {e}"),
+    }
+}
+
+/// Persist the store atomically (same pattern as the poll cursor).
+/// Best-effort — a write failure only costs durability across the next
+/// restart, never the in-memory state.
+#[cfg(not(test))]
+fn persist_store(state: &StoreState) {
+    let Some(path) = store_path() else {
+        return;
+    };
+    let body = match serde_json::to_vec(state) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("helper_tasks: store serialize failed (best-effort): {e}");
+            return;
+        }
+    };
+    if let Err(e) = crate::fs_atomic::atomic_write(&path, &body) {
+        warn!("helper_tasks: store persist failed (best-effort): {e}");
+    }
+}
+
+/// Test builds never touch the real config dir.
+#[cfg(test)]
+fn persist_store(_state: &StoreState) {}
+
+fn parse_ts(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|d| d.with_timezone(&chrono::Utc))
+}
+
+/// `candidate` is strictly newer than `current`. Falls back to lexicographic
+/// comparison when either timestamp fails to parse (RFC 3339 in a uniform
+/// format sorts lexicographically).
+fn is_newer(candidate: &str, current: &str) -> bool {
+    match (parse_ts(candidate), parse_ts(current)) {
+        (Some(c), Some(e)) => c > e,
+        _ => candidate > current,
+    }
+}
+
+/// Fold newly polled answers into the store, keyed by answer `id`, and trim
+/// to [`MAX_STORED_ANSWERS`] FIFO. An id already present is normally a poll
+/// re-read (the cursor overlap window); but coord also UPSERTS verdict
+/// *revisions* under the SAME id with a bumped `created_at` — on id match the
+/// stored answer is REPLACED when the incoming `created_at` is newer, so a
+/// helper changing their verdict is reflected instead of dropped.
 pub fn record_answers(new_answers: Vec<HelperAnswer>) {
     if new_answers.is_empty() {
         return;
     }
-    let Ok(mut store) = answers_store().lock() else {
+    let Ok(mut s) = store().lock() else {
         return;
     };
+    let mut changed = false;
     for a in new_answers {
-        if store.iter().any(|existing| existing.id == a.id) {
+        if let Some(existing) = s.answers.iter_mut().find(|e| e.id == a.id) {
+            if is_newer(&a.created_at, &existing.created_at) {
+                *existing = a;
+                changed = true;
+            }
             continue;
         }
-        if store.len() >= MAX_STORED_ANSWERS {
-            store.pop_front();
+        if s.answers.len() >= MAX_STORED_ANSWERS {
+            s.answers.pop_front();
         }
-        store.push_back(a);
+        s.answers.push_back(a);
+        changed = true;
     }
+    if changed {
+        persist_store(&s);
+    }
+}
+
+/// Record task provenance parsed from the drain's `POST /coord/helper-tasks`
+/// 201 response, so reflection verdict lines can render "page X (app Y)"
+/// instead of the coord task UUID. Persisted with the rest of the store.
+pub fn record_task_metadata(task_id: &str, app_id: &str, page_id: Option<String>) {
+    let Ok(mut s) = store().lock() else {
+        return;
+    };
+    s.task_meta.insert(
+        task_id.to_string(),
+        TaskMeta {
+            app_id: app_id.to_string(),
+            page_id,
+        },
+    );
+    if s.task_meta.len() > MAX_TASK_META {
+        let referenced: std::collections::HashSet<String> =
+            s.answers.iter().map(|a| a.task_id.clone()).collect();
+        s.task_meta
+            .retain(|k, _| k == task_id || referenced.contains(k));
+    }
+    persist_store(&s);
+}
+
+/// True when the store knows about anything (answers or emitted tasks) — used
+/// by the poller so pausing emission does not also pause collecting answers
+/// to tasks already outstanding.
+pub fn store_has_content() -> bool {
+    store()
+        .lock()
+        .map(|s| !s.answers.is_empty() || !s.task_meta.is_empty())
+        .unwrap_or(false)
+}
+
+fn cooldown_key(app_id: &str, page_id: &str) -> String {
+    format!("{app_id}\u{1f}{page_id}")
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// True when a spot-check for `(app_id, page_id)` was emitted within
+/// [`EMIT_COOLDOWN`] — the registrar then skips the duplicate emit.
+pub fn emit_cooldown_active(app_id: &str, page_id: &str) -> bool {
+    let now = unix_now();
+    store()
+        .lock()
+        .map(|s| {
+            s.emit_cooldowns
+                .get(&cooldown_key(app_id, page_id))
+                .is_some_and(|&t| now.saturating_sub(t) < EMIT_COOLDOWN.as_secs())
+        })
+        .unwrap_or(false)
+}
+
+/// Stamp "now" as the last spot-check emit for `(app_id, page_id)`. Expired
+/// entries are pruned on each stamp so the map stays bounded to
+/// actively-emitting pages. Persisted with the rest of the store.
+pub fn record_emit_timestamp(app_id: &str, page_id: &str) {
+    let now = unix_now();
+    let Ok(mut s) = store().lock() else {
+        return;
+    };
+    let window = EMIT_COOLDOWN.as_secs();
+    s.emit_cooldowns
+        .retain(|_, t| now.saturating_sub(*t) < window);
+    s.emit_cooldowns.insert(cooldown_key(app_id, page_id), now);
+    persist_store(&s);
 }
 
 /// Snapshot of the retained answers, oldest first (poll order).
 pub fn recent_answers() -> Vec<HelperAnswer> {
-    answers_store()
+    store()
         .lock()
-        .map(|s| s.iter().cloned().collect())
+        .map(|s| s.answers.iter().cloned().collect())
         .unwrap_or_default()
 }
 
@@ -78,11 +293,28 @@ pub fn recent_answers() -> Vec<HelperAnswer> {
 const MAX_REFLECTION_VERDICTS: usize = 20;
 
 /// Render collected helper verdicts as a concise reflection-prompt section.
-/// Returns `None` when no answers have been collected — the reflection prompt
-/// is then unchanged (zero cost for the common no-helpers case).
+/// Only answers younger than [`REFLECTION_VERDICT_MAX_AGE`] are included
+/// (answers whose `created_at` doesn't parse are excluded — they can't be
+/// aged). Returns `None` when nothing qualifies — the reflection prompt is
+/// then unchanged (zero cost for the common no-helpers case).
 pub fn reflection_context_section() -> Option<String> {
-    let answers = recent_answers();
-    if answers.is_empty() {
+    let (answers, task_meta) = store()
+        .lock()
+        .map(|s| {
+            (
+                s.answers.iter().cloned().collect::<Vec<_>>(),
+                s.task_meta.clone(),
+            )
+        })
+        .unwrap_or_default();
+    let cutoff = chrono::Utc::now()
+        - chrono::Duration::from_std(REFLECTION_VERDICT_MAX_AGE)
+            .unwrap_or_else(|_| chrono::Duration::hours(24));
+    let fresh: Vec<&HelperAnswer> = answers
+        .iter()
+        .filter(|a| parse_ts(&a.created_at).is_some_and(|t| t >= cutoff))
+        .collect();
+    if fresh.is_empty() {
         return None;
     }
 
@@ -94,12 +326,21 @@ pub fn reflection_context_section() -> Option<String> {
          above automated heuristics for the page it names.\n\n",
     );
     // Newest first, capped.
-    for a in answers.iter().rev().take(MAX_REFLECTION_VERDICTS) {
+    for a in fresh.iter().rev().take(MAX_REFLECTION_VERDICTS) {
         let verdict = serde_json::to_value(a.verdict)
             .ok()
             .and_then(|v| v.as_str().map(str::to_string))
             .unwrap_or_else(|| "unknown".to_string());
-        let mut line = format!("- task {}: {}", a.task_id, verdict);
+        // Name the page/app when the drain recorded provenance for the task;
+        // fall back to the raw task UUID otherwise.
+        let target = match task_meta.get(&a.task_id) {
+            Some(meta) => match meta.page_id.as_deref() {
+                Some(page) => format!("page {page} (app {})", meta.app_id),
+                None => format!("app {}", meta.app_id),
+            },
+            None => format!("task {}", a.task_id),
+        };
+        let mut line = format!("- {target}: {verdict}");
         if !a.reasons.is_empty() {
             line.push_str(&format!(" (reasons: {})", a.reasons.join(", ")));
         }
@@ -112,11 +353,25 @@ pub fn reflection_context_section() -> Option<String> {
     Some(section)
 }
 
+/// Resolve the managed [`HelperTaskRegistrar`] from Tauri state. `None`
+/// during early boot or in tests — callers treat that as a silent no-op
+/// (best-effort posture).
+pub fn registrar_from_app(app_handle: &tauri::AppHandle) -> Option<HelperTaskRegistrar> {
+    use tauri::Manager;
+    match app_handle.try_state::<HelperTaskRegistrar>() {
+        Some(reg) => Some(reg.inner().clone()),
+        None => {
+            debug!("helper_tasks: registrar not managed yet — skipping spot-check emit");
+            None
+        }
+    }
+}
+
 /// Emit-hook entrypoint for the yellow-band spec-check classification
-/// (`spec_api::spec_check`). Resolves the managed [`HelperTaskRegistrar`]
-/// from Tauri state and emits a `spot_check` task for the page. Best-effort:
-/// a missing registrar (early boot, tests) or a disabled owner setting is a
-/// silent no-op — the spec-check response is never affected.
+/// (`spec_api::spec_check`). Emits a `spot_check` task for the page via the
+/// given registrar. Best-effort: a disabled owner setting or an active
+/// per-page cooldown is a silent no-op — the spec-check response is never
+/// affected.
 ///
 /// `screenshot_url` is `None` at this call site: the runner's screenshot
 /// upload path (`commands::screenshot::capture_and_upload_screenshot`)
@@ -125,16 +380,11 @@ pub fn reflection_context_section() -> Option<String> {
 /// helper portal renders the prompt without an image, so the answer flow
 /// still works end-to-end.
 pub fn maybe_emit_spot_check(
-    app_handle: &tauri::AppHandle,
+    registrar: &HelperTaskRegistrar,
     app_id: &str,
     page_id: &str,
     match_rate: f64,
 ) {
-    use tauri::Manager;
-    let Some(registrar) = app_handle.try_state::<HelperTaskRegistrar>() else {
-        debug!("helper_tasks: registrar not managed yet — skipping spot-check emit");
-        return;
-    };
     let prompt = format!("Does this page look right? Page: {page_id} (app: {app_id})");
     registrar.emit_spot_check(
         app_id,
@@ -150,7 +400,12 @@ mod tests {
     use super::*;
     use qontinui_types::helper_task::HelperVerdict;
 
-    fn answer(id: &str, verdict: HelperVerdict, reasons: Vec<&str>) -> HelperAnswer {
+    fn answer_at(
+        id: &str,
+        verdict: HelperVerdict,
+        reasons: Vec<&str>,
+        created_at: &str,
+    ) -> HelperAnswer {
         HelperAnswer {
             id: id.to_string(),
             task_id: format!("task-for-{id}"),
@@ -158,8 +413,12 @@ mod tests {
             verdict,
             reasons: reasons.into_iter().map(String::from).collect(),
             free_text: None,
-            created_at: "2026-07-01T00:00:00Z".to_string(),
+            created_at: created_at.to_string(),
         }
+    }
+
+    fn answer(id: &str, verdict: HelperVerdict, reasons: Vec<&str>) -> HelperAnswer {
+        answer_at(id, verdict, reasons, &chrono::Utc::now().to_rfc3339())
     }
 
     /// The store + section render are process-global; run the assertions in
@@ -174,8 +433,21 @@ mod tests {
                 vec!["text_cut_off", "overlapping"],
             ),
         ]);
-        // Re-recording the same ids is a no-op (cursor boundary safety).
-        record_answers(vec![answer("a1", HelperVerdict::Approve, vec![])]);
+        // Re-recording the same id with the same created_at is a no-op
+        // (cursor-overlap re-read safety).
+        let all_before = recent_answers();
+        let a1_ts = all_before
+            .iter()
+            .find(|a| a.id == "a1")
+            .unwrap()
+            .created_at
+            .clone();
+        record_answers(vec![answer_at(
+            "a1",
+            HelperVerdict::Approve,
+            vec![],
+            &a1_ts,
+        )]);
 
         let all = recent_answers();
         assert_eq!(all.iter().filter(|a| a.id == "a1").count(), 1);
@@ -185,6 +457,110 @@ mod tests {
         assert!(section.contains("## Human helper verdicts"));
         assert!(section.contains("task task-for-a1: approve"));
         assert!(section.contains("task task-for-a2: reject (reasons: text_cut_off, overlapping)"));
+    }
+
+    #[test]
+    fn revision_with_newer_created_at_replaces_stored_answer() {
+        let old_ts = (chrono::Utc::now() - chrono::Duration::minutes(10)).to_rfc3339();
+        let new_ts = chrono::Utc::now().to_rfc3339();
+        record_answers(vec![answer_at(
+            "rev1",
+            HelperVerdict::Approve,
+            vec![],
+            &old_ts,
+        )]);
+        // Coord UPSERTS a revision under the SAME id with a bumped created_at.
+        record_answers(vec![answer_at(
+            "rev1",
+            HelperVerdict::Reject,
+            vec!["wrong_color"],
+            &new_ts,
+        )]);
+        let stored: Vec<_> = recent_answers()
+            .into_iter()
+            .filter(|a| a.id == "rev1")
+            .collect();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].verdict, HelperVerdict::Reject);
+        assert_eq!(stored[0].created_at, new_ts);
+
+        // An OLDER created_at under the same id never regresses the store.
+        let older_ts = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        record_answers(vec![answer_at(
+            "rev1",
+            HelperVerdict::Approve,
+            vec![],
+            &older_ts,
+        )]);
+        let stored: Vec<_> = recent_answers()
+            .into_iter()
+            .filter(|a| a.id == "rev1")
+            .collect();
+        assert_eq!(stored[0].verdict, HelperVerdict::Reject);
+    }
+
+    #[test]
+    fn reflection_section_ages_out_stale_verdicts_and_names_pages() {
+        let stale_ts = (chrono::Utc::now() - chrono::Duration::hours(48)).to_rfc3339();
+        record_answers(vec![
+            answer_at(
+                "stale1",
+                HelperVerdict::Reject,
+                vec!["overlapping"],
+                &stale_ts,
+            ),
+            answer("fresh1", HelperVerdict::Approve, vec![]),
+        ]);
+        record_task_metadata(
+            "task-for-fresh1",
+            "my-app",
+            Some("settings-general".to_string()),
+        );
+
+        let section = reflection_context_section().expect("fresh answer present → section");
+        // Stale verdicts age out (REFLECTION_VERDICT_MAX_AGE).
+        assert!(!section.contains("task-for-stale1"));
+        // Mapped tasks render page/app context instead of the task UUID.
+        assert!(section.contains("page settings-general (app my-app): approve"));
+        assert!(!section.contains("task task-for-fresh1"));
+    }
+
+    #[test]
+    fn emit_cooldown_gates_repeat_emits_per_page() {
+        assert!(!emit_cooldown_active("cool-app", "page-x"));
+        record_emit_timestamp("cool-app", "page-x");
+        assert!(emit_cooldown_active("cool-app", "page-x"));
+        // Cooldown is per-(app, page): sibling pages/apps are unaffected.
+        assert!(!emit_cooldown_active("cool-app", "page-y"));
+        assert!(!emit_cooldown_active("other-app", "page-x"));
+    }
+
+    #[test]
+    fn store_state_round_trips_through_json() {
+        let mut state = StoreState::default();
+        state
+            .answers
+            .push_back(answer("persist1", HelperVerdict::Approve, vec![]));
+        state.task_meta.insert(
+            "task-for-persist1".to_string(),
+            TaskMeta {
+                app_id: "app".to_string(),
+                page_id: Some("page".to_string()),
+            },
+        );
+        state
+            .emit_cooldowns
+            .insert(cooldown_key("app", "page"), unix_now());
+
+        let json = serde_json::to_string(&state).unwrap();
+        let loaded: StoreState = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.answers.len(), 1);
+        assert_eq!(loaded.answers[0].id, "persist1");
+        assert_eq!(
+            loaded.task_meta.get("task-for-persist1").unwrap().page_id,
+            Some("page".to_string())
+        );
+        assert_eq!(loaded.emit_cooldowns.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/helper_tasks/poller.rs
+++ b/src-tauri/src/helper_tasks/poller.rs
@@ -1,0 +1,167 @@
+//! Helper-answer poll loop (plan `2026-06-29-helper-task-queue`, Phase 1.3
+//! Part D).
+//!
+//! Periodically GETs `GET /coord/helper-tasks/answers?since=<cursor>` with
+//! the device JWT (same auth + coord-base resolution posture as
+//! `mcp::session_message_poller`), folds returned answers into the in-memory
+//! store (`super::record_answers`), and persists the cursor to a small JSON
+//! file next to `settings.json` so a restart resumes where it left off.
+//!
+//! Safety rails (mirroring the sibling pollers):
+//! - **Owner-gated.** `settings.helper_tasks.emit_enabled=false` (default)
+//!   skips the tick — a runner that never emits tasks has no answers to pull,
+//!   so the feature adds zero always-on coord traffic until opted in.
+//! - **Device-JWT-gated.** Unpaired ⇒ skip quietly.
+//! - **503-tolerant.** Coord maps un-migrated helper-task tables to 503 —
+//!   treated as "feature not available yet", debug-logged, never an error.
+//! - **Fail-open.** Any error is logged and the loop continues; spawned from
+//!   `mcp_api.rs` as a plain background task.
+
+use std::time::Duration;
+
+use qontinui_types::helper_task::HelperAnswer;
+use tracing::{debug, info, warn};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Cursor file co-located with `settings.json` (honors the per-instance
+/// `QONTINUI_CONFIG_DIR` override, so temp runners don't share the primary's
+/// cursor).
+const CURSOR_FILE: &str = "helper-answers-cursor.json";
+
+/// Run the poll loop forever. Spawned once at API boot; every failure mode is
+/// contained inside the tick.
+pub async fn run_forever() {
+    info!(
+        "helper_tasks poller started (interval={}s, gated on settings.helper_tasks.emit_enabled)",
+        POLL_INTERVAL.as_secs()
+    );
+    loop {
+        if let Err(e) = tick().await {
+            warn!("helper_tasks poller: tick failed (will retry): {e}");
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn tick() -> Result<(), String> {
+    // Owner gate — default OFF. No emit ⇒ no answers ⇒ no traffic.
+    let cfg = crate::settings::get_helper_tasks_settings();
+    if !cfg.emit_enabled {
+        return Ok(());
+    }
+
+    // Device JWT — unpaired ⇒ skip the tick quietly (no spam).
+    let token = match crate::auth::AuthManager::new().get_access_token() {
+        Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
+        _ => {
+            debug!("helper_tasks poller: no device JWT yet (unpaired) — skipping tick");
+            return Ok(());
+        }
+    };
+
+    let base = crate::mcp::agent_worktrees::coord_http_base()
+        .map_err(|e| format!("coord base unresolved: {e}"))?;
+    let base = base.trim_end_matches('/');
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("http client init: {e}"))?;
+
+    // Build the query manually: this workspace's reqwest feature set does not
+    // include `query`, and the cursor is a single RFC 3339 value anyway.
+    let url = match load_cursor() {
+        Some(cursor) => format!(
+            "{base}/coord/helper-tasks/answers?since={}",
+            percent_encode(&cursor)
+        ),
+        None => format!("{base}/coord/helper-tasks/answers"),
+    };
+
+    let resp = client
+        .get(&url)
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+    let status = resp.status();
+    if status == reqwest::StatusCode::SERVICE_UNAVAILABLE {
+        // Helper-task tables not migrated coord-side — feature not available
+        // yet. Non-fatal by design.
+        debug!("helper_tasks poller: coord returned 503 (tables not migrated) — skipping tick");
+        return Ok(());
+    }
+    if !status.is_success() {
+        return Err(format!("GET {url} -> HTTP {status}"));
+    }
+
+    // Oldest-first per the coord contract; the LAST element carries the
+    // newest `created_at`, which becomes the next cursor.
+    let answers: Vec<HelperAnswer> = resp
+        .json()
+        .await
+        .map_err(|e| format!("answers decode: {e}"))?;
+    if answers.is_empty() {
+        return Ok(());
+    }
+
+    let next_cursor = answers
+        .last()
+        .map(|a| a.created_at.clone())
+        .unwrap_or_default();
+    let count = answers.len();
+    super::record_answers(answers);
+    if !next_cursor.is_empty() {
+        save_cursor(&next_cursor);
+    }
+    info!("helper_tasks poller: collected {count} helper answer(s) (cursor -> {next_cursor})");
+    Ok(())
+}
+
+/// Minimal RFC 3986 percent-encoding for a query VALUE: everything outside
+/// the unreserved set (`A-Z a-z 0-9 - . _ ~`) is `%XX`-escaped. Covers the
+/// `:` / `+` an RFC 3339 timestamp can carry without pulling in a crate.
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for b in value.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+fn cursor_path() -> Option<std::path::PathBuf> {
+    crate::settings::get_config_dir()
+        .ok()
+        .map(|d| d.join(CURSOR_FILE))
+}
+
+/// Load the persisted `since` cursor (RFC 3339). `None` on first run or any
+/// read/parse failure — the first poll then fetches from the beginning, and
+/// the store's id-dedup absorbs any overlap.
+fn load_cursor() -> Option<String> {
+    let path = cursor_path()?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    v.get("since")
+        .and_then(|s| s.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Persist the cursor atomically. Best-effort — a write failure only means
+/// the next restart re-fetches a window the dedup already absorbs.
+fn save_cursor(since: &str) {
+    let Some(path) = cursor_path() else {
+        return;
+    };
+    let body = serde_json::json!({ "since": since }).to_string();
+    if let Err(e) = crate::fs_atomic::atomic_write(&path, body.as_bytes()) {
+        warn!("helper_tasks poller: cursor persist failed (best-effort): {e}");
+    }
+}

--- a/src-tauri/src/helper_tasks/poller.rs
+++ b/src-tauri/src/helper_tasks/poller.rs
@@ -3,14 +3,17 @@
 //!
 //! Periodically GETs `GET /coord/helper-tasks/answers?since=<cursor>` with
 //! the device JWT (same auth + coord-base resolution posture as
-//! `mcp::session_message_poller`), folds returned answers into the in-memory
+//! `mcp::session_message_poller`), folds returned answers into the persisted
 //! store (`super::record_answers`), and persists the cursor to a small JSON
 //! file next to `settings.json` so a restart resumes where it left off.
 //!
 //! Safety rails (mirroring the sibling pollers):
-//! - **Owner-gated.** `settings.helper_tasks.emit_enabled=false` (default)
-//!   skips the tick — a runner that never emits tasks has no answers to pull,
-//!   so the feature adds zero always-on coord traffic until opted in.
+//! - **Owner-gated, with an outstanding-work carve-out.** The tick runs when
+//!   `settings.helper_tasks.emit_enabled` is on OR the store already knows
+//!   about tasks/answers — pausing emission must not stop collecting answers
+//!   to tasks that are already outstanding. A runner that never emitted
+//!   anything (empty store, emit off) still adds zero always-on coord
+//!   traffic.
 //! - **Device-JWT-gated.** Unpaired ⇒ skip quietly.
 //! - **503-tolerant.** Coord maps un-migrated helper-task tables to 503 —
 //!   treated as "feature not available yet", debug-logged, never an error.
@@ -29,11 +32,19 @@ const POLL_INTERVAL: Duration = Duration::from_secs(60);
 /// cursor).
 const CURSOR_FILE: &str = "helper-answers-cursor.json";
 
+/// Overlap window subtracted from the persisted cursor when polling. Coord
+/// filters strictly `created_at > since` while the cursor is the newest
+/// `created_at` the poller has SEEN — an answer committed concurrently with a
+/// poll and stamped ≤ cursor would otherwise be skipped forever. Re-reading a
+/// 2s boundary window is idempotent: the store dedups by answer id and only
+/// replaces on a strictly newer `created_at` (revision rule).
+const CURSOR_OVERLAP_SECS: i64 = 2;
+
 /// Run the poll loop forever. Spawned once at API boot; every failure mode is
 /// contained inside the tick.
 pub async fn run_forever() {
     info!(
-        "helper_tasks poller started (interval={}s, gated on settings.helper_tasks.emit_enabled)",
+        "helper_tasks poller started (interval={}s, active when settings.helper_tasks.emit_enabled OR the answer store is non-empty)",
         POLL_INTERVAL.as_secs()
     );
     loop {
@@ -45,9 +56,12 @@ pub async fn run_forever() {
 }
 
 async fn tick() -> Result<(), String> {
-    // Owner gate — default OFF. No emit ⇒ no answers ⇒ no traffic.
+    // Owner gate — default OFF — but only for a runner with nothing
+    // outstanding: pausing emission must not stop collecting answers to tasks
+    // already emitted, so a non-empty store keeps the poll alive. Only the
+    // EMIT side keys on the toggle.
     let cfg = crate::settings::get_helper_tasks_settings();
-    if !cfg.emit_enabled {
+    if !cfg.emit_enabled && !super::store_has_content() {
         return Ok(());
     }
 
@@ -74,7 +88,7 @@ async fn tick() -> Result<(), String> {
     let url = match load_cursor() {
         Some(cursor) => format!(
             "{base}/coord/helper-tasks/answers?since={}",
-            percent_encode(&cursor)
+            percent_encode(&overlapped_since(&cursor))
         ),
         None => format!("{base}/coord/helper-tasks/answers"),
     };
@@ -97,7 +111,9 @@ async fn tick() -> Result<(), String> {
     }
 
     // Oldest-first per the coord contract; the LAST element carries the
-    // newest `created_at`, which becomes the next cursor.
+    // newest `created_at`, which becomes the next cursor. NOTE: coord's
+    // filter is strictly EXCLUSIVE (`created_at > since`) — the
+    // CURSOR_OVERLAP_SECS window above is what protects the boundary.
     let answers: Vec<HelperAnswer> = resp
         .json()
         .await
@@ -133,6 +149,16 @@ fn percent_encode(value: &str) -> String {
         }
     }
     out
+}
+
+/// Subtract [`CURSOR_OVERLAP_SECS`] from an RFC 3339 cursor. Falls back to
+/// the raw cursor when it doesn't parse (coord then applies its strict `>`
+/// against the value we stored — same behavior as before the overlap).
+fn overlapped_since(cursor: &str) -> String {
+    match chrono::DateTime::parse_from_rfc3339(cursor) {
+        Ok(dt) => (dt - chrono::Duration::seconds(CURSOR_OVERLAP_SECS)).to_rfc3339(),
+        Err(_) => cursor.to_string(),
+    }
 }
 
 fn cursor_path() -> Option<std::path::PathBuf> {

--- a/src-tauri/src/helper_tasks/registrar.rs
+++ b/src-tauri/src/helper_tasks/registrar.rs
@@ -6,8 +6,10 @@
 //! shared [`OutboxWriter`] the `CoordSync` drain loop reads. Emitting a task
 //! is therefore one durable local write; the drain maps
 //! [`SessionEventKind::HelperTaskCreated`] to `POST /coord/helper-tasks` with
-//! the device JWT and the existing retry posture (a coord 503 — helper-task
-//! tables not migrated — is dropped with a warn, never a retry loop).
+//! the device JWT under a best-effort posture: transient failures get a
+//! bounded per-record retry that never blocks session events queued behind
+//! them, and a coord `helper_task_queue_unavailable` 503 (helper-task tables
+//! not migrated) is dropped with a warn, never a retry loop.
 
 use std::sync::Arc;
 
@@ -54,8 +56,11 @@ impl HelperTaskRegistrar {
 
     /// Emit a `spot_check` helper task for `app_id`. Gated on the owner
     /// setting (`settings.helper_tasks`): emit must be enabled AND
-    /// `"spot_check"` must be in `emit_kinds`. Returns `true` when a task was
-    /// recorded on the outbox. Best-effort throughout — a disabled gate or an
+    /// `"spot_check"` must be in `emit_kinds`. Also gated on the per-
+    /// `(app_id, page_id)` emit cooldown ([`super::EMIT_COOLDOWN`]) so a
+    /// still-yellow page doesn't re-emit a duplicate task on every
+    /// evaluation. Returns `true` when a task was recorded on the outbox.
+    /// Best-effort throughout — a disabled gate, an active cooldown, or an
     /// outbox write error never disturbs the caller.
     pub fn emit_spot_check(
         &self,
@@ -74,7 +79,18 @@ impl HelperTaskRegistrar {
             debug!("helper_tasks: kind spot_check not in emit_kinds — skipping for {app_id}");
             return false;
         }
-        self.record_spot_check(app_id, prompt, screenshot_url, page_id, match_rate)
+        let page_key = page_id.as_deref().unwrap_or("").to_string();
+        if super::emit_cooldown_active(app_id, &page_key) {
+            debug!(
+                "helper_tasks: spot-check for {app_id}/{page_key} within emit cooldown — skipping"
+            );
+            return false;
+        }
+        let recorded = self.record_spot_check(app_id, prompt, screenshot_url, page_id, match_rate);
+        if recorded {
+            super::record_emit_timestamp(app_id, &page_key);
+        }
+        recorded
     }
 
     /// Build the `CreateHelperTaskRequest` body and record it on the outbox.

--- a/src-tauri/src/helper_tasks/registrar.rs
+++ b/src-tauri/src/helper_tasks/registrar.rs
@@ -1,0 +1,250 @@
+//! `HelperTaskRegistrar` — outbox writer for helper-task creation
+//! (plan `2026-06-29-helper-task-queue`, Phase 1.3 Part A).
+//!
+//! Mirrors [`crate::claude_session::coord_register::AiCoordRegistrar`]'s
+//! shape: a plain cloneable struct wrapping `Arc<Inner>` that holds the SAME
+//! shared [`OutboxWriter`] the `CoordSync` drain loop reads. Emitting a task
+//! is therefore one durable local write; the drain maps
+//! [`SessionEventKind::HelperTaskCreated`] to `POST /coord/helper-tasks` with
+//! the device JWT and the existing retry posture (a coord 503 — helper-task
+//! tables not migrated — is dropped with a warn, never a retry loop).
+
+use std::sync::Arc;
+
+use qontinui_types::helper_task::{
+    HelperAnswerSchema, HelperTaskKind, HelperTaskPayload, HelperTaskSource, HelperVerdict,
+};
+use serde_json::json;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::session::local_store::OutboxWriter;
+use crate::session::SessionEventKind;
+
+/// Preset reject-reason chips offered to the helper on a `spot_check` task.
+const SPOT_CHECK_PRESET_REASONS: [&str; 4] = [
+    "text_cut_off",
+    "overlapping",
+    "wrong_color",
+    "button_missing",
+];
+
+/// Records helper-task creation requests on the shared session outbox.
+///
+/// Managed as Tauri state (see `main.rs`, constructed alongside
+/// `AiCoordRegistrar` with the same outbox + machine id); cheap to clone.
+#[derive(Clone)]
+pub struct HelperTaskRegistrar {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    outbox: Arc<OutboxWriter>,
+    machine_id: Uuid,
+}
+
+impl HelperTaskRegistrar {
+    /// Construct from the shared session outbox + this device's `machine_id`.
+    /// The outbox MUST be the same `Arc` the `CoordSync` drain loop reads.
+    pub fn new(outbox: Arc<OutboxWriter>, machine_id: Uuid) -> Self {
+        Self {
+            inner: Arc::new(Inner { outbox, machine_id }),
+        }
+    }
+
+    /// Emit a `spot_check` helper task for `app_id`. Gated on the owner
+    /// setting (`settings.helper_tasks`): emit must be enabled AND
+    /// `"spot_check"` must be in `emit_kinds`. Returns `true` when a task was
+    /// recorded on the outbox. Best-effort throughout — a disabled gate or an
+    /// outbox write error never disturbs the caller.
+    pub fn emit_spot_check(
+        &self,
+        app_id: &str,
+        prompt: &str,
+        screenshot_url: Option<String>,
+        page_id: Option<String>,
+        match_rate: Option<f64>,
+    ) -> bool {
+        let cfg = crate::settings::get_helper_tasks_settings();
+        if !cfg.emit_enabled {
+            debug!("helper_tasks: emit disabled (settings.helper_tasks.emit_enabled=false) — skipping spot-check for {app_id}");
+            return false;
+        }
+        if !cfg.emit_kinds.iter().any(|k| k == "spot_check") {
+            debug!("helper_tasks: kind spot_check not in emit_kinds — skipping for {app_id}");
+            return false;
+        }
+        self.record_spot_check(app_id, prompt, screenshot_url, page_id, match_rate)
+    }
+
+    /// Build the `CreateHelperTaskRequest` body and record it on the outbox.
+    /// Split from [`Self::emit_spot_check`] so tests can exercise the wire
+    /// shape without the settings-file gate.
+    ///
+    /// Wire shape: snake_case top-level fields; nested structs serialize
+    /// camelCase via the canonical `qontinui_types::helper_task` types.
+    fn record_spot_check(
+        &self,
+        app_id: &str,
+        prompt: &str,
+        screenshot_url: Option<String>,
+        page_id: Option<String>,
+        match_rate: Option<f64>,
+    ) -> bool {
+        let payload = HelperTaskPayload {
+            screenshot_url,
+            ..Default::default()
+        };
+        let answer_schema = HelperAnswerSchema {
+            verdicts: vec![
+                HelperVerdict::Approve,
+                HelperVerdict::Reject,
+                HelperVerdict::NotSure,
+            ],
+            preset_reasons: SPOT_CHECK_PRESET_REASONS
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+            allow_free_text: true,
+            allow_not_sure: true,
+        };
+        let source = HelperTaskSource {
+            finding_id: None,
+            page_id,
+            match_rate,
+        };
+        // `expires_at` is omitted — coord's broker default applies.
+        let body = json!({
+            "app_id": app_id,
+            "kind": HelperTaskKind::SpotCheck,
+            "prompt": prompt,
+            "payload": payload,
+            "answer_schema": answer_schema,
+            "required_votes": 1,
+            "source": source,
+        });
+
+        // The outbox keys its monotonic `seq` on `(machine_id, session_id)`,
+        // but helper tasks have no real session — mint a deterministic UUIDv5
+        // per app so all tasks for one app share a seq lane (stable ordering,
+        // idempotent replay) without colliding across apps. Coord never reads
+        // this id (mirrors `AiCoordRegistrar::report_commits`).
+        let session_id = Uuid::new_v5(
+            &Uuid::NAMESPACE_URL,
+            format!("helper-task:{app_id}").as_bytes(),
+        );
+
+        match self.inner.outbox.record(
+            self.inner.machine_id,
+            session_id,
+            SessionEventKind::HelperTaskCreated,
+            body,
+        ) {
+            Ok(_) => {
+                info!("helper_tasks: enqueued spot_check task for app {app_id}");
+                true
+            }
+            Err(e) => {
+                warn!("helper_tasks: outbox HelperTaskCreated write failed for {app_id} (best-effort): {e}");
+                false
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn registrar() -> (HelperTaskRegistrar, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let outbox = Arc::new(OutboxWriter::open(dir.path().join("outbox.jsonl")).unwrap());
+        (HelperTaskRegistrar::new(outbox, Uuid::new_v4()), dir)
+    }
+
+    #[test]
+    fn record_spot_check_writes_create_request_shape() {
+        let (reg, _dir) = registrar();
+        assert!(reg.record_spot_check(
+            "my-app",
+            "Does this page look right? Page: settings-general (app: my-app)",
+            None,
+            Some("settings-general".to_string()),
+            Some(0.72),
+        ));
+
+        let pending = reg.inner.outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        let row = &pending[0];
+        assert_eq!(row.event_kind, SessionEventKind::HelperTaskCreated.as_str());
+
+        let body = &row.payload;
+        // Top-level fields are snake_case.
+        assert_eq!(body["app_id"], json!("my-app"));
+        assert_eq!(body["kind"], json!("spot_check"));
+        assert_eq!(body["required_votes"], json!(1));
+        assert!(body.get("expires_at").is_none());
+        // Nested structs are camelCase (canonical schema serialization).
+        assert_eq!(
+            body["answer_schema"]["verdicts"],
+            json!(["approve", "reject", "not_sure"])
+        );
+        assert_eq!(
+            body["answer_schema"]["presetReasons"],
+            json!([
+                "text_cut_off",
+                "overlapping",
+                "wrong_color",
+                "button_missing"
+            ])
+        );
+        assert_eq!(body["answer_schema"]["allowFreeText"], json!(true));
+        assert_eq!(body["answer_schema"]["allowNotSure"], json!(true));
+        assert_eq!(body["source"]["pageId"], json!("settings-general"));
+        assert_eq!(body["source"]["matchRate"], json!(0.72));
+        // SpotCheck without a screenshot omits the field entirely.
+        assert!(body["payload"].get("screenshotUrl").is_none());
+    }
+
+    #[test]
+    fn spot_checks_for_one_app_share_a_seq_lane() {
+        let (reg, _dir) = registrar();
+        assert!(reg.record_spot_check("app-a", "p1", None, None, None));
+        assert!(reg.record_spot_check("app-a", "p2", None, None, None));
+        assert!(reg.record_spot_check("app-b", "p3", None, None, None));
+
+        let pending = reg.inner.outbox.pending().unwrap();
+        assert_eq!(pending.len(), 3);
+        let a_rows: Vec<_> = pending
+            .iter()
+            .filter(|r| r.payload["app_id"] == json!("app-a"))
+            .collect();
+        assert_eq!(a_rows.len(), 2);
+        assert_eq!(a_rows[0].session_id, a_rows[1].session_id);
+        assert_eq!(a_rows[0].seq, 1);
+        assert_eq!(a_rows[1].seq, 2);
+        let b_row = pending
+            .iter()
+            .find(|r| r.payload["app_id"] == json!("app-b"))
+            .unwrap();
+        assert_ne!(b_row.session_id, a_rows[0].session_id);
+    }
+
+    #[test]
+    fn screenshot_url_is_forwarded_when_present() {
+        let (reg, _dir) = registrar();
+        assert!(reg.record_spot_check(
+            "app",
+            "p",
+            Some("https://example.com/shot.png".to_string()),
+            None,
+            None,
+        ));
+        let pending = reg.inner.outbox.pending().unwrap();
+        assert_eq!(
+            pending[0].payload["payload"]["screenshotUrl"],
+            json!("https://example.com/shot.png")
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2211,6 +2211,11 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // same CoordSync drain) as the AI-session registrar. Managed
                 // as Tauri state so the spec-check yellow-band hook
                 // (`helper_tasks::maybe_emit_spot_check`) can reach it.
+                // Restore the persisted store (collected answers + task
+                // provenance + emit cooldowns) BEFORE anything can emit or
+                // render — a restart must not discard human verdicts (coord
+                // only serves answers newer than the poll cursor).
+                helper_tasks::load_persisted_store();
                 let helper_task_registrar =
                     helper_tasks::HelperTaskRegistrar::new(registrar_outbox.clone(), machine_id);
                 app.manage(helper_task_registrar);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -94,6 +94,7 @@ mod blind_spots;
 mod graphql;
 mod health_monitor;
 mod heartbeat;
+mod helper_tasks;
 mod install_effects_producer;
 mod instance;
 mod instance_health;
@@ -1456,6 +1457,9 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::global_log_sources::set_log_source_ai_selection_mode,
             commands::global_log_sources::update_global_log_source,
             commands::global_log_sources::update_global_log_source_profile,
+            commands::helper_tasks::get_helper_answers,
+            commands::helper_tasks::get_helper_tasks_settings,
+            commands::helper_tasks::save_helper_tasks_settings,
             commands::hooks::create_hook,
             commands::hooks::delete_hook,
             commands::hooks::get_all_hooks,
@@ -2202,6 +2206,14 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         uuid::Uuid::parse_str(s).ok()
                     })
                     .unwrap_or_else(uuid::Uuid::new_v4);
+                // Helper Task Queue (plan 2026-06-29, Phase 1.3) — the
+                // helper-task registrar shares the SAME outbox (and thus the
+                // same CoordSync drain) as the AI-session registrar. Managed
+                // as Tauri state so the spec-check yellow-band hook
+                // (`helper_tasks::maybe_emit_spot_check`) can reach it.
+                let helper_task_registrar =
+                    helper_tasks::HelperTaskRegistrar::new(registrar_outbox.clone(), machine_id);
+                app.manage(helper_task_registrar);
                 // Session-automation Phase 0 (R1–R6) — register authenticated
                 // AI sessions into coord.sessions with their task_run_id, so
                 // they are visible + addressable + correctly stale to coord.

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -391,6 +391,7 @@ const VALID_TAB_IDS: &[&str] = &[
     "wrappers",
     "productivity",
     "regression",
+    "helper-tasks",
 ];
 
 // ============================================================================

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1912,6 +1912,18 @@ pub fn create_router(
         });
     }
 
+    // Helper Task Queue (plan 2026-06-29, Phase 1.3 Part D) — poll collected
+    // helper answers from coord into the in-memory store that feeds the
+    // reflection-context section and the Helper Tasks Review tab. Owner-gated
+    // (settings.helper_tasks.emit_enabled, default OFF) and device-JWT-gated
+    // inside the tick, so spawning unconditionally adds no always-on traffic.
+    {
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+            crate::helper_tasks::poller::run_forever().await;
+        });
+    }
+
     // Restore persisted coord-mcp proxy nonces + reconcile session configs to
     // the current bound port (plan 2026-06-13 Phases 3b + 3c). 3b makes an
     // already-written `.mcp.json` keep validating across a restart (the nonce

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1913,10 +1913,12 @@ pub fn create_router(
     }
 
     // Helper Task Queue (plan 2026-06-29, Phase 1.3 Part D) — poll collected
-    // helper answers from coord into the in-memory store that feeds the
-    // reflection-context section and the Helper Tasks Review tab. Owner-gated
-    // (settings.helper_tasks.emit_enabled, default OFF) and device-JWT-gated
-    // inside the tick, so spawning unconditionally adds no always-on traffic.
+    // helper answers from coord into the persisted store that feeds the
+    // reflection-context section and the Helper Tasks Review tab. The tick
+    // runs when settings.helper_tasks.emit_enabled is on OR the store already
+    // has tasks/answers (pausing emission must not pause collection), and is
+    // device-JWT-gated — spawning unconditionally adds no always-on traffic
+    // for an opted-out runner with an empty store.
     {
         tokio::spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;

--- a/src-tauri/src/reflection/workflow.rs
+++ b/src-tauri/src/reflection/workflow.rs
@@ -454,7 +454,16 @@ pub fn build_reflection_config(
 ) -> LoopConfig {
     LoopConfig {
         max_iterations: 3,
-        base_prompt: build_agentic_prompt(source_workflow_name),
+        base_prompt: {
+            // Helper Task Queue (plan 2026-06-29, Phase 1.3 Part D): append
+            // the collected human helper verdicts as a small additive section.
+            // None (the common no-helpers case) leaves the prompt unchanged.
+            let mut prompt = build_agentic_prompt(source_workflow_name);
+            if let Some(section) = crate::helper_tasks::reflection_context_section() {
+                prompt.push_str(&section);
+            }
+            prompt
+        },
         workflow_name: workflow_name.to_string(),
         workflow_id: format!("reflection-{}", execution_id),
         execution_id: execution_id.to_string(),
@@ -1083,7 +1092,15 @@ pub fn build_project_reflection_config(
 ) -> LoopConfig {
     LoopConfig {
         max_iterations: 3, // Increased from 2: AI verification step needs room to retry
-        base_prompt: build_project_agentic_prompt(source_workflow_name),
+        base_prompt: {
+            // Helper Task Queue (Phase 1.3 Part D) — same additive helper-verdict
+            // section as build_reflection_config.
+            let mut prompt = build_project_agentic_prompt(source_workflow_name);
+            if let Some(section) = crate::helper_tasks::reflection_context_section() {
+                prompt.push_str(&section);
+            }
+            prompt
+        },
         workflow_name: workflow_name.to_string(),
         workflow_id: format!("project-reflection-{}", execution_id),
         execution_id: execution_id.to_string(),
@@ -1505,7 +1522,16 @@ pub fn build_ui_bridge_reflection_config(
 ) -> LoopConfig {
     LoopConfig {
         max_iterations: 5,
-        base_prompt: build_ui_bridge_agentic_prompt(source_workflow_name),
+        base_prompt: {
+            // Helper Task Queue (Phase 1.3 Part D) — helper spot-check verdicts
+            // are page-visual judgments, the most relevant signal for the
+            // UI-bridge reflection variant.
+            let mut prompt = build_ui_bridge_agentic_prompt(source_workflow_name);
+            if let Some(section) = crate::helper_tasks::reflection_context_section() {
+                prompt.push_str(&section);
+            }
+            prompt
+        },
         workflow_name: workflow_name.to_string(),
         workflow_id: format!("ui-bridge-reflection-{}", execution_id),
         execution_id: execution_id.to_string(),

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -490,12 +490,23 @@ const TICK_IDLE: Duration = Duration::from_secs(5);
 /// Max backoff after repeated transport errors.
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 
+/// Bounded retry budget for a `helper_task_created` record. Helper tasks are
+/// BEST-EFFORT: they must never head-of-line-block session lifecycle events
+/// queued behind them, so a failing record is skipped (not batch-breaking)
+/// and Ack-dropped once its budget is spent.
+const HELPER_TASK_MAX_ATTEMPTS: u32 = 3;
+
 async fn run_drain_loop(inner: Arc<CoordSyncInner>) {
     tracing::info!(
         coord_url = %inner.coord_url,
         "coord_sync: drain loop starting"
     );
     let mut backoff = TICK_BUSY;
+    // Best-effort retry budget for helper_task_created records, keyed by
+    // (session_id, seq). In-memory by design: a restart resets the budget,
+    // which only re-grants retries — never duplicates (coord POST is the
+    // side effect, and an unacked record retries anyway).
+    let mut helper_task_attempts: HashMap<(Uuid, i64), u32> = HashMap::new();
     loop {
         let pending = match inner.outbox.pending() {
             Ok(p) => p,
@@ -518,12 +529,49 @@ async fn run_drain_loop(inner: Arc<CoordSyncInner>) {
 
         for rec in pending {
             match push_record(&inner, &rec).await {
-                PushOutcome::Acked => succeeded.push((rec.session_id, rec.seq)),
+                PushOutcome::Acked => {
+                    succeeded.push((rec.session_id, rec.seq));
+                    helper_task_attempts.remove(&(rec.session_id, rec.seq));
+                }
                 PushOutcome::Conflict { row } => {
                     succeeded.push((rec.session_id, rec.seq));
                     handle_conflict(&inner, &rec, row).await;
                 }
                 PushOutcome::Transport(e) => {
+                    // helper_task_created is BEST-EFFORT: it must never break
+                    // the batch (session lifecycle events queued behind it
+                    // would stall indefinitely). Skip it WITHOUT acking —
+                    // `OutboxWriter::ack` marks exact (session_id, seq) pairs,
+                    // so acking later records leaves this one pending — and
+                    // keep draining. Retried on subsequent ticks up to
+                    // HELPER_TASK_MAX_ATTEMPTS, then Ack-dropped with a warn.
+                    if rec.event_kind == SessionEventKind::HelperTaskCreated.as_str() {
+                        let key = (rec.session_id, rec.seq);
+                        let attempts = helper_task_attempts.entry(key).or_insert(0);
+                        *attempts += 1;
+                        if *attempts >= HELPER_TASK_MAX_ATTEMPTS {
+                            tracing::warn!(
+                                session = %rec.session_id,
+                                seq = rec.seq,
+                                error = %e,
+                                "coord_sync: helper task push failed {HELPER_TASK_MAX_ATTEMPTS} \
+                                 time(s) — dropping (best-effort)"
+                            );
+                            succeeded.push(key);
+                            helper_task_attempts.remove(&key);
+                        } else {
+                            tracing::warn!(
+                                session = %rec.session_id,
+                                seq = rec.seq,
+                                attempt = *attempts,
+                                error = %e,
+                                "coord_sync: helper task push failed — will retry \
+                                 (best-effort; does not block the batch)"
+                            );
+                            had_transport_error = true;
+                        }
+                        continue;
+                    }
                     tracing::warn!(
                         session = %rec.session_id,
                         seq = rec.seq,
@@ -551,6 +599,7 @@ async fn run_drain_loop(inner: Arc<CoordSyncInner>) {
                         "coord_sync: permanent failure — ACKing locally"
                     );
                     succeeded.push((rec.session_id, rec.seq));
+                    helper_task_attempts.remove(&(rec.session_id, rec.seq));
                 }
             }
         }
@@ -649,8 +698,10 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
             // The payload is the full CreateHelperTaskRequest body recorded by
             // HelperTaskRegistrar — forward it verbatim. Auth is the device
             // JWT (attach_device_auth), same as every other coord data-plane
-            // call. A 503 (helper-task tables not migrated yet) is handled
-            // below: dropped with a warn, never retried.
+            // call. Responses take the dedicated best-effort path in
+            // `helper_task_outcome` (201 provenance capture, the
+            // `helper_task_queue_unavailable` 503 drop, bounded retry for
+            // everything else).
             let url = format!("{base}/coord/helper-tasks");
             crate::auth::attach_device_auth(inner.http.post(&url).json(&rec.payload))
                 .send()
@@ -684,6 +735,9 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
 
     match result {
         Ok(resp) => {
+            if kind == "helper_task_created" {
+                return helper_task_outcome(rec, resp).await;
+            }
             let status = resp.status();
             if status.is_success() {
                 return PushOutcome::Acked;
@@ -699,20 +753,6 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
                 }
                 return PushOutcome::Acked;
             }
-            // Helper Task Queue: coord maps un-migrated helper-task tables to
-            // 503 ("feature not available yet"). Retrying can't help until the
-            // operator runs migrations, so drop the row with a warn instead of
-            // entering a backoff loop that would also stall every event queued
-            // behind it.
-            if kind == "helper_task_created" && status == StatusCode::SERVICE_UNAVAILABLE {
-                tracing::warn!(
-                    session = %rec.session_id,
-                    seq = rec.seq,
-                    "coord_sync: POST /coord/helper-tasks returned 503 (helper-task \
-                     tables not migrated) — dropping helper task event"
-                );
-                return PushOutcome::Acked;
-            }
             let detail = resp.text().await.unwrap_or_default();
             if status.is_client_error() {
                 return PushOutcome::PermanentFailure(format!("{status}: {detail}"));
@@ -722,6 +762,71 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
         }
         Err(e) => PushOutcome::Transport(format!("{e}")),
     }
+}
+
+/// Response handling for `helper_task_created` POSTs — best-effort posture.
+///
+/// - **2xx** — the 201 body is the created `HelperTask` (camelCase JSON with
+///   `id` / `appId` / `source.pageId`); its provenance is recorded into the
+///   persisted helper-task store so reflection verdict lines can name the
+///   page/app instead of an unactionable coord task UUID. The store is the
+///   `helper_tasks` module's process-global (`OnceLock`) store, so no state
+///   handle needs plumbing into the drain.
+/// - **503 with body `helper_task_queue_unavailable`** — coord's helper-task
+///   tables aren't migrated; retrying can't help until the operator runs
+///   migrations, so the record is Ack-dropped with a warn.
+/// - **any other 503 (ELB/deploy blip), 5xx** — `Transport`, which the drain
+///   loop maps to a bounded per-record retry that never breaks the batch.
+/// - **4xx** — `PermanentFailure` (Ack-drop), same as other kinds.
+async fn helper_task_outcome(rec: &OutboxRecord, resp: reqwest::Response) -> PushOutcome {
+    let status = resp.status();
+    if status.is_success() {
+        match resp.json::<JsonValue>().await {
+            Ok(body) => {
+                let task_id = body.get("id").and_then(JsonValue::as_str);
+                let app_id = body.get("appId").and_then(JsonValue::as_str);
+                let page_id = body
+                    .pointer("/source/pageId")
+                    .and_then(JsonValue::as_str)
+                    .map(str::to_string);
+                if let (Some(task_id), Some(app_id)) = (task_id, app_id) {
+                    crate::helper_tasks::record_task_metadata(task_id, app_id, page_id);
+                } else {
+                    tracing::debug!(
+                        session = %rec.session_id,
+                        seq = rec.seq,
+                        "coord_sync: helper-task 201 body missing id/appId — provenance skipped"
+                    );
+                }
+            }
+            Err(e) => tracing::debug!(
+                session = %rec.session_id,
+                seq = rec.seq,
+                error = %e,
+                "coord_sync: helper-task 201 body not parseable — provenance skipped"
+            ),
+        }
+        return PushOutcome::Acked;
+    }
+    let detail = resp.text().await.unwrap_or_default();
+    if status == StatusCode::SERVICE_UNAVAILABLE {
+        if detail.contains("helper_task_queue_unavailable") {
+            tracing::warn!(
+                session = %rec.session_id,
+                seq = rec.seq,
+                "coord_sync: POST /coord/helper-tasks returned 503 \
+                 helper_task_queue_unavailable (tables not migrated) — dropping \
+                 helper task event"
+            );
+            return PushOutcome::Acked;
+        }
+        // Transient 503 (ELB / deploy) — bounded-retry, don't drop the task.
+        return PushOutcome::Transport(format!("{status}: {detail}"));
+    }
+    if status.is_client_error() {
+        return PushOutcome::PermanentFailure(format!("{status}: {detail}"));
+    }
+    PushOutcome::Transport(format!("{status}: {detail}"))
 }
 
 /// Reassemble a `POST /sessions` body from the outbox payload + the row's

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -644,6 +644,18 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
                 .send()
                 .await
         }
+        "helper_task_created" => {
+            // Helper Task Queue (plan 2026-06-29-helper-task-queue, Phase 1.3).
+            // The payload is the full CreateHelperTaskRequest body recorded by
+            // HelperTaskRegistrar — forward it verbatim. Auth is the device
+            // JWT (attach_device_auth), same as every other coord data-plane
+            // call. A 503 (helper-task tables not migrated yet) is handled
+            // below: dropped with a warn, never retried.
+            let url = format!("{base}/coord/helper-tasks");
+            crate::auth::attach_device_auth(inner.http.post(&url).json(&rec.payload))
+                .send()
+                .await
+        }
         "commit_report" => {
             // Commit ↔ session lineage push-report (plan
             // 2026-06-07-coord-commit-session-lineage.md, Population path 2).
@@ -685,6 +697,20 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
                     let row = resp.json::<JsonValue>().await.ok();
                     return PushOutcome::Conflict { row };
                 }
+                return PushOutcome::Acked;
+            }
+            // Helper Task Queue: coord maps un-migrated helper-task tables to
+            // 503 ("feature not available yet"). Retrying can't help until the
+            // operator runs migrations, so drop the row with a warn instead of
+            // entering a backoff loop that would also stall every event queued
+            // behind it.
+            if kind == "helper_task_created" && status == StatusCode::SERVICE_UNAVAILABLE {
+                tracing::warn!(
+                    session = %rec.session_id,
+                    seq = rec.seq,
+                    "coord_sync: POST /coord/helper-tasks returned 503 (helper-task \
+                     tables not migrated) — dropping helper task event"
+                );
                 return PushOutcome::Acked;
             }
             let detail = resp.text().await.unwrap_or_default();

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -190,8 +190,10 @@ pub enum SessionEventKind {
     /// Helper Task Queue (plan `2026-06-29-helper-task-queue`, Phase 1.3).
     /// Drained to `POST /coord/helper-tasks`; the payload is the full
     /// `CreateHelperTaskRequest` body recorded by
-    /// [`crate::helper_tasks::HelperTaskRegistrar`]. A coord 503 (helper-task
-    /// tables not migrated yet) is dropped with a warn — never a retry loop.
+    /// [`crate::helper_tasks::HelperTaskRegistrar`]. Best-effort: failures
+    /// never block session events queued behind it (bounded per-record retry,
+    /// then Ack-drop); a coord `helper_task_queue_unavailable` 503
+    /// (helper-task tables not migrated yet) is dropped with a warn.
     HelperTaskCreated,
 }
 

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -187,6 +187,12 @@ pub enum SessionEventKind {
     /// orthogonal to the liveness `Heartbeat`. Emitted on operator interaction
     /// by [`crate::claude_session::coord_register::AiCoordRegistrar::progress_on_interaction`].
     Progress,
+    /// Helper Task Queue (plan `2026-06-29-helper-task-queue`, Phase 1.3).
+    /// Drained to `POST /coord/helper-tasks`; the payload is the full
+    /// `CreateHelperTaskRequest` body recorded by
+    /// [`crate::helper_tasks::HelperTaskRegistrar`]. A coord 503 (helper-task
+    /// tables not migrated yet) is dropped with a warn — never a retry loop.
+    HelperTaskCreated,
 }
 
 impl SessionEventKind {
@@ -201,6 +207,7 @@ impl SessionEventKind {
             SessionEventKind::HandoffRequest => "handoff_request",
             SessionEventKind::CommitReport => "commit_report",
             SessionEventKind::Progress => "progress",
+            SessionEventKind::HelperTaskCreated => "helper_task_created",
         }
     }
 }
@@ -1219,6 +1226,7 @@ mod tests {
             SessionEventKind::OutputChunk,
             SessionEventKind::HandoffRequest,
             SessionEventKind::CommitReport,
+            SessionEventKind::HelperTaskCreated,
         ];
         for k in kinds {
             let json = serde_json::to_string(&k).unwrap();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1417,6 +1417,42 @@ impl From<&MemoryConsolidationSettings> for crate::memory::consolidation::Consol
     }
 }
 
+// ============================================================================
+// Helper Task Queue Settings (plan 2026-06-29-helper-task-queue, Phase 1.3)
+// ============================================================================
+
+/// Owner controls for the Helper Task Queue emit surface.
+///
+/// When `emit_enabled` is true, runner subsystems (currently the yellow-band
+/// spec-check hook in `spec_api::spec_check`) emit human-judgment micro-tasks
+/// to coord's helper-task broker via `helper_tasks::HelperTaskRegistrar`.
+/// `emit_kinds` scopes which task kinds may be emitted — Phase 1 ships only
+/// `"spot_check"`. Default is OFF so no helper tasks leave the runner until
+/// the owner opts in via Settings (Helper Tasks page → Config tab).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HelperTasksSettings {
+    /// Master emit toggle. Default FALSE — opt-in only.
+    #[serde(default)]
+    pub emit_enabled: bool,
+    /// Task kinds the runner may emit (snake_case wire values, e.g.
+    /// `"spot_check"`). Emit sites check membership before emitting.
+    #[serde(default = "default_helper_task_emit_kinds")]
+    pub emit_kinds: Vec<String>,
+}
+
+fn default_helper_task_emit_kinds() -> Vec<String> {
+    vec!["spot_check".to_string()]
+}
+
+impl Default for HelperTasksSettings {
+    fn default() -> Self {
+        Self {
+            emit_enabled: false,
+            emit_kinds: default_helper_task_emit_kinds(),
+        }
+    }
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Default)]
 pub struct Settings {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1574,6 +1610,10 @@ pub struct Settings {
     /// Tier-2 sign-in, cleared on sign-out. `local_user_id` stays alongside.
     #[serde(default)]
     pub qontinui_user_id: Option<String>,
+    /// Helper Task Queue owner controls (emit toggle + allowed kinds).
+    /// Default OFF — see `HelperTasksSettings`.
+    #[serde(default)]
+    pub helper_tasks: HelperTasksSettings,
 }
 
 // ============================================================================
@@ -1810,8 +1850,11 @@ fn default_app_mode() -> String {
     "advanced".to_string()
 }
 
-/// Get the settings file path in the app data directory
-fn get_settings_path() -> Result<PathBuf, String> {
+/// Resolve (and create if missing) the app config directory that holds
+/// `settings.json` and small sibling state files (e.g. the helper-answers
+/// poll cursor). Honors the per-instance `QONTINUI_CONFIG_DIR` override the
+/// supervisor sets for spawned runners.
+pub(crate) fn get_config_dir() -> Result<PathBuf, String> {
     let app_data_dir = std::env::var("QONTINUI_CONFIG_DIR")
         .ok()
         .filter(|s| !s.is_empty())
@@ -1825,7 +1868,12 @@ fn get_settings_path() -> Result<PathBuf, String> {
             .map_err(|e| format!("Failed to create app data directory: {}", e))?;
     }
 
-    Ok(app_data_dir.join(SETTINGS_FILE))
+    Ok(app_data_dir)
+}
+
+/// Get the settings file path in the app data directory
+fn get_settings_path() -> Result<PathBuf, String> {
+    Ok(get_config_dir()?.join(SETTINGS_FILE))
 }
 
 /// Load settings from file
@@ -2534,6 +2582,20 @@ pub fn save_saved_projects(projects: Vec<SavedProject>) -> Result<(), String> {
     let mut settings = load_settings();
     settings.saved_projects = projects;
     save_settings(&settings)
+}
+
+// ============================================================================
+// Helper Task Queue accessors
+// ============================================================================
+
+/// Get the current Helper Task Queue settings.
+pub fn get_helper_tasks_settings() -> HelperTasksSettings {
+    crate::config_facade::get_setting::<HelperTasksSettings>()
+}
+
+/// Save Helper Task Queue settings.
+pub fn save_helper_tasks_settings(helper_tasks: HelperTasksSettings) -> Result<(), String> {
+    crate::config_facade::save_setting(helper_tasks)
 }
 
 // ============================================================================

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -718,19 +718,15 @@ pub async fn post_spec_check(
         req.page_id, snapshot_id, result.summary.match_outcome, result.summary.overall_match_rate, result.classification
     );
 
-    // Helper Task Queue (plan 2026-06-29, Phase 1.3 Part B): a Yellow
-    // (partial-match) classification is exactly the ambiguous band a human
-    // spot-check resolves cheaply — Green needs no help and Red is already a
-    // hard failure. Owner-gated (settings.helper_tasks, default OFF) inside
-    // maybe_emit_spot_check; best-effort and never affects the response.
-    if result.classification == ClassificationStatus::Yellow {
-        crate::helper_tasks::maybe_emit_spot_check(
-            &state.app_handle,
-            &req.app_id,
-            &req.page_id,
-            f64::from(result.summary.overall_match_rate),
-        );
-    }
+    // Helper Task Queue (plan 2026-06-29, Phase 1.3 Part B) — see
+    // maybe_emit_yellow_spot_check (shared with both batch paths via
+    // evaluate_one).
+    maybe_emit_yellow_spot_check(
+        crate::helper_tasks::registrar_from_app(&state.app_handle).as_ref(),
+        &req.app_id,
+        &req.page_id,
+        &result,
+    );
 
     // Plan 06: emit Completed after the evaluator returns. The full result
     // body stays out of the broadcast (subscribers join by snapshot_id).
@@ -932,6 +928,12 @@ pub async fn post_spec_check_batch(
     };
     let app_arc = Arc::new(app_option);
 
+    // Helper Task Queue (Phase 1.3 Part B): resolve the registrar handle ONCE,
+    // outside any stream/task closure — an Arc-backed clone is cheap, and
+    // capturing it before construction is what lets the NDJSON unfold closure
+    // (which has no Tauri state handle) participate in the yellow-band emit.
+    let helper_registrar = crate::helper_tasks::registrar_from_app(&state.app_handle);
+
     if req.stream {
         return stream_batch_results(
             req.app_id.clone(),
@@ -943,6 +945,7 @@ pub async fn post_spec_check_batch(
             req.pages,
             req.shared_policy,
             app_arc,
+            helper_registrar,
         )
         .await;
     }
@@ -958,6 +961,7 @@ pub async fn post_spec_check_batch(
         let fingerprint_owned = fingerprint.clone();
         let content_hash_owned = content_hash.clone();
         let app_owned = app_arc.clone();
+        let registrar_owned = helper_registrar.clone();
         set.spawn(async move {
             evaluate_one(
                 &app_id_owned,
@@ -969,6 +973,7 @@ pub async fn post_spec_check_batch(
                 &content_hash_owned,
                 shared_policy.as_ref(),
                 (*app_owned).as_ref(),
+                registrar_owned.as_ref(),
             )
             .await
         });
@@ -985,23 +990,6 @@ pub async fn post_spec_check_batch(
     }
     // Stable order by input pageId for determinism.
     results.sort_by(|a, b| a.page_id.cmp(&b.page_id));
-
-    // Helper Task Queue (Phase 1.3 Part B) — same Yellow-band hook as the
-    // single-shot handler, applied per evaluated page. Owner-gated + best-effort
-    // inside maybe_emit_spot_check. (The NDJSON streaming path is not hooked —
-    // its unfold closure has no handle to Tauri state.)
-    for r in results.iter().filter(|r| r.status == "ok") {
-        if let Some(res) = r.result.as_ref() {
-            if res.classification == ClassificationStatus::Yellow {
-                crate::helper_tasks::maybe_emit_spot_check(
-                    &state.app_handle,
-                    &req.app_id,
-                    &r.page_id,
-                    f64::from(res.summary.overall_match_rate),
-                );
-            }
-        }
-    }
 
     // Plan 06: emit Completed once after all per-element evaluations have
     // landed. The `eval_error_count` derives from input vs successfully-evaluated.
@@ -1103,6 +1091,33 @@ impl BatchElementResult {
     }
 }
 
+/// Helper Task Queue (plan 2026-06-29, Phase 1.3 Part B): the ONE yellow-band
+/// spot-check emit shared by all three handler paths (single-shot, batch
+/// collected, batch NDJSON — the latter two via [`evaluate_one`]). A Yellow
+/// (partial-match) classification is exactly the ambiguous band a human
+/// spot-check resolves cheaply — Green needs no help and Red is already a
+/// hard failure. Owner-gated (settings.helper_tasks, default OFF) and
+/// cooldown-gated inside the registrar; best-effort and never affects the
+/// response. `None` registrar (early boot, tests) is a silent no-op.
+fn maybe_emit_yellow_spot_check(
+    registrar: Option<&crate::helper_tasks::HelperTaskRegistrar>,
+    app_id: &str,
+    page_id: &str,
+    result: &SpecCheckResult,
+) {
+    if result.classification != ClassificationStatus::Yellow {
+        return;
+    }
+    if let Some(reg) = registrar {
+        crate::helper_tasks::maybe_emit_spot_check(
+            reg,
+            app_id,
+            page_id,
+            f64::from(result.summary.overall_match_rate),
+        );
+    }
+}
+
 /// Evaluate one batch entry. Identical to the single-shot handler except
 /// errors become per-element statuses, not HTTP responses (§5.14).
 #[allow(clippy::too_many_arguments)]
@@ -1116,6 +1131,7 @@ async fn evaluate_one(
     content_sha256: &str,
     shared_policy: Option<&SpecCheckPolicy>,
     app_option: Option<&qontinui_types::apps::App>,
+    helper_registrar: Option<&crate::helper_tasks::HelperTaskRegistrar>,
 ) -> BatchElementResult {
     if invalid_page_id(&entry.page_id) {
         return BatchElementResult::invalid_page_id(entry.page_id.clone());
@@ -1141,6 +1157,11 @@ async fn evaluate_one(
 
     // Apply app-specific thresholds to the evaluation result
     apply_thresholds_to_result(&mut result, app_option);
+
+    // Shared classification site for both batch paths (collected + NDJSON).
+    // Runs AFTER threshold application so the Yellow-band check sees the
+    // final (app-adjusted) classification, matching the single-shot path.
+    maybe_emit_yellow_spot_check(helper_registrar, app_id, &entry.page_id, &result);
 
     // Per-entry override wins over the shared policy.
     let policy = entry.policy_override.as_ref().or(shared_policy);
@@ -1177,6 +1198,9 @@ async fn stream_batch_results(
     pages: Vec<BatchPageEntry>,
     shared_policy: Option<SpecCheckPolicy>,
     app_option: Arc<Option<qontinui_types::apps::App>>,
+    // Cloned OUT of Tauri state by the caller so the unfold closure below can
+    // own it — Arc-backed, so per-iteration clones are cheap.
+    helper_registrar: Option<crate::helper_tasks::HelperTaskRegistrar>,
 ) -> Response {
     // Plan 06: stream-path Completed emission. Accumulate counts as we
     // walk each item, then emit on stream end (when the inner iterator is
@@ -1214,6 +1238,7 @@ async fn stream_batch_results(
         let fingerprint = fingerprint.clone();
         let content_hash = content_hash.clone();
         let app_option = app_option.clone();
+        let helper_registrar = helper_registrar.clone();
         async move {
             let entry = match st.iter.next() {
                 Some(e) => e,
@@ -1253,6 +1278,7 @@ async fn stream_batch_results(
                 &content_hash,
                 shared_policy.as_ref(),
                 (*app_option).as_ref(),
+                helper_registrar.as_ref(),
             )
             .await;
             match (r.status, r.result.as_ref()) {
@@ -1431,6 +1457,7 @@ mod tests {
             "",
             None,
             None,
+            None,
         )
         .await;
         assert_eq!(r.status, "spec-not-found");
@@ -1457,6 +1484,7 @@ mod tests {
             "scs_test",
             &fp,
             "",
+            None,
             None,
             None,
         )
@@ -1526,6 +1554,7 @@ mod tests {
             "scs_test",
             &fp,
             "",
+            None,
             None,
             None,
         )
@@ -1612,6 +1641,7 @@ mod tests {
             &fp,
             "",
             Some(&policy),
+            None,
             None,
         )
         .await;

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -26,7 +26,8 @@ use crate::spec_api::storage::{self, RUNNER_APP_ID};
 use qontinui_spec_check as spec_check; // crate name = "qontinui-spec-check"
 use qontinui_types::spec_api_events::SpecApiEvent;
 use qontinui_types::spec_check::{
-    MatchOutcome, PolicyEvaluation, SpecCheckPolicy, SpecCheckResult, ThresholdConfig,
+    ClassificationStatus, MatchOutcome, PolicyEvaluation, SpecCheckPolicy, SpecCheckResult,
+    ThresholdConfig,
 };
 use qontinui_types::ui_bridge::UIBridgeSnapshot; // capital UI; lives in ui_bridge
 
@@ -717,6 +718,20 @@ pub async fn post_spec_check(
         req.page_id, snapshot_id, result.summary.match_outcome, result.summary.overall_match_rate, result.classification
     );
 
+    // Helper Task Queue (plan 2026-06-29, Phase 1.3 Part B): a Yellow
+    // (partial-match) classification is exactly the ambiguous band a human
+    // spot-check resolves cheaply — Green needs no help and Red is already a
+    // hard failure. Owner-gated (settings.helper_tasks, default OFF) inside
+    // maybe_emit_spot_check; best-effort and never affects the response.
+    if result.classification == ClassificationStatus::Yellow {
+        crate::helper_tasks::maybe_emit_spot_check(
+            &state.app_handle,
+            &req.app_id,
+            &req.page_id,
+            f64::from(result.summary.overall_match_rate),
+        );
+    }
+
     // Plan 06: emit Completed after the evaluator returns. The full result
     // body stays out of the broadcast (subscribers join by snapshot_id).
     // Stream D: emit on the request's `app_id` channel.
@@ -970,6 +985,23 @@ pub async fn post_spec_check_batch(
     }
     // Stable order by input pageId for determinism.
     results.sort_by(|a, b| a.page_id.cmp(&b.page_id));
+
+    // Helper Task Queue (Phase 1.3 Part B) — same Yellow-band hook as the
+    // single-shot handler, applied per evaluated page. Owner-gated + best-effort
+    // inside maybe_emit_spot_check. (The NDJSON streaming path is not hooked —
+    // its unfold closure has no handle to Tauri state.)
+    for r in results.iter().filter(|r| r.status == "ok") {
+        if let Some(res) = r.result.as_ref() {
+            if res.classification == ClassificationStatus::Yellow {
+                crate::helper_tasks::maybe_emit_spot_check(
+                    &state.app_handle,
+                    &req.app_id,
+                    &r.page_id,
+                    f64::from(res.summary.overall_match_rate),
+                );
+            }
+        }
+    }
 
     // Plan 06: emit Completed once after all per-element evaluations have
     // landed. The `eval_error_count` derives from input vs successfully-evaluated.

--- a/src/components/app/TabContent.tsx
+++ b/src/components/app/TabContent.tsx
@@ -73,6 +73,7 @@ import { OrchestrationLoopPanel } from "@/components/orchestration-loop/Orchestr
 import { MetaOptimizerPage } from "@/pages/MetaOptimizerPage";
 import { OnlineLearningDashboard } from "@/components/online-learning/OnlineLearningDashboard";
 import { SpecsPage } from "@/pages/specs/SpecsPage";
+import { HelperTasksPage } from "@/pages/helper-tasks/HelperTasksPage";
 import { UIBridgeIntegrationPage } from "@/pages/ui-bridge-integration/UIBridgeIntegrationPage";
 import { WrappersLibraryPage } from "@/pages/wrappers/WrappersLibraryPage";
 import { UIBridgeStateMachinePage } from "@/pages/state-machine";
@@ -800,6 +801,18 @@ export function TabContent({
               setActiveTab("unified-workflow-builder");
             }}
           />
+        </div>
+      );
+
+    case "helper-tasks":
+      return (
+        <div data-page-id="helper-tasks" className="h-full overflow-hidden">
+          <PageRegistration
+            id="helper-tasks"
+            name="Helper Tasks"
+            description="Helper Task Queue — emit settings, collected helper answers, and helper invites"
+          />
+          <HelperTasksPage />
         </div>
       );
 

--- a/src/components/app/tab-types.ts
+++ b/src/components/app/tab-types.ts
@@ -105,7 +105,8 @@ export type MainTabId =
   | "wrappers"
   | "productivity"
   | "regression"
-  | "memory-federation";
+  | "memory-federation"
+  | "helper-tasks";
 
 const VALID_TAB_IDS: MainTabId[] = [
   "prompt-home",
@@ -213,6 +214,7 @@ const VALID_TAB_IDS: MainTabId[] = [
   "productivity",
   "regression",
   "memory-federation",
+  "helper-tasks",
 ];
 
 export const SIDEBAR_COLLAPSED_KEY = "qontinui-sidebar-collapsed";
@@ -331,6 +333,7 @@ export const TAB_LABELS: Record<MainTabId, string> = {
   productivity: "Productivity",
   regression: "Regression",
   "memory-federation": "Memory Federation",
+  "helper-tasks": "Helper Tasks",
 };
 
 /**
@@ -364,6 +367,7 @@ const NAV_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
   "wrappers",
   "productivity",
   "regression",
+  "helper-tasks",
 ]);
 
 /**

--- a/src/pages/helper-tasks/HelperTasksPage.tsx
+++ b/src/pages/helper-tasks/HelperTasksPage.tsx
@@ -1,0 +1,405 @@
+/**
+ * HelperTasksPage — Helper Task Queue owner surface (plan
+ * 2026-06-29-helper-task-queue, Phase 1.3 Part E).
+ *
+ * Three sub-tabs:
+ *   - "Config" — owner emit toggle (`helper_tasks.emit_enabled`, default OFF)
+ *     plus per-kind checkboxes, wired to the `get_helper_tasks_settings` /
+ *     `save_helper_tasks_settings` Tauri commands.
+ *   - "Review" — the helper answers collected by the background poll
+ *     (`get_helper_answers`), newest first.
+ *   - "Invite" — static explainer + deep link to the web app's team invite
+ *     page for adding a helper with the HELPER role.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CheckCircle2,
+  HelpCircle,
+  Loader2,
+  MessageSquare,
+  RefreshCw,
+  Settings as SettingsIcon,
+  ThumbsDown,
+  ThumbsUp,
+  UserPlus,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types (mirror the Rust shapes)
+// ---------------------------------------------------------------------------
+
+interface TauriResult<T> {
+  success: boolean;
+  message?: string;
+  data?: T;
+}
+
+/** Mirrors `settings::HelperTasksSettings` (snake_case serde). */
+interface HelperTasksSettings {
+  emit_enabled: boolean;
+  emit_kinds: string[];
+}
+
+/** Mirrors `qontinui_types::helper_task::HelperAnswer` (camelCase serde). */
+interface HelperAnswer {
+  id: string;
+  taskId: string;
+  helperUserId: string;
+  verdict: string;
+  reasons: string[];
+  freeText?: string | null;
+  createdAt: string;
+}
+
+/** Phase 1 ships spot_check only; the rest land with Phase 2/3. */
+const KNOWN_KINDS: ReadonlyArray<{ id: string; label: string; available: boolean }> = [
+  { id: "spot_check", label: "Spot check — “does this page look right?”", available: true },
+  { id: "compare", label: "Compare — “which of these looks better?” (Phase 2)", available: false },
+  { id: "walk_through", label: "Walk-through — guided flow check (Phase 2/3)", available: false },
+];
+
+const INVITE_URL = "https://qontinui.io/settings/team";
+
+type SubTab = "config" | "review" | "invite";
+
+const SUB_TABS: ReadonlyArray<{
+  id: SubTab;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}> = [
+  { id: "config", label: "Config", icon: SettingsIcon },
+  { id: "review", label: "Review", icon: MessageSquare },
+  { id: "invite", label: "Invite", icon: UserPlus },
+];
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function HelperTasksPage(): React.JSX.Element {
+  const [activeSubTab, setActiveSubTab] = useState<SubTab>("config");
+
+  return (
+    <div className="flex h-full flex-col">
+      <div
+        role="tablist"
+        aria-label="Helper Tasks sub-tabs"
+        className="flex items-center gap-1 border-b border-border-primary px-4"
+      >
+        {SUB_TABS.map((t) => {
+          const Icon = t.icon;
+          const isActive = t.id === activeSubTab;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setActiveSubTab(t.id)}
+              className={[
+                "inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 -mb-px",
+                isActive
+                  ? "border-brand-primary text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary",
+              ].join(" ")}
+            >
+              <Icon className="size-3.5" />
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {activeSubTab === "config" && <ConfigTab />}
+        {activeSubTab === "review" && <ReviewTab />}
+        {activeSubTab === "invite" && <InviteTab />}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Config tab
+// ---------------------------------------------------------------------------
+
+function ConfigTab(): React.JSX.Element {
+  const [settings, setSettings] = useState<HelperTasksSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedFlash, setSavedFlash] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    invoke<TauriResult<HelperTasksSettings>>("get_helper_tasks_settings")
+      .then((result) => {
+        if (cancelled) return;
+        if (result?.success && result.data) {
+          setSettings(result.data);
+        } else {
+          setError(result?.message ?? "Failed to load Helper Task settings");
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setError(String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = useCallback(async (next: HelperTasksSettings) => {
+    setSettings(next);
+    setSaving(true);
+    setError(null);
+    try {
+      await invoke<TauriResult<void>>("save_helper_tasks_settings", {
+        helperTasksSettings: next,
+      });
+      setSavedFlash(true);
+      setTimeout(() => setSavedFlash(false), 1500);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 p-6 text-sm text-text-muted">
+        <Loader2 className="size-4 animate-spin" /> Loading settings…
+      </div>
+    );
+  }
+
+  const current: HelperTasksSettings = settings ?? {
+    emit_enabled: false,
+    emit_kinds: ["spot_check"],
+  };
+
+  const toggleKind = (kind: string, checked: boolean) => {
+    const kinds = checked
+      ? Array.from(new Set([...current.emit_kinds, kind]))
+      : current.emit_kinds.filter((k) => k !== kind);
+    void save({ ...current, emit_kinds: kinds });
+  };
+
+  return (
+    <div className="max-w-2xl space-y-6 p-6">
+      <div>
+        <h2 className="text-base font-semibold text-text-primary">Helper Task emission</h2>
+        <p className="mt-1 text-sm text-text-muted">
+          When enabled, this runner emits small human-judgment tasks (e.g. “does this page look
+          right?”) to your team&apos;s helpers whenever a spec-check lands in the partial-match
+          (yellow) band. Answers flow back into reflection as high-signal fix targets. Default is
+          off — nothing leaves the runner until you opt in.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded border border-status-error/40 bg-status-error/10 p-3 text-sm text-status-error">
+          {error}
+        </div>
+      )}
+
+      <label className="flex items-center gap-3">
+        <input
+          type="checkbox"
+          className="size-4"
+          checked={current.emit_enabled}
+          disabled={saving}
+          onChange={(e) => void save({ ...current, emit_enabled: e.target.checked })}
+        />
+        <span className="text-sm font-medium text-text-primary">Emit helper tasks</span>
+        {saving && <Loader2 className="size-3.5 animate-spin text-text-muted" />}
+        {savedFlash && !saving && <CheckCircle2 className="size-3.5 text-status-success" />}
+      </label>
+
+      <div>
+        <h3 className="text-sm font-medium text-text-primary">Task kinds</h3>
+        <p className="mb-2 mt-0.5 text-xs text-text-muted">
+          Which kinds of tasks this runner may emit.
+        </p>
+        <div className="space-y-2">
+          {KNOWN_KINDS.map((kind) => (
+            <label
+              key={kind.id}
+              className={["flex items-center gap-3", kind.available ? "" : "opacity-50"].join(" ")}
+            >
+              <input
+                type="checkbox"
+                className="size-4"
+                checked={current.emit_kinds.includes(kind.id)}
+                disabled={saving || !kind.available || !current.emit_enabled}
+                onChange={(e) => toggleKind(kind.id, e.target.checked)}
+              />
+              <span className="text-sm text-text-primary">{kind.label}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Review tab
+// ---------------------------------------------------------------------------
+
+function verdictBadge(verdict: string): React.JSX.Element {
+  switch (verdict) {
+    case "approve":
+      return (
+        <span className="inline-flex items-center gap-1 rounded bg-status-success/15 px-2 py-0.5 text-xs font-medium text-status-success">
+          <ThumbsUp className="size-3" /> approve
+        </span>
+      );
+    case "reject":
+      return (
+        <span className="inline-flex items-center gap-1 rounded bg-status-error/15 px-2 py-0.5 text-xs font-medium text-status-error">
+          <ThumbsDown className="size-3" /> reject
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-flex items-center gap-1 rounded bg-bg-tertiary px-2 py-0.5 text-xs font-medium text-text-muted">
+          <HelpCircle className="size-3" /> {verdict}
+        </span>
+      );
+  }
+}
+
+function ReviewTab(): React.JSX.Element {
+  const {
+    data,
+    isFetching,
+    error: queryError,
+    refetch,
+  } = useQuery<HelperAnswer[]>({
+    queryKey: ["helper-answers"],
+    queryFn: async () => {
+      const result = await invoke<TauriResult<HelperAnswer[]>>("get_helper_answers");
+      if (!result?.success || !result.data) {
+        throw new Error(result?.message ?? "Failed to load helper answers");
+      }
+      return result.data;
+    },
+  });
+
+  const answers = data ?? [];
+  const loading = isFetching;
+  const error = queryError ? String(queryError) : null;
+  const refresh = () => void refetch();
+
+  return (
+    <div className="max-w-3xl space-y-4 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-text-primary">Helper answers</h2>
+          <p className="mt-1 text-sm text-text-muted">
+            Verdicts your helpers submitted for tasks this runner emitted. The runner polls coord
+            every minute while emission is enabled; answers also feed the reflection agent
+            automatically.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          className="inline-flex items-center gap-1.5 rounded border border-border-primary px-2.5 py-1.5 text-sm text-text-primary hover:bg-bg-tertiary"
+        >
+          <RefreshCw className={["size-3.5", loading ? "animate-spin" : ""].join(" ")} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded border border-status-error/40 bg-status-error/10 p-3 text-sm text-status-error">
+          {error}
+        </div>
+      )}
+
+      {!loading && answers.length === 0 && !error && (
+        <div className="rounded border border-border-primary p-6 text-center text-sm text-text-muted">
+          No helper answers yet. Enable emission in the Config tab and invite a helper — answers
+          appear here as they come back.
+        </div>
+      )}
+
+      <ul className="space-y-2">
+        {[...answers].reverse().map((a) => (
+          <li key={a.id} className="rounded border border-border-primary p-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                {verdictBadge(a.verdict)}
+                <span className="font-mono text-xs text-text-muted">task {a.taskId}</span>
+              </div>
+              <span className="text-xs text-text-muted">{a.createdAt}</span>
+            </div>
+            {a.reasons.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {a.reasons.map((r) => (
+                  <span
+                    key={r}
+                    className="rounded-full bg-bg-tertiary px-2 py-0.5 text-xs text-text-primary"
+                  >
+                    {r}
+                  </span>
+                ))}
+              </div>
+            )}
+            {a.freeText && (
+              <p className="mt-2 text-sm text-text-primary">&ldquo;{a.freeText}&rdquo;</p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Invite tab
+// ---------------------------------------------------------------------------
+
+function InviteTab(): React.JSX.Element {
+  return (
+    <div className="max-w-2xl space-y-4 p-6">
+      <h2 className="text-base font-semibold text-text-primary">Invite a helper</h2>
+      <p className="text-sm text-text-muted">
+        Helpers are non-technical teammates who answer small judgment questions — no code access, no
+        dev tooling. They review a screenshot or a live page in a stripped-down portal and tap
+        approve / reject / not-sure, optionally with a reason. Their verdicts flow back into this
+        runner&apos;s reflection loop.
+      </p>
+      <ol className="list-decimal space-y-2 pl-5 text-sm text-text-primary">
+        <li>
+          Open your team settings in the web app and invite the person with the{" "}
+          <span className="font-mono text-xs">HELPER</span> role.
+        </li>
+        <li>They sign in and see only the helper portal — open tasks for your apps.</li>
+        <li>
+          Enable “Emit helper tasks” in the Config tab here so this runner starts publishing
+          spot-checks for them to answer.
+        </li>
+      </ol>
+      <a
+        href={INVITE_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center gap-1.5 rounded bg-brand-primary px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+      >
+        <UserPlus className="size-3.5" />
+        Open team invite page
+      </a>
+      <p className="text-xs text-text-muted">{INVITE_URL}</p>
+    </div>
+  );
+}

--- a/src/pages/helper-tasks/index.ts
+++ b/src/pages/helper-tasks/index.ts
@@ -1,0 +1,1 @@
+export { HelperTasksPage } from "./HelperTasksPage";


### PR DESCRIPTION
## What

Phase 1.3 of the **Helper Task Queue** (plan `2026-06-29-helper-task-queue-non-programmer-dev`): the runner becomes producer + consumer of human-judgment micro-tasks.

- **Producer:** `HelperTaskRegistrar` on the outbox→CoordSync-drain pattern (new `SessionEventKind::HelperTaskCreated` → `POST /coord/helper-tasks`, device JWT). Emits a SpotCheck when a spec-check classifies **Yellow** (partial match), from the shared classification site covering all three handler paths (single, JSON batch, NDJSON streaming). Gated by new `helper_tasks` settings (**default OFF**) + a 24h per-(app,page) emit cooldown.
- **Drain semantics:** helper-task records are best-effort — they never head-of-line-block session lifecycle events (skip-without-ack, bounded 3-attempt budget, then drop-with-warn). Only a 503 carrying coord's `helper_task_queue_unavailable` marker (tables not migrated) is dropped immediately; transient 503s retry.
- **Consumer:** 60s poller on `GET /coord/helper-tasks/answers` with a persisted cursor (2s overlap, idempotent replay) + **persisted answer store** (restart-safe) + task provenance captured from the drain's 201 response. Runs whenever emit is on OR outstanding work exists.
- **Reflection:** verdicts <24h old folded into all three reflection prompt variants as "Human helper verdicts" naming the **page/app** — an approve confirms, a reject with reasons is a high-signal fix target. Verdict revisions (coord same-id upserts) replace stale entries.
- **Owner UI:** Helper Tasks page — Config (emit toggle + kinds), Review (collected verdicts), Invite (link to web team invite). Sidebar item ships via qontinui-navigation#9 (+publish); the page is reachable now via tab activation (`tabId: helper-tasks`).

## Review

High-effort multi-agent review run pre-PR; **10 confirmed findings fixed** in the second commit (restart data loss, drain head-of-line blocking, dropped verdict revisions, context-less reflection lines, transient-503 drops, duplicate emission, cursor race, toggle-gated collection, stale re-injection, NDJSON path gap).

## Verification

`cargo check` clean (0 warnings) on both commits; tsc/eslint clean. Unit tests (wire-shape, revision-replace, cooldown) run in CI — the local test-binary link exceeds this environment's process window; local pre-commit clippy bypassed for the same reason (CI clippy is authoritative).

## Siblings

coord #853 (merged — broker/routes), web migration #682 (landed), web portal #702 (open), qontinui-navigation #9 (open).

Note: emitted screenshots are Phase-1-deferred (capture at the spec-check site needs auth/project context not available there); the portal renders prompt-only tasks fine.