### PR TITLE
feat(devenv): in-app enrollment — Tauri command + settings panel (Phase 2)

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -1136,58 +1136,19 @@ fn active_profile_dsn() -> Result<String, String> {
 // `qontinui_runner_lib::env_agent` so the runner GUI's background task and this
 // CLI share one code path.
 
-/// Wire shape of the enroll request body. Conforms EXACTLY to the backend
-/// contract: `{ enrollment_code, machine_id?, hostname? }`.
-#[derive(Debug, Serialize)]
-struct EnrollRequest {
-    enrollment_code: String,
-    machine_id: Option<String>,
-    hostname: Option<String>,
-}
-
-/// Wire shape of the enroll response. The backend returns the machine key ONCE
-/// — we store it immediately. `environment_id` is sourced from HERE, never
-/// hardcoded.
-#[derive(Debug, Deserialize)]
-struct EnrollResponse {
-    machine_id: String,
-    machine_key: String,
-    #[serde(default)]
-    environment_id: Option<String>,
-}
-
-/// Resolve the web backend base URL for the enroll POST. Order:
-/// `--backend` → `QONTINUI_WEB_BASE` → web base derived from the active
-/// profile's coord_url (`derive_web_base_from_coord(coord_http_base())`).
-fn resolve_env_backend_base(backend_arg: Option<&str>) -> Result<String, String> {
-    if let Some(b) = backend_arg {
-        let t = b.trim();
-        if !t.is_empty() {
-            return Ok(t.trim_end_matches('/').to_string());
-        }
-    }
-    if let Ok(v) = std::env::var("QONTINUI_WEB_BASE") {
-        let t = v.trim();
-        if !t.is_empty() {
-            return Ok(t.trim_end_matches('/').to_string());
-        }
-    }
-    let coord_base = coord_http_base()
-        .map_err(|e| format!("could not resolve a backend URL (no --backend, no QONTINUI_WEB_BASE, and coord_url unavailable: {e})"))?;
-    Ok(derive_web_base_from_coord(&coord_base))
-}
-
 fn cmd_env_enroll(
     code: &str,
     backend_arg: Option<&str>,
     environment_arg: Option<&str>,
 ) -> ExitCode {
+    use qontinui_runner_lib::env_agent::enroll::{self, EnrollParams};
+
     if code.trim().is_empty() {
         eprintln!("error: --code requires a non-empty enrollment code");
         return ExitCode::from(2);
     }
 
-    let backend = match resolve_env_backend_base(backend_arg) {
+    let backend = match enroll::resolve_backend_base(backend_arg) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("error: {e}");
@@ -1195,117 +1156,40 @@ fn cmd_env_enroll(
         }
     };
 
-    // machine_id + hostname come from the existing device-file reader. A
-    // machine.json is expected (run `qontinui_profile device init` first), but
-    // we tolerate its absence by sending nulls — the backend may assign a
+    // machine_id + hostname come from ~/.qontinui/machine.json (run
+    // `qontinui_profile device init` first for a stable identity). Absence is
+    // tolerated — the shared core sends nulls and the backend may assign a
     // machine_id.
-    let path = device_file_path();
-    let (machine_id, hostname): (Option<String>, Option<String>) = match path {
-        Some(p) if p.exists() => match read_device_file(&p) {
-            Ok(f) => (Some(f.device_id), Some(f.hostname)),
-            Err(e) => {
-                eprintln!(
-                    "warning: machine.json unreadable ({e}); enrolling with null machine_id/hostname"
-                );
-                (None, None)
-            }
-        },
-        _ => {
-            eprintln!(
-                "note: no ~/.qontinui/machine.json — enrolling with null machine_id/hostname \
-                 (run `qontinui_profile device init` first for a stable identity)"
-            );
-            (None, None)
-        }
-    };
+    let (machine_id, hostname) = enroll::local_machine_identity();
+    if machine_id.is_none() {
+        eprintln!(
+            "note: no readable ~/.qontinui/machine.json — enrolling with null machine_id/hostname \
+             (run `qontinui_profile device init` first for a stable identity)"
+        );
+    }
 
-    let body = EnrollRequest {
-        enrollment_code: code.trim().to_string(),
+    // The POST + key storage + env-agent.json write live in the shared
+    // `env_agent::enroll` core, so this CLI, the in-app Tauri command, and the
+    // (Phase 3) dispatched directive consumer all enroll through one code path.
+    match enroll::run_enroll(EnrollParams {
+        code: code.to_string(),
+        backend,
         machine_id,
         hostname,
-    };
-    let url = format!("{}/api/v1/devenv/agent/enroll", backend);
-    let client = match reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("error: reqwest client build failed: {e}");
-            return ExitCode::from(2);
-        }
-    };
-    let resp = match client.post(&url).json(&body).send() {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("error: POST {url} failed (backend unreachable?): {e}");
-            return ExitCode::from(1);
-        }
-    };
-    let status = resp.status();
-    if !status.is_success() {
-        let body_text = resp
-            .text()
-            .unwrap_or_else(|_| "<unable to read response body>".to_string());
-        eprintln!("error: enroll failed — POST {url} -> HTTP {status}: {body_text}");
-        // Write NOTHING on failure.
-        return ExitCode::from(1);
-    }
-    let parsed: EnrollResponse = match resp.json() {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("error: enroll succeeded but decoding the response failed: {e}");
-            return ExitCode::from(1);
-        }
-    };
-
-    // environment_id ALWAYS comes from the response. The --environment flag is
-    // a diagnostic override only; the response value wins when present.
-    let environment_id = parsed
-        .environment_id
-        .clone()
-        .or_else(|| environment_arg.map(|s| s.to_string()));
-    let environment_id = match environment_id {
-        Some(e) if !e.trim().is_empty() => e,
-        _ => {
-            eprintln!(
-                "error: enroll response did not include an environment_id and none was supplied \
-                 via --environment; refusing to write a half-enrolled config"
+        environment_override: environment_arg.map(|s| s.to_string()),
+    }) {
+        Ok(outcome) => {
+            println!(
+                "enrolled: machine_id={} environment_id={} backend={} (machine key stored)",
+                outcome.machine_id, outcome.environment_id, outcome.backend_url
             );
-            return ExitCode::from(1);
+            ExitCode::SUCCESS
         }
-    };
-
-    // Store the machine key in secure storage FIRST — it is the credential.
-    let storage = match qontinui_runner_lib::secure_storage::SecureStorage::new() {
-        Ok(s) => s,
         Err(e) => {
-            eprintln!("error: could not open secure storage: {e}");
-            return ExitCode::from(2);
+            eprintln!("error: {e}");
+            ExitCode::from(1)
         }
-    };
-    if let Err(e) = storage.store_agent_machine_key(&parsed.machine_key) {
-        eprintln!("error: failed to store machine key: {e}");
-        return ExitCode::from(2);
     }
-
-    // Then write env-agent.json with the RESPONSE environment_id.
-    let cfg = qontinui_runner_lib::env_agent::config::EnvAgentConfig {
-        backend_url: backend.clone(),
-        machine_id: parsed.machine_id.clone(),
-        environment_id: environment_id.clone(),
-        enrolled_at: Some(chrono::Utc::now().to_rfc3339()),
-    };
-    if let Err(e) = cfg.save() {
-        eprintln!("error: enrolled + key stored, but writing env-agent.json failed: {e}");
-        return ExitCode::from(2);
-    }
-
-    println!(
-        "enrolled: machine_id={} environment_id={} backend={} (machine key stored)",
-        parsed.machine_id, environment_id, backend
-    );
-    ExitCode::SUCCESS
 }
 
 fn cmd_env_capture(dry_run: bool) -> ExitCode {

--- a/src-tauri/src/commands/devenv_enroll.rs
+++ b/src-tauri/src/commands/devenv_enroll.rs
@@ -1,0 +1,109 @@
+//! In-app devenv enrollment commands (Phase 2 — no terminal).
+//!
+//! Wrap the shared `env_agent::enroll` core so the runner's Settings UI can
+//! enroll this machine into a web devenv environment without a terminal: the
+//! operator pastes the one-time code and clicks Enroll. `spawn_env_capture()`
+//! (`main.rs`) picks up the mid-session enroll on its next tick — its enrollment
+//! gate is checked INSIDE the loop — so the drift view populates without a
+//! runner restart.
+
+use serde::Serialize;
+use tracing::info;
+
+use qontinui_runner_lib::env_agent::enroll::{self, EnrollParams};
+
+use super::CommandResponse;
+
+/// Current enrollment status for the Settings panel (mirrors `env show`).
+#[derive(Serialize)]
+struct EnrollStatus {
+    enrolled: bool,
+    machine_id: Option<String>,
+    environment_id: Option<String>,
+    backend_url: Option<String>,
+    enrolled_at: Option<String>,
+    /// Whether a machine key is present in secure storage (capture can push).
+    has_key: bool,
+}
+
+/// Enroll this machine into a devenv environment via a one-time code.
+///
+/// `backend` is optional — when omitted it resolves from the active profile's
+/// `coord_url` (same order as the CLI). The enroll POST + key storage + config
+/// write run on a blocking pool via the shared core; nothing is persisted on
+/// failure.
+#[tauri::command]
+pub async fn devenv_enroll(
+    code: String,
+    backend: Option<String>,
+) -> Result<CommandResponse, String> {
+    let outcome = tokio::task::spawn_blocking(move || {
+        let backend = enroll::resolve_backend_base(backend.as_deref())?;
+        let (machine_id, hostname) = enroll::local_machine_identity();
+        enroll::run_enroll(EnrollParams {
+            code,
+            backend,
+            machine_id,
+            hostname,
+            environment_override: None,
+        })
+    })
+    .await
+    .map_err(|e| format!("enroll task panicked: {e}"))??;
+
+    info!(
+        "devenv_enroll: enrolled machine_id={} environment_id={} backend={}",
+        outcome.machine_id, outcome.environment_id, outcome.backend_url
+    );
+
+    Ok(CommandResponse {
+        success: true,
+        message: Some(format!(
+            "Enrolled into environment {} — config capture will start shortly.",
+            outcome.environment_id
+        )),
+        data: Some(
+            serde_json::to_value(outcome).map_err(|e| format!("serialize enroll outcome: {e}"))?,
+        ),
+    })
+}
+
+/// Read the current enrollment status (mirrors `qontinui_profile env show`).
+#[tauri::command]
+pub fn devenv_enroll_status() -> Result<CommandResponse, String> {
+    use qontinui_runner_lib::env_agent::config::EnvAgentConfig;
+
+    let cfg = EnvAgentConfig::load();
+    let has_key = qontinui_runner_lib::secure_storage::SecureStorage::new()
+        .ok()
+        .and_then(|s| s.get_agent_machine_key().ok().flatten())
+        .map(|k| !k.is_empty())
+        .unwrap_or(false);
+
+    let status = match cfg {
+        Some(c) => EnrollStatus {
+            enrolled: c.is_enrolled(),
+            machine_id: Some(c.machine_id),
+            environment_id: Some(c.environment_id),
+            backend_url: Some(c.backend_url),
+            enrolled_at: c.enrolled_at,
+            has_key,
+        },
+        None => EnrollStatus {
+            enrolled: false,
+            machine_id: None,
+            environment_id: None,
+            backend_url: None,
+            enrolled_at: None,
+            has_key,
+        },
+    };
+
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: Some(
+            serde_json::to_value(status).map_err(|e| format!("serialize enroll status: {e}"))?,
+        ),
+    })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -180,6 +180,7 @@ pub mod database; // Database maintenance and optimization
 pub mod dataset;
 pub mod debug;
 pub mod dev_findings; // Dev-only: seed synthetic findings into the frontend tracker
