### PR TITLE
fix(runner): close the three lost-wakeup delivery holes (stall-watchdog PR 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6693,7 +6693,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "hex",

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -484,7 +484,9 @@ fn build_coord_ws_url(coord_url: &str, device_id: uuid::Uuid) -> String {
 }
 
 /// Read `~/.qontinui/machine.json` → device_id. Falls back to None.
-fn load_local_device_id() -> Option<uuid::Uuid> {
+/// `pub(crate)` so `mcp::session_message_poller` can stamp its
+/// delivery-blocked surfacing POSTs with the device identity.
+pub(crate) fn load_local_device_id() -> Option<uuid::Uuid> {
     #[derive(Deserialize)]
     struct DeviceFile {
         #[serde(alias = "machine_id")]
@@ -533,10 +535,11 @@ pub fn spawn_runtime() {
     }
 
     info!("agent_runtime: starting for device_id={}", device_id);
-    // Periodic backstop for the capacity-freed re-poll: drains a deferred
-    // (AtCap) continuation even if its terminal's exit-hook trigger is missed.
-    // Spawned independently of the WS pump so it survives subscription flaps;
-    // it is an idle no-op until the first AtCap deferral arms it.
+    // Periodic backstop poll (always armed): drains a pending continuation /
+    // unit dispatch even when every push-shaped trigger is missed — a lost WS
+    // frame while connected, a deferred (AtCap) continuation whose terminal
+    // exit-hook trigger never fired, a slot freed between WS connects.
+    // Spawned independently of the WS pump so it survives subscription flaps.
     spawn_continuation_backstop_poll(device_id);
     tokio::spawn(async move {
         if let Err(e) = subscribe_to_spawn_requests(device_id).await {
@@ -1297,34 +1300,6 @@ fn register_continuation_session(terminal_id: String, anchor_key: Option<String>
 // Capacity-freed re-poll (Defect A item 3, layered on #484)
 // =============================================================================
 
-/// Has at least one `AtCap` deferral happened this process lifetime?
-///
-/// #484 leaves an `AtCap` continuation pending (uncancelled, unconsumed) on
-/// coord so it is re-deliverable once a cap slot frees — but it adds NO trigger
-/// to re-fetch it. Without one, a deferred continuation only drains on the next
-/// WS reconnect (`poll_pending_continuations` is called exactly once, on
-/// connect). This flag arms the periodic backstop poll
-/// ([`spawn_continuation_backstop_poll`]) so the queue still drains even if the
-/// capacity-freed exit-hook trigger ([`notify_continuation_terminal_exit`]) is
-/// missed (e.g. coord registration failed so no exit hook was installed, or the
-/// process restarted between the deferral and the slot freeing). Cheap, set-once,
-/// never reset: a single deferral is enough to want the backstop for the rest of
-/// the process's life.
-fn at_cap_ever() -> &'static std::sync::atomic::AtomicBool {
-    static AT_CAP_EVER: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-    &AT_CAP_EVER
-}
-
-/// Record that an `AtCap` deferral occurred (arms the periodic backstop poll).
-fn mark_at_cap_deferral() {
-    at_cap_ever().store(true, std::sync::atomic::Ordering::Relaxed);
-}
-
-/// Whether any `AtCap` deferral has happened this process lifetime.
-fn at_cap_deferral_happened() -> bool {
-    at_cap_ever().load(std::sync::atomic::Ordering::Relaxed)
-}
-
 /// Capacity-freed re-poll trigger: called from the continuation terminal's
 /// on-exit hook (`create_terminal_session_backend`, `commands/terminal.rs`) the
 /// instant a continuation-spawned PTY exits.
@@ -1393,41 +1368,75 @@ fn deregister_exited_continuation(terminal_id: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// How often the periodic backstop poll fires once armed (5 min).
-const CONTINUATION_BACKSTOP_POLL_SECS: u64 = 300;
+/// Default backstop-poll cadence (5 min). Env-tunable via
+/// [`CONTINUATION_BACKSTOP_POLL_SECS_ENV`].
+const CONTINUATION_BACKSTOP_POLL_SECS_DEFAULT: u64 = 300;
 
-/// Spawn the periodic backstop poll task (Defect A item 3, backstop half).
+/// Floor for the backstop-poll cadence — a misconfigured tiny value must not
+/// turn the safety net into a coord hammer.
+const CONTINUATION_BACKSTOP_POLL_SECS_FLOOR: u64 = 30;
+
+/// Env var overriding the backstop-poll cadence (seconds). Default
+/// [`CONTINUATION_BACKSTOP_POLL_SECS_DEFAULT`], floored at
+/// [`CONTINUATION_BACKSTOP_POLL_SECS_FLOOR`].
+const CONTINUATION_BACKSTOP_POLL_SECS_ENV: &str = "RUNNER_CONTINUATION_BACKSTOP_POLL_SECS";
+
+/// Resolve the backstop-poll cadence from a raw env value. Pure over the input
+/// so the default / floor / garbage-fallback policy is unit-testable without
+/// env mutation: unset or non-numeric → default; numeric → floored.
+fn resolve_backstop_poll_secs(raw: Option<&str>) -> u64 {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .map(|v| v.max(CONTINUATION_BACKSTOP_POLL_SECS_FLOOR))
+        .unwrap_or(CONTINUATION_BACKSTOP_POLL_SECS_DEFAULT)
+}
+
+/// The configured backstop-poll cadence (env override, else the default).
+fn continuation_backstop_poll_secs() -> u64 {
+    resolve_backstop_poll_secs(
+        std::env::var(CONTINUATION_BACKSTOP_POLL_SECS_ENV)
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Spawn the periodic backstop poll task (Defect A item 3, backstop half;
+/// always-on since the `2026-07-03-subagent-stall-watchdog` plan).
 ///
-/// A best-effort safety net for the capacity-freed exit-hook trigger
-/// ([`notify_continuation_terminal_exit`]): a missed exit signal — a continuation
-/// terminal whose coord registration failed (so no on-exit hook was installed),
-/// or a slot that frees while the runner is between WS connects — must not strand
-/// a deferred continuation on coord's pending queue until an unrelated WS
-/// reconnect happens to re-poll. Every [`CONTINUATION_BACKSTOP_POLL_SECS`] this
-/// task polls coord for pending continuations, but ONLY after at least one
-/// `AtCap` deferral has happened this process lifetime
-/// ([`at_cap_deferral_happened`]) — until then there is nothing to drain and the
-/// task is a cheap idle tick (no network I/O).
+/// A best-effort safety net for EVERY lost-wakeup path, not just the
+/// capacity-freed exit-hook trigger ([`notify_continuation_terminal_exit`]):
+/// a WS frame lost while connected, a continuation terminal whose coord
+/// registration failed (so no on-exit hook was installed), or a slot that
+/// frees while the runner is between WS connects — none of these may strand a
+/// pending continuation on coord's queue until an unrelated WS reconnect
+/// happens to re-poll. Every [`continuation_backstop_poll_secs`] this task
+/// polls coord for pending continuations and unit dispatches
+/// **unconditionally**.
+///
+/// It used to poll only after at least one `AtCap` deferral this process
+/// lifetime (the deleted `at_cap_deferral_happened` arming flag) — but that
+/// gate meant a WS frame lost while connected, with no AtCap deferral and no
+/// terminal exit, stranded a continuation until the next reconnect. The tick
+/// is two cheap authenticated GETs against coord; paying them every interval
+/// buys at-least-once delivery for the whole class.
 ///
 /// Spawned once per process from [`spawn_runtime`]. Independent of the WS pump
 /// so it keeps draining even while the subscription is flapping.
 fn spawn_continuation_backstop_poll(device_id: uuid::Uuid) {
     tokio::spawn(async move {
-        let mut interval =
-            tokio::time::interval(Duration::from_secs(CONTINUATION_BACKSTOP_POLL_SECS));
+        let secs = continuation_backstop_poll_secs();
+        let mut interval = tokio::time::interval(Duration::from_secs(secs));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        // Skip the immediate first tick — nothing can be deferred at startup.
+        // Skip the immediate first tick — the WS-connect catch-up poll
+        // (`poll_pending_continuations` on connect) covers startup.
         interval.tick().await;
         loop {
             interval.tick().await;
-            if at_cap_deferral_happened() {
-                debug!(
-                    "agent_runtime: backstop poll firing (a prior AtCap deferral armed it) \
-                     for device_id={device_id}"
-                );
-                poll_pending_continuations(device_id).await;
-                poll_pending_unit_dispatches(device_id).await;
-            }
+            debug!(
+                "agent_runtime: backstop poll firing (every {secs}s, always armed) \
+                 for device_id={device_id}"
+            );
+            poll_pending_continuations(device_id).await;
+            poll_pending_unit_dispatches(device_id).await;
         }
     });
 }
@@ -2065,12 +2074,11 @@ async fn run_gate_continuation_inner(
             return Ok(());
         }
         ContinuationGuard::AtCap(cap) => {
-            // Mark that a deferral happened this process lifetime so the periodic
-            // backstop poll arms (`spawn_continuation_backstop_poll`): even if the
-            // capacity-freed exit-hook trigger is missed, the deferred queue still
-            // drains within the backstop interval instead of stranding until an
-            // unrelated WS reconnect.
-            mark_at_cap_deferral();
+            // The deferred continuation stays pending on coord; the periodic
+            // backstop poll (`spawn_continuation_backstop_poll`, always armed)
+            // re-fetches it within one interval even if the capacity-freed
+            // exit-hook trigger is missed — no per-process arming flag needed.
+            //
             // The `deferred:` prefix (Resolved Q3) distinguishes a capacity DEFER
             // (the continuation is intact + pending on coord, re-deliverable once a
             // slot frees) from a hard spawn failure, so a coord-side consumer can
@@ -5574,29 +5582,45 @@ mod tests {
         clear_continuation_registry();
     }
 
-    /// The periodic-backstop arming flag flips from `false` to `true` the first
-    /// time an `AtCap` deferral is recorded, and stays `true` (set-once, never
-    /// reset) — so the backstop poll stays armed for the rest of the process's
-    /// life once any deferral has happened.
+    /// The periodic backstop poll is ALWAYS armed — its cadence resolution is
+    /// the only remaining policy knob. Unset / garbage env values fall back to
+    /// the 300s default; explicit values are honored but floored at 30s so a
+    /// misconfiguration can't turn the safety net into a coord hammer.
     ///
-    /// NOTE: the flag is a process-global `static AtomicBool` shared across the
-    /// whole test binary; this test only asserts the post-mark state (`true`) and
-    /// the idempotence of a second mark, never the pre-mark `false` (another test
-    /// could have armed it first). It runs under `CONT_GUARD_LOCK` for ordering
-    /// hygiene with the other continuation tests.
+    /// (Replaces `at_cap_deferral_arms_backstop_flag`: the AtCap arming
+    /// predicate was deleted with the gate — a WS frame lost while connected,
+    /// with no AtCap deferral this process lifetime and no terminal exit,
+    /// stranded a continuation until the next reconnect. The loop body now
+    /// polls unconditionally on every tick; there is no arming state left to
+    /// test.)
     #[test]
-    fn at_cap_deferral_arms_backstop_flag() {
-        let _g = CONT_GUARD_LOCK.lock().unwrap();
-        mark_at_cap_deferral();
-        assert!(
-            at_cap_deferral_happened(),
-            "an AtCap deferral must arm the periodic-backstop flag"
+    fn backstop_poll_secs_default_floor_and_override() {
+        // Unset → default.
+        assert_eq!(
+            resolve_backstop_poll_secs(None),
+            CONTINUATION_BACKSTOP_POLL_SECS_DEFAULT,
+            "unset env must fall back to the 300s default"
         );
-        // Set-once / idempotent: marking again keeps it armed.
-        mark_at_cap_deferral();
-        assert!(
-            at_cap_deferral_happened(),
-            "the backstop flag stays armed (set-once, never reset)"
+        // Garbage → default (never panics, never zero).
+        assert_eq!(
+            resolve_backstop_poll_secs(Some("not-a-number")),
+            CONTINUATION_BACKSTOP_POLL_SECS_DEFAULT
+        );
+        assert_eq!(
+            resolve_backstop_poll_secs(Some("")),
+            CONTINUATION_BACKSTOP_POLL_SECS_DEFAULT
+        );
+        // Explicit override honored (whitespace-tolerant).
+        assert_eq!(resolve_backstop_poll_secs(Some(" 600 ")), 600);
+        // Below-floor values are clamped up; zero can never disable the poll.
+        assert_eq!(
+            resolve_backstop_poll_secs(Some("5")),
+            CONTINUATION_BACKSTOP_POLL_SECS_FLOOR
+        );
+        assert_eq!(
+            resolve_backstop_poll_secs(Some("0")),
+            CONTINUATION_BACKSTOP_POLL_SECS_FLOOR,
+            "the backstop is always-on; 0 must clamp to the floor, not park the loop"
         );
     }
 

--- a/src-tauri/src/mcp/session_message_poller.rs
+++ b/src-tauri/src/mcp/session_message_poller.rs
@@ -58,6 +58,12 @@
 //!   against a double-inject within a tick or before the ack lands. A
 //!   per-`to_session` cooldown debounces a flapping source so it cannot spam a
 //!   session.
+//! - **Blocked-delivery surfacing.** A `priority="blocking"` message that
+//!   stays undeliverable (target not live, or PTY never idle) past
+//!   `RUNNER_BLOCKING_MSG_SURFACE_SECS` is reported to coord via a fail-open
+//!   `delivery-blocked` POST — evidence for the stall-watchdog supervisor,
+//!   never a change to delivery behavior. Gated (default ON) by
+//!   `RUNNER_DELIVERY_SURFACING_ENABLED`.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -173,6 +179,247 @@ impl DeliveryGuard {
     fn mark_injected(&mut self, to_session: &str, message_id: &str, now: Instant) {
         self.last_injected.insert(to_session.to_string(), now);
         self.delivered.insert(message_id.to_string(), now);
+    }
+}
+
+// ===========================================================================
+// Delivery-blocked surfacing (lost-wakeup fixes 2-3,
+// plan 2026-07-03-subagent-stall-watchdog)
+// ===========================================================================
+//
+// A `priority="blocking"` message that cannot be delivered used to fail
+// SILENTLY forever: an unresolvable `to_session` just logged-and-waited (until
+// the 14d TTL), and a PTY that never passes the idle gate deferred injection
+// on every tick with no aging signal. Both are exactly the invisible-stall
+// class the stall-watchdog plan exists to kill, so once a blocking message has
+// been blocked past `RUNNER_BLOCKING_MSG_SURFACE_SECS` we POST a typed
+// delivery-failure to coord (`.../delivery-blocked`) as EVIDENCE for coord's
+// expectation supervisor. Delivery behavior itself is UNCHANGED — the POST is
+// reporting-only, fail-open, and fired at most once per threshold window per
+// message.
+
+/// Flag gating the surfacing POSTs (fixes 2-3). **Default ON** — they are
+/// reporting-only (no mutation, no injection change; plan vet decision).
+/// `0`/`false`/`no`/`off` disables the POSTs (blocked-time tracking still
+/// runs; it is cheap and keeps `blocked_since` honest if re-enabled).
+const SURFACING_ENABLED_ENV: &str = "RUNNER_DELIVERY_SURFACING_ENABLED";
+
+/// How long a blocking message must be continuously undeliverable before the
+/// first surfacing POST, and the minimum spacing between POSTs for the same
+/// message thereafter (once per window). Seconds; env-tunable.
+const SURFACE_SECS_ENV: &str = "RUNNER_BLOCKING_MSG_SURFACE_SECS";
+
+/// Default surfacing threshold: 30 minutes.
+const SURFACE_SECS_DEFAULT: u64 = 1800;
+
+/// Resolve the surfacing flag from a raw env value. Pure for unit tests.
+/// Absent ⇒ ON (default); only an explicit falsy value disables.
+fn resolve_surfacing_enabled(raw: Option<&str>) -> bool {
+    match raw {
+        Some(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "no" | "off"
+        ),
+        None => true,
+    }
+}
+
+/// Is delivery-blocked surfacing enabled? (env, default ON)
+fn surfacing_enabled() -> bool {
+    resolve_surfacing_enabled(std::env::var(SURFACING_ENABLED_ENV).ok().as_deref())
+}
+
+/// Resolve the surfacing threshold from a raw env value. Pure for unit tests.
+/// Unset / non-numeric ⇒ the 1800s default.
+fn resolve_surface_threshold(raw: Option<&str>) -> Duration {
+    Duration::from_secs(
+        raw.and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(SURFACE_SECS_DEFAULT),
+    )
+}
+
+/// The configured surfacing threshold (env override, else 1800s).
+fn surface_threshold() -> Duration {
+    resolve_surface_threshold(std::env::var(SURFACE_SECS_ENV).ok().as_deref())
+}
+
+/// Why a blocking message could not be delivered — the typed `reason` the
+/// surfacing POST carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum BlockReason {
+    /// Fix 2: `to_session` does not resolve to a live local session.
+    TargetNotLive,
+    /// Fix 3: the target PTY keeps failing the idle gate, deferring injection.
+    PtyNeverIdle,
+}
+
+impl BlockReason {
+    /// The wire value for the POST body's `reason` field.
+    fn as_str(self) -> &'static str {
+        match self {
+            BlockReason::TargetNotLive => "target_not_live",
+            BlockReason::PtyNeverIdle => "pty_never_idle",
+        }
+    }
+}
+
+/// Pure surfacing decision: should a POST fire NOW for a message first seen
+/// blocked at `first_seen`, last surfaced at `last_posted`?
+///
+/// - Disabled flag ⇒ never.
+/// - Blocked for less than `threshold` ⇒ not yet.
+/// - Never posted ⇒ fire.
+/// - Already posted ⇒ fire again only after a full `threshold` cooldown window
+///   since the last POST (at most one POST per message per window).
+fn should_surface(
+    first_seen: Instant,
+    last_posted: Option<Instant>,
+    now: Instant,
+    threshold: Duration,
+    enabled: bool,
+) -> bool {
+    if !enabled {
+        return false;
+    }
+    if now.duration_since(first_seen) < threshold {
+        return false;
+    }
+    match last_posted {
+        None => true,
+        Some(at) => now.duration_since(at) >= threshold,
+    }
+}
+
+/// Per-(message, reason) blocked-delivery bookkeeping.
+struct BlockEntry {
+    /// Monotonic first-seen, for threshold/cooldown math.
+    first_seen: Instant,
+    /// Wall-clock first-seen, for the POST's `blocked_since` (RFC 3339).
+    first_seen_wall: chrono::DateTime<chrono::Utc>,
+    /// Monotonic time of the last surfacing POST attempt (None = never).
+    last_posted: Option<Instant>,
+}
+
+/// Tracks how long each blocking message has been undeliverable, per reason.
+///
+/// IN-PROCESS ONLY (restart caveat): a runner restart resets the clock, which
+/// only DELAYS surfacing by up to one threshold window — it can never spam,
+/// because a fresh map means no entry is past the threshold yet.
+#[derive(Default)]
+struct SurfacingTracker {
+    entries: HashMap<(String, BlockReason), BlockEntry>,
+}
+
+impl SurfacingTracker {
+    /// Record that `message_id` is blocked for `reason` as of `now`. Returns
+    /// `Some(blocked_since)` when a surfacing POST should fire (and stamps the
+    /// cooldown so the same window never fires twice), else `None`.
+    fn note_blocked(
+        &mut self,
+        message_id: &str,
+        reason: BlockReason,
+        now: Instant,
+        threshold: Duration,
+        enabled: bool,
+    ) -> Option<chrono::DateTime<chrono::Utc>> {
+        let entry = self
+            .entries
+            .entry((message_id.to_string(), reason))
+            .or_insert_with(|| BlockEntry {
+                first_seen: now,
+                first_seen_wall: chrono::Utc::now(),
+                last_posted: None,
+            });
+        if should_surface(entry.first_seen, entry.last_posted, now, threshold, enabled) {
+            // Stamp BEFORE the (fail-open) POST attempt: at most one attempt
+            // per window even if the POST errors — never a retry storm.
+            entry.last_posted = Some(now);
+            Some(entry.first_seen_wall)
+        } else {
+            None
+        }
+    }
+
+    /// A successful delivery clears every tracking entry for the message.
+    fn clear_message(&mut self, message_id: &str) {
+        self.entries.retain(|(mid, _), _| mid != message_id);
+    }
+
+    /// Drop entries whose message is no longer in coord's pending set (it was
+    /// delivered elsewhere, cancelled, or expired) so the map stays bounded.
+    fn retain_pending(&mut self, pending_ids: &std::collections::HashSet<&str>) {
+        self.entries
+            .retain(|(mid, _), _| pending_ids.contains(mid.as_str()));
+    }
+}
+
+/// Fire the delivery-blocked surfacing POST for `message_id` if it has been
+/// blocked past the threshold (once per window). **Fail-open by contract**:
+/// any error / non-2xx — including 404 while the coord route (shipped in the
+/// plan's PR 3) hasn't landed — is a debug log; delivery behavior is never
+/// affected.
+///
+/// Auth: the same device-JWT bearer the poller's `pending` / `mark-delivered`
+/// calls use (the `token` threaded from `deliver_once`).
+async fn surface_blocked_delivery(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    tracker: &mut SurfacingTracker,
+    message_id: &str,
+    reason: BlockReason,
+    now: Instant,
+) {
+    let Some(blocked_since) = tracker.note_blocked(
+        message_id,
+        reason,
+        now,
+        surface_threshold(),
+        surfacing_enabled(),
+    ) else {
+        return;
+    };
+    let Some(device_id) = crate::agent_runtime::load_local_device_id() else {
+        debug!(
+            "session_message_poller: delivery-blocked surfacing for msg {message_id} \
+             skipped — no local device id"
+        );
+        return;
+    };
+    let url = format!("{base}/coord/session-messages/{message_id}/delivery-blocked");
+    let body = serde_json::json!({
+        "device_id": device_id.to_string(),
+        "reason": reason.as_str(),
+        "blocked_since": blocked_since.to_rfc3339(),
+    });
+    match client
+        .post(&url)
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
+            info!(
+                "session_message_poller: surfaced delivery-blocked msg {message_id} \
+                 (reason={}) to coord",
+                reason.as_str()
+            );
+        }
+        Ok(resp) => {
+            // 404 expected until coord's delivery-blocked route ships (PR 3).
+            debug!(
+                "session_message_poller: delivery-blocked POST for msg {message_id} \
+                 -> HTTP {} (fail-open, continuing)",
+                resp.status()
+            );
+        }
+        Err(e) => {
+            debug!(
+                "session_message_poller: delivery-blocked POST for msg {message_id} \
+                 failed: {e} (fail-open, continuing)"
+            );
+        }
     }
 }
 
@@ -449,6 +696,7 @@ async fn poller_loop(api_state: Arc<ApiState>, mut shutdown_rx: watch::Receiver<
     );
 
     let mut guard = DeliveryGuard::default();
+    let mut tracker = SurfacingTracker::default();
     // Edge-trigger the "killed" / "unpaired" steady-state logs.
     let mut last_killed_logged = false;
 
@@ -471,7 +719,7 @@ async fn poller_loop(api_state: Arc<ApiState>, mut shutdown_rx: watch::Receiver<
                 last_killed_logged = false;
             }
             // Fail-open: a tick error NEVER panics the loop.
-            if let Err(e) = deliver_once(&api_state, &mut guard).await {
+            if let Err(e) = deliver_once(&api_state, &mut guard, &mut tracker).await {
                 warn!("session_message_poller: delivery tick failed: {e}");
             }
             guard.prune(Instant::now());
@@ -490,8 +738,14 @@ async fn poller_loop(api_state: Arc<ApiState>, mut shutdown_rx: watch::Receiver<
 /// One delivery pass: pull pending → resolve → (idle-gate for PTY) → inject via
 /// the in-process primitive → mark delivered. Returns `Err` only for a
 /// tick-level failure (no JWT, coord unreachable, decode) — a per-message
-/// resolution miss or idle-skip is normal and silent.
-async fn deliver_once(api_state: &Arc<ApiState>, guard: &mut DeliveryGuard) -> anyhow::Result<()> {
+/// resolution miss or idle-skip is normal and silent, except that a BLOCKING
+/// message blocked past the surfacing threshold fires a (fail-open, once per
+/// window) delivery-blocked POST via `tracker`.
+async fn deliver_once(
+    api_state: &Arc<ApiState>,
+    guard: &mut DeliveryGuard,
+    tracker: &mut SurfacingTracker,
+) -> anyhow::Result<()> {
     // Device JWT — unpaired ⇒ skip the tick quietly (no spam).
     let token = match crate::auth::AuthManager::new().get_access_token() {
         Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
@@ -521,6 +775,14 @@ async fn deliver_once(api_state: &Arc<ApiState>, guard: &mut DeliveryGuard) -> a
         anyhow::bail!("pull {pending_url} -> HTTP {}", resp.status());
     }
     let pending: PendingResponse = resp.json().await?;
+    // Drop surfacing entries for messages no longer pending (delivered
+    // elsewhere / cancelled / expired) so the tracker stays bounded.
+    let pending_ids: std::collections::HashSet<&str> = pending
+        .messages
+        .iter()
+        .map(|m| m.message_id.as_str())
+        .collect();
+    tracker.retain_pending(&pending_ids);
     if pending.messages.is_empty() {
         return Ok(());
     }
@@ -585,6 +847,18 @@ async fn deliver_once(api_state: &Arc<ApiState>, guard: &mut DeliveryGuard) -> a
                      here — pending until it next opens",
                     msg.message_id
                 );
+                // Fix 2: a blocking message unresolvable past the threshold is
+                // surfaced to coord (once per window, fail-open).
+                surface_blocked_delivery(
+                    &client,
+                    &base,
+                    &token,
+                    tracker,
+                    &msg.message_id,
+                    BlockReason::TargetNotLive,
+                    now,
+                )
+                .await;
             } else {
                 debug!(
                     "session_message_poller: msg {} target {to_session} not live — pending",
@@ -617,6 +891,22 @@ async fn deliver_once(api_state: &Arc<ApiState>, guard: &mut DeliveryGuard) -> a
                         "session_message_poller: terminal {terminal_id} not idle — deferring msg {}",
                         msg.message_id
                     );
+                    // Fix 3: a blocking message whose PTY never quiesces past
+                    // the threshold is surfaced to coord as evidence for the
+                    // stuck-not-dead classifier (once per window, fail-open).
+                    // Injection behavior is unchanged — we still just defer.
+                    if msg.priority == "blocking" {
+                        surface_blocked_delivery(
+                            &client,
+                            &base,
+                            &token,
+                            tracker,
+                            &msg.message_id,
+                            BlockReason::PtyNeverIdle,
+                            now,
+                        )
+                        .await;
+                    }
                     continue;
                 }
                 task_run_id.clone()
@@ -631,6 +921,8 @@ async fn deliver_once(api_state: &Arc<ApiState>, guard: &mut DeliveryGuard) -> a
         // 4. Mark delivered. Record locally FIRST (cooldown + delivered-set)
         // so even if the ack POST fails we won't re-inject within the TTL.
         guard.mark_injected(to_session, &msg.message_id, now);
+        // A successful delivery clears the message's blocked-surfacing state.
+        tracker.clear_message(&msg.message_id);
 
         let mark_url = format!("{base}/coord/session-messages/mark-delivered");
         if let Err(e) = client
@@ -889,5 +1181,169 @@ mod tests {
         assert!(framed.contains("directed message"));
         assert!(framed.contains("normal priority"));
         assert!(!framed.contains("from session"));
+    }
+
+    // ---- delivery-blocked surfacing (fixes 2-3) ---------------------------
+
+    const THRESH: Duration = Duration::from_secs(1800);
+
+    // NOTE: all instants below are built ADDITIVELY from a fresh `Instant::now()`
+    // base (`base + offset`), never `Instant::now() - big_offset` — `Instant`
+    // subtraction panics on underflow, and on a freshly booted CI VM the
+    // monotonic clock's zero point can be closer than the offsets used here.
+
+    #[test]
+    fn surfacing_disabled_flag_never_fires() {
+        let first_seen = Instant::now();
+        let now = first_seen + THRESH * 3;
+        assert!(!should_surface(first_seen, None, now, THRESH, false));
+    }
+
+    #[test]
+    fn surfacing_waits_for_threshold() {
+        let first_seen = Instant::now();
+        // Just became blocked — not yet.
+        assert!(!should_surface(first_seen, None, first_seen, THRESH, true));
+        // Blocked one second short of the threshold — still not yet.
+        let now = first_seen + THRESH - Duration::from_secs(1);
+        assert!(!should_surface(first_seen, None, now, THRESH, true));
+        // Past the threshold, never posted — fire.
+        let now = first_seen + THRESH + Duration::from_secs(1);
+        assert!(should_surface(first_seen, None, now, THRESH, true));
+    }
+
+    #[test]
+    fn surfacing_cooldown_is_once_per_window() {
+        let first_seen = Instant::now();
+        let now = first_seen + THRESH * 3;
+        // Posted moments ago — the same window must NOT fire again.
+        let just_posted = now - Duration::from_secs(5);
+        assert!(!should_surface(
+            first_seen,
+            Some(just_posted),
+            now,
+            THRESH,
+            true
+        ));
+        // A full window since the last POST — fires again (next window).
+        let window_ago = now - THRESH;
+        assert!(should_surface(
+            first_seen,
+            Some(window_ago),
+            now,
+            THRESH,
+            true
+        ));
+    }
+
+    #[test]
+    fn tracker_fires_once_then_cools_down_then_fires_next_window() {
+        let mut t = SurfacingTracker::default();
+        let t0 = Instant::now();
+        // First sighting: entry created, nothing fires (below threshold).
+        assert!(t
+            .note_blocked("m1", BlockReason::TargetNotLive, t0, THRESH, true)
+            .is_none());
+        // Past the threshold: fires exactly once...
+        let t1 = t0 + THRESH + Duration::from_secs(1);
+        let since = t.note_blocked("m1", BlockReason::TargetNotLive, t1, THRESH, true);
+        assert!(since.is_some(), "first over-threshold sighting must fire");
+        // ...and the immediate next tick is in cooldown.
+        let t2 = t1 + Duration::from_secs(10);
+        assert!(t
+            .note_blocked("m1", BlockReason::TargetNotLive, t2, THRESH, true)
+            .is_none());
+        // A full window later it fires again, carrying the SAME blocked_since
+        // (first-seen is never reset by a POST).
+        let t3 = t1 + THRESH;
+        let again = t.note_blocked("m1", BlockReason::TargetNotLive, t3, THRESH, true);
+        assert_eq!(
+            again, since,
+            "blocked_since must remain the first-seen time"
+        );
+    }
+
+    #[test]
+    fn tracker_reasons_are_tracked_independently() {
+        let mut t = SurfacingTracker::default();
+        let t0 = Instant::now();
+        let t1 = t0 + THRESH + Duration::from_secs(1);
+        // target_not_live aged past the threshold...
+        t.note_blocked("m1", BlockReason::TargetNotLive, t0, THRESH, true);
+        assert!(t
+            .note_blocked("m1", BlockReason::TargetNotLive, t1, THRESH, true)
+            .is_some());
+        // ...but a FRESH pty_never_idle sighting of the same message starts
+        // its own clock and does not fire yet.
+        assert!(t
+            .note_blocked("m1", BlockReason::PtyNeverIdle, t1, THRESH, true)
+            .is_none());
+    }
+
+    #[test]
+    fn successful_delivery_clears_tracking() {
+        let mut t = SurfacingTracker::default();
+        let t0 = Instant::now();
+        t.note_blocked("m1", BlockReason::TargetNotLive, t0, THRESH, true);
+        t.note_blocked("m1", BlockReason::PtyNeverIdle, t0, THRESH, true);
+        t.note_blocked("m2", BlockReason::TargetNotLive, t0, THRESH, true);
+        t.clear_message("m1");
+        // m1's clocks restart from scratch; m2 is untouched.
+        let t1 = t0 + THRESH + Duration::from_secs(1);
+        assert!(
+            t.note_blocked("m1", BlockReason::TargetNotLive, t1, THRESH, true)
+                .is_none(),
+            "delivery must reset m1's first-seen clock"
+        );
+        assert!(
+            t.note_blocked("m2", BlockReason::TargetNotLive, t1, THRESH, true)
+                .is_some(),
+            "m2's clock must be unaffected by m1's delivery"
+        );
+    }
+
+    #[test]
+    fn retain_pending_drops_vanished_messages() {
+        let mut t = SurfacingTracker::default();
+        let t0 = Instant::now();
+        t.note_blocked("gone", BlockReason::TargetNotLive, t0, THRESH, true);
+        t.note_blocked("kept", BlockReason::PtyNeverIdle, t0, THRESH, true);
+        let pending: std::collections::HashSet<&str> = ["kept"].into_iter().collect();
+        t.retain_pending(&pending);
+        assert!(!t
+            .entries
+            .contains_key(&("gone".to_string(), BlockReason::TargetNotLive)));
+        assert!(t
+            .entries
+            .contains_key(&("kept".to_string(), BlockReason::PtyNeverIdle)));
+    }
+
+    #[test]
+    fn surfacing_env_parsing_defaults() {
+        // Flag: absent ⇒ ON; only explicit falsy values disable.
+        assert!(resolve_surfacing_enabled(None));
+        assert!(resolve_surfacing_enabled(Some("1")));
+        assert!(resolve_surfacing_enabled(Some("weird")));
+        assert!(!resolve_surfacing_enabled(Some("0")));
+        assert!(!resolve_surfacing_enabled(Some("false")));
+        assert!(!resolve_surfacing_enabled(Some("No")));
+        assert!(!resolve_surfacing_enabled(Some(" off ")));
+        // Threshold: default 1800s, numeric override, garbage ⇒ default.
+        assert_eq!(resolve_surface_threshold(None), Duration::from_secs(1800));
+        assert_eq!(
+            resolve_surface_threshold(Some("60")),
+            Duration::from_secs(60)
+        );
+        assert_eq!(
+            resolve_surface_threshold(Some("nope")),
+            Duration::from_secs(1800)
+        );
+    }
+
+    #[test]
+    fn block_reason_wire_values() {
+        // Pins the coord route contract (`POST .../delivery-blocked` body).
+        assert_eq!(BlockReason::TargetNotLive.as_str(), "target_not_live");
+        assert_eq!(BlockReason::PtyNeverIdle.as_str(), "pty_never_idle");
     }
 }


### PR DESCRIPTION
Plan: `plans/2026-07-03-subagent-stall-watchdog.md` — PR 2 of 6 (D6 runner fixes, G2 lost-wakeup holes).

## What

**Fix 1 — backstop poll always armed** (`agent_runtime.rs`). Deletes the `at_cap_deferral_happened` arming gate: the 300s continuation/unit-dispatch backstop poll now fires unconditionally, so a WS frame lost while connected (no AtCap deferral, no terminal exit) can no longer strand a pending continuation until the next reconnect. Cadence is env-tunable via `RUNNER_CONTINUATION_BACKSTOP_POLL_SECS` (floored at 30s so a misconfiguration can't hammer coord; `0` clamps to the floor, never parks the loop). No flag — this removes a footgun gate.

**Fix 2 — undeliverable blocking messages surface** (`session_message_poller.rs`). A `priority="blocking"` message whose `to_session` doesn't resolve to a live local session past `RUNNER_BLOCKING_MSG_SURFACE_SECS` (default 1800) fires a typed POST to `POST /coord/session-messages/{id}/delivery-blocked` with `reason="target_not_live"` + `blocked_since`.

**Fix 3 — never-idle PTY aging** (same file). A blocking message whose target PTY never passes the idle gate past the same threshold fires the same POST with `reason="pty_never_idle"` — evidence for the supervisor's stuck-not-dead classifier. Injection behavior is unchanged (still just defers).

Fixes 2-3 are reporting-only, behind `RUNNER_DELIVERY_SURFACING_ENABLED` (**default ON** per the plan's resolved decision), at most one POST per message per threshold window (cooldown stamped before the attempt — no retry storm), and **fail-open by contract**: any error including 404 is a debug log, because the coord route ships in the plan's PR 3. No new runner routes (axum route table untouched).

## Tests

- `backstop_poll_secs_default_floor_and_override` — cadence resolution: default / floor / garbage / zero (replaces the deleted arming-flag test; the loop body now polls unconditionally, there is no arming predicate left).
- `should_surface` threshold + once-per-window cooldown; tracker fires exactly once then cools down then fires next window with the same `blocked_since`; per-reason independence; successful delivery clears tracking; `retain_pending` bounds the map; env parsing; wire-value pins for the coord route contract.
- All test instants are built additively from `Instant::now()` (never `now - big_offset`, which panics on underflow on freshly booted CI VMs).

## Verification

- `cargo check --all-targets` — clean.
- `cargo clippy -- -D warnings` (CI's exact invocation) — clean.
- `cargo fmt -- --check` — clean.
- Targeted tests: 1/1 backstop + 23/23 `session_message_poller` tests pass (`cargo test --bin qontinui-runner`).

Note: the local pre-push hook's stricter `cargo clippy --all-targets -- -D warnings` is red on **pristine origin/main** (8 pre-existing lints in `src-tauri/src/flywheel_e2e_tests.rs` — `doc_overindented_list_items`, `field_reassign_with_default`; that file is byte-identical to main in this branch and is being handled separately). Pushed with the hook's documented `QONTINUI_PREPUSH_SKIP=1` knob so CI gates, per the hook's own guidance.

Cargo.lock: `qontinui-types 0.7.0 → 0.8.0` — sibling `qontinui-schemas` released 0.8.0; CI clones schemas at depth 1 so the lock matches what CI resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)