### PR TITLE
fix(release): pass --target to tauri CLI itself (pnpm does not eat the '--')

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,12 +257,11 @@ jobs:
 
       # Tauri's NSIS bundler auto-downloads its toolset (makensis + plugins) and
       # the WebView2 bootstrapper into %LOCALAPPDATA%\tauri on first use. On a
-      # fresh windows-latest runner that download has to happen every run, and
-      # when it is missing/incomplete the bundler aborts immediately after
-      # "Built application" with a bare "cannot find the file specified
-      # (os error 2)" (issue #654). Caching that dir makes the toolset present
-      # on cache-hit and persists a successful download across runs on miss.
-      # Keyed on the OS so each platform gets its own cache slot.
+      # fresh windows-latest runner that download happens every run; caching the
+      # dir skips it on cache-hit. (Note: the recurring "os error 2" at bundle
+      # start, once suspected to be this download — issue #654 — was actually
+      # the --target flag being hidden from tauri behind `--`; see the Build
+      # step below.) Keyed on the OS so each platform gets its own cache slot.
       - name: Cache Tauri bundler toolchain
         uses: actions/cache@v4
         with:
@@ -288,10 +287,14 @@ jobs:
         # env:
         #   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         #   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        # --verbose surfaces the exact bundler step/file if bundling fails
-        # (the terse "cannot find the file specified (os error 2)" otherwise
-        # hides which resource/tool Tauri couldn't resolve).
-        run: pnpm run tauri build --verbose ${{ matrix.bundles && format('--bundles {0}', matrix.bundles) || '' }} -- --target ${{ matrix.target }}
+        # --target must be tauri's OWN flag, not behind `--`. Under npm the
+        # first `--` was eaten by npm itself, so tauri saw `--target`; pnpm
+        # passes `--` through verbatim, which made tauri forward --target to
+        # cargo only. Cargo then wrote the exe to target/<triple>/release/
+        # while the bundler (unaware of the target) looked in target/release/
+        # — the root cause of the "cannot find the file specified (os error
+        # 2)" right after "Built application" on every 1.0.x release run.
+        run: pnpm run tauri build --verbose ${{ matrix.bundles && format('--bundles {0}', matrix.bundles) || '' }} --target ${{ matrix.target }}
 
       # - name: Sign Windows executable
       #   if: runner.os == 'Windows'
@@ -322,8 +325,11 @@ jobs:
 
       - name: Generate checksums
         shell: bash
+        # The repo root is a cargo workspace, so build artifacts land in the
+        # workspace-root target/ dir (target/<triple>/release/bundle), not
+        # src-tauri/target/.
         run: |
-          cd src-tauri/target/${{ matrix.target }}/release/bundle
+          cd target/${{ matrix.target }}/release/bundle
 
           if [[ "${{ matrix.platform }}" == "ubuntu-22.04" ]]; then
             sha256sum deb/*.deb appimage/*.AppImage > checksums-${{ matrix.name }}.txt
@@ -341,9 +347,9 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
-            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
-            src-tauri/target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
+            target/${{ matrix.target }}/release/bundle/deb/*.deb
+            target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -354,8 +360,8 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
-            src-tauri/target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
+            target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -366,8 +372,8 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
-            src-tauri/target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
+            target/${{ matrix.target }}/release/bundle/nsis/*.exe
+            target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem
Every 1.0.x release run has failed on the Windows NSIS leg with a bare `failed to bundle project: The system cannot find the file specified (os error 2)` right after "Built application". The published v1.0.0 installer never came from CI. Prior fixes (resources glob revert in #681, NSIS preinstall, bundler-toolchain cache) chased the wrong cause.

## Root cause
`pnpm run tauri build ... -- --target <triple>`. Under **npm**, the first `--` is consumed by npm itself, so tauri received `--target` as its own flag (that is why the pre-pnpm v0.0.5-alpha release worked). **pnpm passes `--` through verbatim** — the failing job log shows `npx tauri "build" ... "--" "--target" "x86_64-pc-windows-msvc"` — so tauri forwarded `--target` to cargo only. Cargo wrote the exe to `target/x86_64-pc-windows-msvc/release/`, while the bundler (unaware of any target) looked in `target/release/` and aborted on its first file copy. The 1.0.1 job log confirms: `Built [tauri_cli::build] application at: ...\target\release\qontinui-runner.exe` (no triple), then the os-error-2 failure 30 ms later.

## Fix
1. Drop the `--` so `--target` is tauri's own flag; the bundler then resolves `target/<triple>/release/` correctly.
2. Fix the checksum/upload asset paths: the repo is a cargo workspace, so bundles land under the workspace-root `target/`, not `src-tauri/target/` (latent — never reached because the build always died first).
3. Correct the bundler-toolchain-cache comment that attributed the os-error-2 to the NSIS toolset download (issue #654).

## Validation
- Job-log evidence above (run 28623171479 vs the v0.0.5-alpha-era invocation).
- Runtime proof requires a tag run: after merge, re-push the `v1.0.1` tag (draft release currently has zero assets, so re-cutting loses nothing) and confirm the Windows job uploads `Qontinui.Runner_1.0.1_x64-setup.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