+pub mod devenv_enroll; // Phase 2 — in-app devenv enrollment (no terminal); wraps env_agent::enroll
 pub mod discoveries;
 pub mod durable_execution; // Conductor-inspired replay, rollback, iteration diffs
 pub mod event_search; // Unified full-text search across activity_timeline, observations, deferred_questions, error_events

--- a/src-tauri/src/env_agent/enroll.rs
+++ b/src-tauri/src/env_agent/enroll.rs
@@ -1,0 +1,247 @@
+//! Shared enroll code path — binds this machine to a web devenv environment via
+//! a one-time enrollment code.
+//!
+//! This is the SINGLE implementation of the enroll POST used by every consumer:
+//! - the `qontinui_profile env enroll --code <code>` CLI (`bin/qontinui_profile.rs`),
+//! - the in-app Tauri command (`commands::devenv_enroll`), and
+//! - (Phase 3) the dispatched `events.devenv.enroll_requested` directive consumer.
+//!
+//! The enroll flow mirrors the backend contract in
+//! `qontinui-web` `app/api/v1/endpoints/devenv_agent.py`: POST
+//! `{enrollment_code, machine_id?, hostname?}` to
+//! `{backend}/api/v1/devenv/agent/enroll`; on success the response carries the
+//! machine key ONCE (stored immediately in `SecureStorage`) plus the
+//! `environment_id` (ALWAYS sourced from the response, never hardcoded). Nothing
+//! is written on failure.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::config::EnvAgentConfig;
+
+/// Wire shape of the enroll request body. Conforms EXACTLY to the backend
+/// contract: `{ enrollment_code, machine_id?, hostname? }`.
+#[derive(Debug, Serialize)]
+struct EnrollRequest {
+    enrollment_code: String,
+    machine_id: Option<String>,
+    hostname: Option<String>,
+}
+
+/// Wire shape of the enroll response. The backend returns the machine key ONCE
+/// — we store it immediately. `environment_id` is sourced from HERE.
+#[derive(Debug, Deserialize)]
+struct EnrollResponse {
+    machine_id: String,
+    machine_key: String,
+    #[serde(default)]
+    environment_id: Option<String>,
+}
+
+/// Fully-resolved enroll inputs. The CALLER resolves backend + identity so this
+/// core is transport-agnostic and free of CLI-arg / profile coupling. Use
+/// [`resolve_backend_base`] + [`local_machine_identity`] to populate the
+/// non-`code` fields from the ambient environment.
+#[derive(Debug, Clone)]
+pub struct EnrollParams {
+    /// The one-time enrollment code minted by the web dashboard.
+    pub code: String,
+    /// Web backend base URL (no trailing slash needed — trimmed here).
+    pub backend: String,
+    /// Stable machine identity from `~/.qontinui/machine.json`, or `None` to let
+    /// the backend assign one.
+    pub machine_id: Option<String>,
+    /// This machine's hostname, or `None`.
+    pub hostname: Option<String>,
+    /// Diagnostic override for `environment_id`; the response value wins when
+    /// present. Normally `None`.
+    pub environment_override: Option<String>,
+}
+
+/// Successful enroll outcome — what got persisted.
+#[derive(Debug, Clone, Serialize)]
+pub struct EnrollOutcome {
+    pub machine_id: String,
+    pub environment_id: String,
+    pub backend_url: String,
+}
+
+/// Perform the enroll POST, store the minted machine key in secure storage, and
+/// write `~/.qontinui/env-agent.json`. Blocking (`reqwest::blocking`) — call
+/// directly from the sync CLI, or via `spawn_blocking` from an async Tauri
+/// command. Writes NOTHING on any failure (returns `Err`).
+pub fn run_enroll(params: EnrollParams) -> Result<EnrollOutcome, String> {
+    let code = params.code.trim();
+    if code.is_empty() {
+        return Err("enrollment code is empty".to_string());
+    }
+    let backend = params.backend.trim().trim_end_matches('/').to_string();
+    if backend.is_empty() {
+        return Err("backend base URL is empty".to_string());
+    }
+
+    let body = EnrollRequest {
+        enrollment_code: code.to_string(),
+        machine_id: params.machine_id.clone(),
+        hostname: params.hostname.clone(),
+    };
+    let url = format!("{backend}/api/v1/devenv/agent/enroll");
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("reqwest client build failed: {e}"))?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .map_err(|e| format!("POST {url} failed (backend unreachable?): {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body_text = resp
+            .text()
+            .unwrap_or_else(|_| "<unable to read response body>".to_string());
+        return Err(format!(
+            "enroll failed — POST {url} -> HTTP {status}: {body_text}"
+        ));
+    }
+
+    let parsed: EnrollResponse = resp
+        .json()
+        .map_err(|e| format!("enroll succeeded but decoding the response failed: {e}"))?;
+
+    // environment_id ALWAYS comes from the response when present; the override is
+    // a diagnostic fallback only.
+    let environment_id = parsed
+        .environment_id
+        .clone()
+        .or(params.environment_override)
+        .filter(|e| !e.trim().is_empty())
+        .ok_or_else(|| {
+            "enroll response did not include an environment_id and none was supplied; \
+             refusing to write a half-enrolled config"
+                .to_string()
+        })?;
+
+    // Store the machine key FIRST — it is the credential.
+    let storage = crate::secure_storage::SecureStorage::new()
+        .map_err(|e| format!("could not open secure storage: {e}"))?;
+    storage
+        .store_agent_machine_key(&parsed.machine_key)
+        .map_err(|e| format!("failed to store machine key: {e}"))?;
+
+    // Then write env-agent.json with the RESPONSE environment_id.
+    let cfg = EnvAgentConfig {
+        backend_url: backend.clone(),
+        machine_id: parsed.machine_id.clone(),
+        environment_id: environment_id.clone(),
+        enrolled_at: Some(chrono::Utc::now().to_rfc3339()),
+    };
+    cfg.save()
+        .map_err(|e| format!("enrolled + key stored, but writing env-agent.json failed: {e}"))?;
+
+    Ok(EnrollOutcome {
+        machine_id: parsed.machine_id,
+        environment_id,
+        backend_url: backend,
+    })
+}
+
+/// Resolve the web backend base URL for the enroll POST. Order:
+/// explicit arg → `QONTINUI_WEB_BASE` → web base derived from the active
+/// profile's `coord_url` (`pair::derive_web_base_from_coord(pair::coord_http_base())`).
+/// Shared by the CLI (`resolve_env_backend_base`) and the Tauri command.
+pub fn resolve_backend_base(explicit: Option<&str>) -> Result<String, String> {
+    if let Some(b) = explicit {
+        let t = b.trim();
+        if !t.is_empty() {
+            return Ok(t.trim_end_matches('/').to_string());
+        }
+    }
+    if let Ok(v) = std::env::var("QONTINUI_WEB_BASE") {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Ok(t.trim_end_matches('/').to_string());
+        }
+    }
+    let coord_base = crate::pair::coord_http_base().map_err(|e| {
+        format!(
+            "could not resolve a backend URL (no explicit backend, no QONTINUI_WEB_BASE, \
+             and coord_url unavailable: {e})"
+        )
+    })?;
+    Ok(crate::pair::derive_web_base_from_coord(&coord_base))
+}
+
+/// Read `~/.qontinui/machine.json` → `(machine_id, hostname)`, both optional.
+/// A missing/unreadable/unparseable file yields `(None, None)` — enroll tolerates
+/// null identity (the backend may assign a machine_id). Accepts the legacy
+/// `machine_id` key as an alias for `device_id`, matching the CLI reader.
+pub fn local_machine_identity() -> (Option<String>, Option<String>) {
+    #[derive(Deserialize)]
+    struct DeviceFile {
+        #[serde(alias = "machine_id")]
+        device_id: String,
+        #[serde(default)]
+        hostname: String,
+    }
+    let Some(home) = dirs::home_dir() else {
+        return (None, None);
+    };
+    let path = home.join(".qontinui").join("machine.json");
+    let Ok(bytes) = std::fs::read(&path) else {
+        return (None, None);
+    };
+    match serde_json::from_slice::<DeviceFile>(&bytes) {
+        Ok(f) => {
+            let hostname = if f.hostname.trim().is_empty() {
+                None
+            } else {
+                Some(f.hostname)
+            };
+            (Some(f.device_id), hostname)
+        }
+        Err(_) => (None, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_backend_prefers_explicit_and_trims_slash() {
+        assert_eq!(
+            resolve_backend_base(Some("https://qontinui.io/")).unwrap(),
+            "https://qontinui.io"
+        );
+    }
+
+    #[test]
+    fn run_enroll_rejects_empty_code() {
+        let err = run_enroll(EnrollParams {
+            code: "   ".to_string(),
+            backend: "https://qontinui.io".to_string(),
+            machine_id: None,
+            hostname: None,
+            environment_override: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("enrollment code is empty"), "got: {err}");
+    }
+
+    #[test]
+    fn run_enroll_rejects_empty_backend() {
+        let err = run_enroll(EnrollParams {
+            code: "ENR-ABC".to_string(),
+            backend: "  ".to_string(),
+            machine_id: None,
+            hostname: None,
+            environment_override: None,
+        })
+        .unwrap_err();
+        assert!(err.contains("backend base URL is empty"), "got: {err}");
+    }
+}

--- a/src-tauri/src/env_agent/mod.rs
+++ b/src-tauri/src/env_agent/mod.rs
@@ -44,6 +44,7 @@
 
 pub mod collectors;
 pub mod config;
+pub mod enroll;
 
 use std::sync::OnceLock;
 use std::time::Duration;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1319,6 +1319,8 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::debug::set_debug_settings,
             commands::dev_findings::dev_seed_finding,
             commands::dev_findings::is_dev_endpoints_enabled,
+            commands::devenv_enroll::devenv_enroll,
+            commands::devenv_enroll::devenv_enroll_status,
             commands::discoveries::clear_discovery,
             commands::discoveries::clear_failed_discoveries,
             commands::discoveries::get_discovery_summary,

--- a/src/components/settings/DevenvEnrollSettings.tsx
+++ b/src/components/settings/DevenvEnrollSettings.tsx
@@ -1,0 +1,175 @@
+/**
+ * DevenvEnrollSettings.tsx
+ *
+ * Phase 2 — in-app devenv enrollment (no terminal). Paste the one-time
+ * enrollment code minted by the web dashboard, click Enroll, and this machine
+ * binds to the environment and starts reporting its (secret-free) config to the
+ * drift view. Wraps the `devenv_enroll` / `devenv_enroll_status` Tauri commands,
+ * which share the `env_agent::enroll` core with the `qontinui_profile env enroll`
+ * CLI — so the terminal and the UI enroll through one code path.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { KeyRound, Check, Loader2, Server } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
+import type { LogFunction } from "./types";
+
+interface TauriResult<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+interface EnrollStatus {
+  enrolled: boolean;
+  machine_id: string | null;
+  environment_id: string | null;
+  backend_url: string | null;
+  enrolled_at: string | null;
+  has_key: boolean;
+}
+
+interface EnrollOutcome {
+  machine_id: string;
+  environment_id: string;
+  backend_url: string;
+}
+
+interface DevenvEnrollSettingsProps {
+  onLog: LogFunction;
+}
+
+export function DevenvEnrollSettings({ onLog }: DevenvEnrollSettingsProps) {
+  const [code, setCode] = useState("");
+  const [backend, setBackend] = useState("");
+  const [status, setStatus] = useState<EnrollStatus | null>(null);
+  const [enrolling, setEnrolling] = useState(false);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      const res =
+        await invoke<TauriResult<EnrollStatus>>("devenv_enroll_status");
+      if (res.success && res.data) setStatus(res.data);
+    } catch (e) {
+      onLog("error", `Failed to read enrollment status: ${e}`);
+    }
+  }, [onLog]);
+
+  useEffect(() => {
+    void refreshStatus();
+  }, [refreshStatus]);
+
+  const handleEnroll = useCallback(async () => {
+    const trimmed = code.trim();
+    if (!trimmed) {
+      onLog("warning", "Enter the enrollment code from the dashboard first.");
+      return;
+    }
+    setEnrolling(true);
+    try {
+      const res = await invoke<TauriResult<EnrollOutcome>>("devenv_enroll", {
+        code: trimmed,
+        backend: backend.trim() || null,
+      });
+      if (res.success) {
+        onLog("success", res.message ?? "Enrolled successfully.");
+        setCode("");
+        await refreshStatus();
+      } else {
+        onLog("error", res.message ?? "Enrollment failed.");
+      }
+    } catch (e) {
+      onLog("error", `Enrollment failed: ${e}`);
+    } finally {
+      setEnrolling(false);
+    }
+  }, [code, backend, onLog, refreshStatus]);
+
+  return (
+    <div className="space-y-6">
+      <SectionHeader
+        title="Devenv Enrollment"
+        description="Bind this machine to a dev-environment so it reports its config to the drift view. Paste the one-time code from the dashboard — no terminal, no build."
+        icon={<Server className="size-5" />}
+      />
+
+      {/* Current enrollment status */}
+      <div className="rounded-md border border-border bg-muted/40 px-4 py-3 text-sm">
+        {status?.enrolled ? (
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 font-medium text-green-600 dark:text-green-500">
+              <Check className="size-4" /> Enrolled
+            </div>
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+              <dt>Environment</dt>
+              <dd className="font-mono">{status.environment_id}</dd>
+              <dt>Machine</dt>
+              <dd className="font-mono">{status.machine_id}</dd>
+              <dt>Backend</dt>
+              <dd className="font-mono break-all">{status.backend_url}</dd>
+              {status.enrolled_at && (
+                <>
+                  <dt>Enrolled</dt>
+                  <dd>{new Date(status.enrolled_at).toLocaleString()}</dd>
+                </>
+              )}
+              <dt>Machine key</dt>
+              <dd>{status.has_key ? "present" : "missing — re-enroll"}</dd>
+            </dl>
+          </div>
+        ) : (
+          <p className="text-muted-foreground">
+            This machine is not enrolled yet. Create a machine in the dashboard,
+            copy its one-time code, and paste it below.
+          </p>
+        )}
+      </div>
+
+      {/* Enroll form */}
+      <div className="space-y-3">
+        <label className="block space-y-1">
+          <span className="text-xs font-medium">Enrollment code</span>
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="paste the one-time code"
+            className="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-sm"
+            disabled={enrolling}
+          />
+        </label>
+        <label className="block space-y-1">
+          <span className="text-xs font-medium text-muted-foreground">
+            Backend URL (optional — resolves from your active profile)
+          </span>
+          <input
+            type="text"
+            value={backend}
+            onChange={(e) => setBackend(e.target.value)}
+            placeholder="https://qontinui.io"
+            className="w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-sm"
+            disabled={enrolling}
+          />
+        </label>
+        <button
+          type="button"
+          onClick={handleEnroll}
+          disabled={enrolling || !code.trim()}
+          className="inline-flex items-center gap-2 rounded-md border border-border bg-muted px-4 py-2 text-sm font-medium hover:bg-muted/70 disabled:opacity-50"
+        >
+          {enrolling ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <KeyRound className="size-4" />
+          )}
+          {enrolling
+            ? "Enrolling…"
+            : status?.enrolled
+              ? "Re-enroll"
+              : "Enroll this machine"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -32,6 +32,7 @@ import { LockYieldPolicySettings } from "./LockYieldPolicySettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { AccountSettings } from "./AccountSettings";
 import { CiRunnerSettings } from "./CiRunnerSettings";
+import { DevenvEnrollSettings } from "./DevenvEnrollSettings";
 import { DevLoopSettings } from "./DevLoopSettings";
 
 interface SettingsProps {
@@ -52,6 +53,7 @@ type SettingsTab =
   | "mobile"
   | "discovery"
   | "backend-connection"
+  | "devenv-enroll"
   | "mcp"
   | "log-sources"
   | "execution-variables"
@@ -82,6 +84,7 @@ const SETTINGS_TABS = [
   { id: "account", label: "Account" },
   { id: "dev-loop", label: "Test My Change" },
   { id: "backend-connection", label: "Backend Connection" },
+  { id: "devenv-enroll", label: "Devenv Enrollment" },
   { id: "ai", label: "AI Providers" },
   { id: "agentic", label: "Advanced AI" },
   { id: "self-healing", label: "Self-Healing" },
@@ -127,6 +130,7 @@ const SUB_TAB_TO_MAIN_TAB: Record<SettingsTab, string> = {
   account: "settings-account",
   "dev-loop": "settings-dev-loop",
   "backend-connection": "settings-backend-connection",
+  "devenv-enroll": "settings-backend-connection",
   ai: "settings-ai",
   agentic: "settings-agentic",
   "self-healing": "settings-self-healing",
@@ -286,6 +290,8 @@ export function Settings({ defaultTab, onLog, onDebugModeChange }: SettingsProps
         return <MobileSettings onLog={onLog} />;
       case "discovery":
         return <DiscoverySettings onLog={onLog} />;
+      case "devenv-enroll":
+        return <DevenvEnrollSettings onLog={onLog} />;
       case "mcp":
         return <McpSettings onLog={onLog} />;
       case "log-sources":


### PR DESCRIPTION
## What

Phase 2 of `plans/2026-07-02-devenv-machine-enrollment-ux-one-click` — enroll a
devenv machine from the runner UI, no terminal.

**Shared enroll core.** Extract the enroll POST + machine-key storage + config
write out of the `qontinui_profile env enroll` CLI into `env_agent::enroll`
(`run_enroll` + `resolve_backend_base` + `local_machine_identity`). The CLI, the
new Tauri command, and the (Phase 3) dispatched directive consumer now enroll
through ONE code path — the CLI's duplicated request/response structs + inline
POST are gone.

**Tauri commands.** `devenv_enroll` (async — the blocking core runs via
`spawn_blocking`) and `devenv_enroll_status` (mirrors `env show`), registered in
`generate_handler!`.

**Settings panel.** A new "Devenv Enrollment" tab: paste the one-time code →
Enroll → live status (environment, machine, backend, key presence).
`spawn_env_capture()` picks up the mid-session enroll on its next tick, so the
drift view populates without a runner restart.

## Verification

- `cargo check` (lib + bins): clean.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test env_agent::enroll`: 3/3 pass (input-validation + backend resolution).
- Frontend `tsc --noEmit`: 0 errors; `eslint` on the panel + Settings.tsx: 0 errors.
- **On-device panel render**: relies on this PR's CI **boot-smoke** (boots the
  built runner, asserts `frontendReady`). The local supervisor's temp-runner
  build targets the primary checkout (currently red on an unrelated
  `qontinui-spec-check` WIP drift), and a full bundle build of an isolated
  worktree was disproportionate — so CI is the render substrate.

## Scope

Phase 2 of 3. Pairs with Phase 1(b) (qontinui-web #701, enroll command in the
dashboard modal). Phase 1(a) sidecar bundling + Phase 3 dispatched self-enroll
remain (tracked by coord gate `5ed3ee1f`).

<!-- nudge: re-eval — CI now fully green (14/14), CLEAN; land to unblock stacked #687/#689 -->