### PR TITLE
feat(terminal): per-session PR status dropdown in the zone header

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -224,6 +224,7 @@ pub mod scripted_output_settings; // get/save the ScriptedOutputSettings (provid
 pub mod security_settings;
 pub mod self_healing_settings;
 pub mod session; // Plan 2026-05-22-coord-native-session-coordination Phase 2 — unified Session primitive Tauri commands
+pub mod session_prs; // Per-session PR merged/unmerged status for the Terminal zone-header dropdown (coord proxy)
 pub mod setup_wizard; // First-launch setup wizard commands
 pub mod shell_commands; // Shell command management and execution
 pub mod spec_drift; // Spec drift detection (useUIElement vs spec assertions)

--- a/src-tauri/src/commands/session_prs.rs
+++ b/src-tauri/src/commands/session_prs.rs
@@ -1,0 +1,131 @@
+//! Per-session PR status for the Terminal page's zone-header dropdown.
+//!
+//! Proxies coord's `GET /pr-merge/session/:session_id/prs` (the inverse of
+//! the PR→author-session resolver): given a terminal's Claude
+//! `--session-id`, coord returns every PR that session's worktree
+//! allocations produced plus the merged/unmerged verdict, unmerged-first.
+//! The device JWT rides on the request via the shared
+//! [`crate::coord_http::coord_get`] helper.
+//!
+//! FAIL-SOFT BY DESIGN: this feeds a passive status indicator that polls in
+//! the background, so every degraded condition (unpaired device, coord
+//! unreachable, endpoint not yet deployed, auth rejection) returns
+//! `Ok({ available: false, reason, ... })` rather than `Err` — the dropdown
+//! hides itself instead of surfacing an error toast per zone per poll. Only
+//! a malformed session id (a caller bug) is a hard `Err`.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// Shape the command's fail-soft envelope from coord's HTTP verdict.
+/// Pure — unit-tested below; the Tauri command is transport glue around it.
+fn shape_response(status: u16, body: Value) -> Value {
+    match status {
+        200 => json!({
+            "available": true,
+            "prs": body.get("prs").cloned().unwrap_or_else(|| json!([])),
+            "allMerged": body.get("all_merged").cloned().unwrap_or(json!(true)),
+        }),
+        401 | 403 => json!({
+            "available": false,
+            "reason": "unauthorized",
+            "prs": [],
+            "allMerged": true,
+        }),
+        // coord build predating the endpoint — the runner can land ahead of
+        // coord; hide the dropdown until coord catches up.
+        404 => json!({
+            "available": false,
+            "reason": "endpoint_missing",
+            "prs": [],
+            "allMerged": true,
+        }),
+        other => json!({
+            "available": false,
+            "reason": "coord_error",
+            "status": other,
+            "prs": [],
+            "allMerged": true,
+        }),
+    }
+}
+
+/// `session_prs_get` — the session's authored PRs with merged verdicts,
+/// unmerged-first (coord orders; the frontend renders verbatim).
+///
+/// Returns `{ available, reason?, prs: [{repo, pr_number, branch, pr_state,
+/// merged, merged_at}], allMerged }`.
+#[tauri::command]
+pub async fn session_prs_get(claude_session_id: String) -> Result<Value, String> {
+    let session_id = uuid::Uuid::parse_str(claude_session_id.trim())
+        .map_err(|e| format!("invalid claude_session_id {claude_session_id:?}: {e}"))?;
+
+    if !crate::coord_http::have_device_token() {
+        return Ok(json!({
+            "available": false,
+            "reason": "unpaired",
+            "prs": [],
+            "allMerged": true,
+        }));
+    }
+
+    let base = crate::coord_mcp::coord_base_url();
+    let url = format!("{base}/pr-merge/session/{session_id}/prs");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))?;
+
+    let resp = match crate::coord_http::coord_get(&client, &url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(json!({
+                "available": false,
+                "reason": "unreachable",
+                "detail": e.to_string(),
+                "prs": [],
+                "allMerged": true,
+            }));
+        }
+    };
+
+    let status = resp.status().as_u16();
+    let body: Value = resp.json().await.unwrap_or(Value::Null);
+    Ok(shape_response(status, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ok_body_maps_prs_and_all_merged_through() {
+        let out = shape_response(
+            200,
+            json!({
+                "agent_session_id": "s",
+                "prs": [{"repo": "o/r", "pr_number": 7, "merged": false}],
+                "all_merged": false,
+            }),
+        );
+        assert_eq!(out["available"], json!(true));
+        assert_eq!(out["allMerged"], json!(false));
+        assert_eq!(out["prs"][0]["pr_number"], json!(7));
+    }
+
+    #[test]
+    fn missing_endpoint_and_auth_rejection_fail_soft() {
+        let out = shape_response(404, Value::Null);
+        assert_eq!(out["available"], json!(false));
+        assert_eq!(out["reason"], json!("endpoint_missing"));
+        assert_eq!(out["prs"], json!([]));
+
+        let out = shape_response(403, Value::Null);
+        assert_eq!(out["reason"], json!("unauthorized"));
+
+        let out = shape_response(500, Value::Null);
+        assert_eq!(out["reason"], json!("coord_error"));
+        assert_eq!(out["status"], json!(500));
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1750,6 +1750,9 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             // Plan 2026-05-23-coord-native-sessions-phase-7-10 §Phase 7 —
             // "Continue elsewhere" cross-machine handoff trigger.
             commands::session::session_handoff,
+            // Terminal zone-header PR dropdown — per-session PR merged/unmerged
+            // status proxied from coord's GET /pr-merge/session/:id/prs.
+            commands::session_prs::session_prs_get,
             // Plan 2026-05-22-coord-native-session-coordination §D12 / Phase 4 —
             // active tenant resolver for the frontend TenantContext.
             commands::tenant::get_active_tenant,

--- a/src/components/terminal/ZoneGrid.tsx
+++ b/src/components/terminal/ZoneGrid.tsx
@@ -22,6 +22,7 @@ import {
   ZoneContextMenu,
   ZoneQuickActions,
   ZoneLabel,
+  SessionPrDropdown,
   HiddenTerminal,
   formatUptime,
   countMatches,
@@ -350,6 +351,7 @@ export function ZoneGrid({
           <div className="absolute top-0 left-0 right-0 flex items-center gap-2 px-3 py-1 bg-[#13141f]/90 backdrop-blur-sm z-20 cursor-pointer">
             <span className="text-[10px] text-[#7aa2f7] font-medium">Maximized</span>
             <span className="text-[10px] text-[#a9b1d6]">{tab.title}</span>
+            <SessionPrDropdown claudeSessionId={tab.claudeSessionId} />
             <span className="text-[9px] text-[#565f89] ml-auto">
               Esc or double-click to restore
             </span>

--- a/src/components/terminal/useSessionPrs.test.ts
+++ b/src/components/terminal/useSessionPrs.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the pure helpers behind the zone-header PR dropdown: ordering
+ * (unmerged first — the actionable rows the operator opens the dropdown
+ * for), the all-merged roll-up driving the green/red trigger symbol, and
+ * the GitHub-link guard for coord's bare-repo-name skew. The hook itself
+ * needs a DOM + Tauri IPC; the helpers are pure (vitest `node` env, same
+ * precedent as the sibling ZoneLabel spec tests).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  sortPrsUnmergedFirst,
+  summarizePrs,
+  prGithubUrl,
+  prLabel,
+  type SessionPr,
+} from "./useSessionPrs";
+
+function pr(overrides: Partial<SessionPr> & Pick<SessionPr, "pr_number" | "merged">): SessionPr {
+  return {
+    repo: "qontinui/qontinui-runner",
+    branch: "feat/x",
+    pr_state: overrides.merged ? "merged" : "open",
+    merged_at: null,
+    ...overrides,
+  };
+}
+
+describe("sortPrsUnmergedFirst", () => {
+  it("puts unmerged PRs above merged ones, newest first within each group", () => {
+    const sorted = sortPrsUnmergedFirst([
+      pr({ pr_number: 660, merged: true }),
+      pr({ pr_number: 670, merged: false }),
+      pr({ pr_number: 665, merged: true }),
+      pr({ pr_number: 650, merged: false }),
+    ]);
+    expect(sorted.map((p) => p.pr_number)).toEqual([670, 650, 665, 660]);
+    expect(sorted.map((p) => p.merged)).toEqual([false, false, true, true]);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [pr({ pr_number: 1, merged: true }), pr({ pr_number: 2, merged: false })];
+    sortPrsUnmergedFirst(input);
+    expect(input.map((p) => p.pr_number)).toEqual([1, 2]);
+  });
+});
+
+describe("summarizePrs", () => {
+  it("is green (allMerged) only when every PR merged", () => {
+    expect(
+      summarizePrs([pr({ pr_number: 1, merged: true }), pr({ pr_number: 2, merged: true })]),
+    ).toEqual({ total: 2, unmerged: 0, allMerged: true });
+    expect(
+      summarizePrs([pr({ pr_number: 1, merged: true }), pr({ pr_number: 2, merged: false })]),
+    ).toEqual({ total: 2, unmerged: 1, allMerged: false });
+  });
+
+  it("is vacuously green on an empty list (dropdown hides itself anyway)", () => {
+    expect(summarizePrs([])).toEqual({ total: 0, unmerged: 0, allMerged: true });
+  });
+});
+
+describe("prGithubUrl / prLabel", () => {
+  it("links owner/name repos and shows the bare-name label", () => {
+    const p = pr({ pr_number: 663, merged: false });
+    expect(prGithubUrl(p)).toBe("https://github.com/qontinui/qontinui-runner/pull/663");
+    expect(prLabel(p)).toBe("qontinui-runner#663");
+  });
+
+  it("refuses a link for coord's bare checkout-name skew", () => {
+    const p = pr({ pr_number: 12, merged: false, repo: "qontinui-runner" });
+    expect(prGithubUrl(p)).toBeNull();
+    expect(prLabel(p)).toBe("qontinui-runner#12");
+  });
+});

--- a/src/components/terminal/useSessionPrs.ts
+++ b/src/components/terminal/useSessionPrs.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Per-session PR merged/unmerged status for the zone-header dropdown.
+ *
+ * Backed by the `session_prs_get` Tauri command, which proxies coord's
+ * `GET /pr-merge/session/:session_id/prs` (agent_worktrees → repo_branches
+ * join) with the device JWT. The command is fail-soft: unpaired device,
+ * unreachable coord, or a coord build predating the endpoint all come back
+ * as `{ available: false }` — the dropdown hides instead of erroring.
+ */
+
+export interface SessionPr {
+  repo: string;
+  pr_number: number;
+  branch: string;
+  pr_state: string | null;
+  merged: boolean;
+  merged_at: string | null;
+}
+
+export interface SessionPrsState {
+  available: boolean;
+  prs: SessionPr[];
+  allMerged: boolean;
+}
+
+const EMPTY: SessionPrsState = { available: false, prs: [], allMerged: true };
+
+/** Unmerged first (the actionable rows), newest PR first within each group.
+ * Coord already orders this way; re-sorting keeps the UI honest if the
+ * payload ever arrives unsorted. Pure — unit-tested. */
+export function sortPrsUnmergedFirst(prs: SessionPr[]): SessionPr[] {
+  return [...prs].sort((a, b) => {
+    if (a.merged !== b.merged) return a.merged ? 1 : -1;
+    if (a.pr_number !== b.pr_number) return b.pr_number - a.pr_number;
+    return a.repo.localeCompare(b.repo);
+  });
+}
+
+/** Roll-up for the trigger symbol: green ⇔ every PR merged. Pure. */
+export function summarizePrs(prs: SessionPr[]): {
+  total: number;
+  unmerged: number;
+  allMerged: boolean;
+} {
+  const unmerged = prs.filter((p) => !p.merged).length;
+  return { total: prs.length, unmerged, allMerged: unmerged === 0 };
+}
+
+/** GitHub URL when the repo is the webhook's `owner/name`; coord can also
+ * surface a bare checkout name (repo-format skew) — no owner, no link. */
+export function prGithubUrl(pr: Pick<SessionPr, "repo" | "pr_number">): string | null {
+  return pr.repo.includes("/") ? `https://github.com/${pr.repo}/pull/${pr.pr_number}` : null;
+}
+
+/** Compact display label: bare repo name + PR number (`runner#663`). */
+export function prLabel(pr: Pick<SessionPr, "repo" | "pr_number">): string {
+  const bare = pr.repo.split("/").pop() ?? pr.repo;
+  return `${bare}#${pr.pr_number}`;
+}
+
+function normalize(raw: unknown): SessionPrsState {
+  if (!raw || typeof raw !== "object") return EMPTY;
+  const v = raw as { available?: boolean; prs?: SessionPr[]; allMerged?: boolean };
+  if (!v.available || !Array.isArray(v.prs)) return EMPTY;
+  const prs = sortPrsUnmergedFirst(v.prs);
+  return { available: true, prs, allMerged: summarizePrs(prs).allMerged };
+}
+
+/**
+ * Poll the session's PR list while mounted. `claudeSessionId` is undefined
+ * for plain PTY tabs and not-yet-reconciled spawns — no fetch, empty state.
+ */
+export function useSessionPrs(
+  claudeSessionId: string | undefined,
+  pollMs = 60_000,
+): SessionPrsState & { refresh: () => void } {
+  // Cache keyed by session id: when the zone is reassigned to another
+  // session, render falls back to EMPTY until that session's fetch lands —
+  // no setState-in-effect reset, no flash of the previous session's PRs.
+  const [cached, setCached] = useState<{ sid: string; data: SessionPrsState } | null>(null);
+  const inFlight = useRef(false);
+
+  const fetchPrs = useCallback(async () => {
+    if (!claudeSessionId || inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const raw = await invoke<unknown>("session_prs_get", {
+        claudeSessionId,
+      });
+      setCached({ sid: claudeSessionId, data: normalize(raw) });
+    } catch (err) {
+      // Hard Err = malformed session id (caller bug) — log once per poll,
+      // keep the last known state rather than flapping the indicator.
+      console.error("session_prs_get failed:", err);
+    } finally {
+      inFlight.current = false;
+    }
+  }, [claudeSessionId]);
+
+  useEffect(() => {
+    if (!claudeSessionId) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetchPrs is async; setCached fires after the IPC await, never synchronously in the effect body
+    void fetchPrs();
+    const timer = setInterval(() => void fetchPrs(), pollMs);
+    return () => clearInterval(timer);
+  }, [claudeSessionId, fetchPrs, pollMs]);
+
+  const state = claudeSessionId && cached?.sid === claudeSessionId ? cached.data : EMPTY;
+  return { ...state, refresh: () => void fetchPrs() };
+}

--- a/src/components/terminal/zone-grid/ZoneLabel.tsx
+++ b/src/components/terminal/zone-grid/ZoneLabel.tsx
@@ -1,11 +1,119 @@
 import { useState, useRef, useEffect } from "react";
-import { ChevronDown, Pin, Filter, ArrowDownToLine, Zap } from "lucide-react";
+import { ChevronDown, GitPullRequest, Pin, Filter, ArrowDownToLine, Zap } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { useUIElement } from "@qontinui/ui-bridge";
 import type { TerminalTab } from "../useTerminalManager";
 import type { ZoneAssignments, SessionState } from "../useZoneLayout";
 import { STATE_BORDER_COLORS } from "./constants";
 import { isNonDurablePty, NON_DURABLE_TOOLTIP, NON_DURABLE_LABEL } from "../sessionDurability";
 import { useTerminalWindowActions } from "../useTerminalWindowActions";
+import { useSessionPrs, summarizePrs, prGithubUrl, prLabel } from "../useSessionPrs";
+
+/** Tokyo-Night verdict colors shared by the summary symbol and per-PR dots
+ * (same green/red the state dots use — `constants.ts`). */
+const PR_MERGED_COLOR = "#9ece6a";
+const PR_UNMERGED_COLOR = "#f7768e";
+
+/**
+ * Per-session PR status dropdown for the zone header: the trigger shows a
+ * pull-request symbol that is green when EVERY PR the session authored has
+ * merged and red otherwise; the panel lists each PR (unmerged first) with
+ * its own red/green mark. Data comes from coord via `useSessionPrs`
+ * (fail-soft: unpaired/unreachable/pre-endpoint coord ⇒ renders nothing).
+ * Hidden for tabs with no Claude session id and sessions with no PRs.
+ */
+export function SessionPrDropdown({ claudeSessionId }: { claudeSessionId?: string }) {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const { available, prs, allMerged, refresh } = useSessionPrs(claudeSessionId);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  if (!claudeSessionId || !available || prs.length === 0) return null;
+
+  const { total, unmerged } = summarizePrs(prs);
+  const summaryColor = allMerged ? PR_MERGED_COLOR : PR_UNMERGED_COLOR;
+  const summaryText = allMerged ? `all ${total} merged` : `${unmerged} of ${total} unmerged`;
+
+  return (
+    <div className="relative shrink-0" ref={panelRef}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          if (!open) refresh();
+          setOpen(!open);
+        }}
+        className="flex items-center gap-0.5 p-0.5 rounded hover:bg-[#2a2d3d] transition-colors"
+        style={{ color: summaryColor }}
+        title={`Session PRs: ${summaryText}`}
+        aria-label={`Session PRs: ${summaryText}`}
+        data-pr-summary={allMerged ? "all-merged" : "unmerged"}
+      >
+        <GitPullRequest className="w-2.5 h-2.5" />
+        <span className="text-[9px] font-mono leading-none">{allMerged ? total : unmerged}</span>
+        <ChevronDown className="w-2 h-2" />
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full mt-0.5 w-56 bg-[#1a1b26] border border-[#2a2d3d] rounded-lg shadow-xl z-50 overflow-hidden">
+          <div className="flex items-center gap-1.5 px-2 py-1 border-b border-[#2a2d3d]">
+            <div
+              className="w-2 h-2 rounded-full shrink-0"
+              style={{ backgroundColor: summaryColor }}
+            />
+            <span className="text-[9px] text-[#a9b1d6]">{summaryText}</span>
+          </div>
+          <div className="max-h-48 overflow-y-auto scrollbar-dark">
+            {prs.map((pr) => {
+              const url = prGithubUrl(pr);
+              return (
+                <button
+                  key={`${pr.repo}#${pr.pr_number}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (url) {
+                      void openUrl(url).catch((err) =>
+                        console.error("Failed to open PR url:", err),
+                      );
+                      setOpen(false);
+                    }
+                  }}
+                  className={`w-full flex items-center gap-1.5 px-2 py-1 text-left transition-colors text-[#a9b1d6] ${
+                    url ? "hover:bg-[#2a2d3d]/50 cursor-pointer" : "cursor-default"
+                  }`}
+                  title={url ?? `${pr.repo}#${pr.pr_number} (no GitHub link — bare repo name)`}
+                >
+                  <div
+                    className="w-1.5 h-1.5 rounded-full shrink-0"
+                    style={{
+                      backgroundColor: pr.merged ? PR_MERGED_COLOR : PR_UNMERGED_COLOR,
+                    }}
+                  />
+                  <span className="text-[10px] font-mono truncate flex-1">{prLabel(pr)}</span>
+                  <span
+                    className="text-[8px] shrink-0"
+                    style={{ color: pr.merged ? PR_MERGED_COLOR : PR_UNMERGED_COLOR }}
+                  >
+                    {pr.merged ? "merged" : (pr.pr_state ?? "open")}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 /**
  * UI Bridge registration spec for a zone header (boot-restore remediation
@@ -143,6 +251,11 @@ export function ZoneLabel({
           {NON_DURABLE_LABEL}
         </span>
       )}
+
+      {/* Per-session PR status: green = every authored PR merged, red = at
+          least one unmerged; the panel lists PR numbers unmerged-first so a
+          stuck/red-CI PR is visible without asking the session. */}
+      <SessionPrDropdown claudeSessionId={tab.claudeSessionId} />
 
       {outputLineCount !== undefined && outputLineCount > 0 && (
         <span className="text-[9px] text-[#565f89] font-mono ml-1 shrink-0">

--- a/src/components/terminal/zone-grid/index.ts
+++ b/src/components/terminal/zone-grid/index.ts
@@ -1,7 +1,7 @@
 export { CompactZoneCard } from "./CompactZoneCard";
 export { ZoneContextMenu } from "./ZoneContextMenu";
 export { ZoneQuickActions } from "./ZoneQuickActions";
-export { ZoneLabel } from "./ZoneLabel";
+export { ZoneLabel, SessionPrDropdown } from "./ZoneLabel";
 export { HiddenTerminal } from "./HiddenTerminal";
 export { ActivitySparkline } from "./ActivitySparkline";
 export { HighlightedText } from "./HighlightedText";


### PR DESCRIPTION
## What

Each session's terminal title bar (zone header) on the Terminal page now shows a pull-request indicator:

- **Trigger symbol**: green when EVERY PR the session authored has merged, red when any is unmerged, with the relevant count (total when all green, unmerged count when red).
- **Dropdown panel**: each PR listed **unmerged-first**, with its own red/green dot, `repo#number` label, state text (`open`/`merged`/`closed`), and click-through to the GitHub PR. Header row repeats the all-merged/not-all-merged summary.
- Also rendered in the maximized-view header. Hidden for tabs with no Claude session id and sessions with no PRs.

## Why

The operator kept having to ask each session whether its PRs merged — sessions don't proactively fix red CI or a stuck merge-chain PR unless prompted, so unmerged PRs went unnoticed. This surfaces them at a glance per terminal.

## How

- New fail-soft Tauri command `session_prs_get` → coord `GET /pr-merge/session/:session_id/prs` (qontinui/qontinui-coord#908 — the inverse of the author-session resolver: `agent_worktrees` by `agent_session_id` → `repo_branches` merged verdict) with the device JWT via the shared `coord_http::coord_get`.
- Every degraded condition (unpaired device, coord unreachable, coord build predating the endpoint, auth rejection) returns `{available: false}` — the dropdown hides instead of erroring, so **this PR is safe to land before coord #908 deploys** (no ordering dependency).
- `useSessionPrs` hook polls every 60s per rendered zone; cache is keyed by session id so zone reassignment never flashes another session's PRs.
- Pure helpers (unmerged-first ordering, all-merged roll-up, GitHub-link guard for coord's bare-repo-name skew) unit-tested; command response shaping unit-tested Rust-side.

## Tests / checks

- `vitest`: new `useSessionPrs.test.ts` (6) + existing `ZoneLabel.test.ts` (3) pass; `tsc`, `eslint`, `prettier` clean.
- `cargo check` + `cargo test session_prs` (2 unit tests) pass.
- Follow-up candidate: PR summary marker on `CompactZoneCard` (compact tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coord re-eval nudge 041427 -->
