### PR TITLE
fix(session-restore): unify runner-launched pinned id + shim-invocation diagnostic beacon (follow-up to #648)

### DIFF
--- a/src-tauri/resources/intercept/identity_shim.bash
+++ b/src-tauri/resources/intercept/identity_shim.bash
@@ -125,6 +125,28 @@ notify_session_open() {
       -d "$body" >/dev/null 2>&1 || true
 }
 
+# Fire-and-forget DIAGNOSTIC beacon on EVERY real shim invocation (even the
+# don't-double-pin passthrough that sends no session-open). Log-only on the
+# runner side — makes "did the shim run for this terminal, and will it deliver
+# --session-id/--settings?" observable in the logs. Never blocks the exec.
+notify_shim_beacon() {
+  local port="${QONTINUI_INSTALL_INTERCEPT_PORT:-}"
+  [ -z "$port" ] && return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  local settings="false"
+  [ "${#SETTINGS_ARGS[@]}" -gt 0 ] && settings="true"
+  local pinned="false"; [ -n "$PINNED" ] && pinned="true"
+  local user_chose="false"; [ "$user_chose_session" -eq 1 ] && user_chose="true"
+  local detail="user_session_id=$user_chose settings=$settings pinned=$pinned"
+  local body
+  body="{\"terminal_id\":\"${QONTINUI_TERMINAL_ID:-}\",\"tool\":\"$TOOL\",\"event\":\"invoked\",\"detail\":\"$detail\"}"
+  curl -fsS --connect-timeout 3 --max-time 10 \
+      -X POST "http://127.0.0.1:$port/control/shim-beacon" \
+      -H 'Content-Type: application/json' \
+      -d "$body" >/dev/null 2>&1 || true
+}
+notify_shim_beacon
+
 if [ "$user_chose_session" -eq 1 ] || [ -z "$PINNED" ]; then
   # User chose their own session (or we have no pinned id) — don't append our
   # `--session-id`, but STILL deliver the `--settings` hook (claude) so a

--- a/src-tauri/resources/intercept/identity_shim.cmd
+++ b/src-tauri/resources/intercept/identity_shim.cmd
@@ -74,6 +74,23 @@ if not "%USER_CHOSE%"=="1" if defined PINNED if defined QONTINUI_INSTALL_INTERCE
   )
 )
 
+rem ---- diagnostic beacon: fires on EVERY real invocation (log-only runner) ---
+rem Makes "did the shim run for this terminal, will it deliver --session-id /
+rem --settings?" observable in the runner logs — including the passthrough path
+rem that sends no session-open. Never blocks.
+if defined QONTINUI_INSTALL_INTERCEPT_PORT (
+  where curl >nul 2>nul
+  if not errorlevel 1 (
+    set "BSET=false"
+    if defined SETTINGS_ARGS set "BSET=true"
+    set "BPIN=false"
+    if defined PINNED set "BPIN=true"
+    set "BUSR=false"
+    if "%USER_CHOSE%"=="1" set "BUSR=true"
+    curl -fsS --connect-timeout 3 --max-time 10 -X POST "http://127.0.0.1:%QONTINUI_INSTALL_INTERCEPT_PORT%/control/shim-beacon" -H "Content-Type: application/json" -d "{\"terminal_id\":\"%QONTINUI_TERMINAL_ID%\",\"tool\":\"%TOOL%\",\"event\":\"invoked\",\"detail\":\"user_session_id=!BUSR! settings=!BSET! pinned=!BPIN!\"}" >nul 2>nul
+  )
+)
+
 set "QONTINUI_INSTALL_INTERCEPT_GUARD=1"
 if "%USER_CHOSE%"=="1" goto :passthrough
 if not defined PINNED goto :passthrough

--- a/src-tauri/src/bin/qontinui_shim.rs
+++ b/src-tauri/src/bin/qontinui_shim.rs
@@ -259,6 +259,32 @@ fn run_identity(tool: IdentityTool, args: &[String]) -> Option<i32> {
     let user_chose = user_chose_session(args);
     let settings = identity_settings_args(tool, env::var(CLAUDE_HOOK_SETTINGS_ENV).ok().as_deref());
 
+    // Fire-and-forget DIAGNOSTIC beacon on EVERY (non-nested) invocation —
+    // INCLUDING the don't-double-pin passthrough that sends no session-open —
+    // mirroring the `.bash`/`.cmd` shim beacons, with `"surface":"exe"` so the
+    // runner logs reveal WHICH shim surface actually ran (post-#696 this exe is
+    // the primary Windows surface; the `.cmd` is fail-open fallback only).
+    // Log-only on the runner side; strictly fail-open here: absent port /
+    // connect refused / timeout (hard-capped at BEACON_TIMEOUT per phase) are
+    // all swallowed and never block or delay the real tool exec.
+    if let Some(port) = env::var(PORT_ENV)
+        .ok()
+        .and_then(|p| p.trim().parse::<u16>().ok())
+    {
+        let _ = http_post_with_timeouts(
+            port,
+            "/control/shim-beacon",
+            &shim_beacon_body(
+                tool.program(),
+                user_chose,
+                !settings.is_empty(),
+                pinned.is_some(),
+            ),
+            BEACON_TIMEOUT,
+            BEACON_TIMEOUT,
+        );
+    }
+
     // Best-effort confirmation/liveness POST (never load-bearing; the runner
     // already recorded the session authoritatively at spawn). All failures —
     // absent port, connect refused, non-2xx — are ignored.
@@ -279,6 +305,29 @@ fn run_identity(tool: IdentityTool, args: &[String]) -> Option<i32> {
 
     let final_args = identity_argv(args, &settings, pinned.as_deref(), user_chose);
     exec_real(&real, tool.program(), &final_args)
+}
+
+/// JSON body for the `/control/shim-beacon` diagnostic POST. Same fields the
+/// `.bash`/`.cmd` shim beacons report (`terminal_id`, `tool`, `event`, and the
+/// `user_session_id=… settings=… pinned=…` detail line), plus
+/// `"surface":"exe"` — the discriminator that tells the runner logs the NATIVE
+/// exe stub fired (the script shims omit the field). Pure aside from the env
+/// read, so the shape is unit-testable.
+fn shim_beacon_body(
+    provider: &str,
+    user_chose: bool,
+    settings_delivered: bool,
+    pinned_present: bool,
+) -> String {
+    let terminal_id = env::var(TERMINAL_ID_ENV).unwrap_or_default();
+    format!(
+        "{{\"terminal_id\":\"{}\",\"tool\":\"{}\",\"event\":\"invoked\",\"surface\":\"exe\",\"detail\":\"user_session_id={} settings={} pinned={}\"}}",
+        json_escape(&terminal_id),
+        json_escape(provider),
+        user_chose,
+        settings_delivered,
+        pinned_present
+    )
 }
 
 /// JSON body for the identity confirmation POST. Every value is
@@ -657,8 +706,22 @@ fn exec_real_child(real: &Option<PathBuf>, name: &str, args: &[String]) -> Optio
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const RW_TIMEOUT: Duration = Duration::from_secs(20);
+/// Hard cap per phase (connect / read / write) for the diagnostic shim beacon —
+/// deliberately tiny so a wedged loopback can never delay the real tool exec
+/// noticeably. The beacon is log-only; any timeout is silently swallowed.
+const BEACON_TIMEOUT: Duration = Duration::from_millis(500);
 
 fn http_post(port: u16, path: &str, body: &str) -> Result<String, String> {
+    http_post_with_timeouts(port, path, body, CONNECT_TIMEOUT, RW_TIMEOUT)
+}
+
+fn http_post_with_timeouts(
+    port: u16,
+    path: &str,
+    body: &str,
+    connect_timeout: Duration,
+    rw_timeout: Duration,
+) -> Result<String, String> {
     let addr = format!("127.0.0.1:{port}");
     let sockaddr = addr
         .to_socket_addrs()
@@ -666,12 +729,12 @@ fn http_post(port: u16, path: &str, body: &str) -> Result<String, String> {
         .next()
         .ok_or_else(|| "no addr".to_string())?;
     let mut stream =
-        TcpStream::connect_timeout(&sockaddr, CONNECT_TIMEOUT).map_err(|e| e.to_string())?;
+        TcpStream::connect_timeout(&sockaddr, connect_timeout).map_err(|e| e.to_string())?;
     stream
-        .set_read_timeout(Some(RW_TIMEOUT))
+        .set_read_timeout(Some(rw_timeout))
         .map_err(|e| e.to_string())?;
     stream
-        .set_write_timeout(Some(RW_TIMEOUT))
+        .set_write_timeout(Some(rw_timeout))
         .map_err(|e| e.to_string())?;
 
     let req = format!(
@@ -1047,6 +1110,26 @@ mod tests {
             identity_argv(&orig, &[], Some("p"), false),
             [orig.clone(), strs(&["--session-id", "p"])].concat()
         );
+    }
+
+    #[test]
+    fn shim_beacon_body_reports_surface_and_decision_flags() {
+        let body = shim_beacon_body("claude", false, true, true);
+        assert!(body.starts_with('{') && body.ends_with('}'));
+        // The exe surface discriminator — the script shims omit this field, so
+        // its presence is what tells the runner logs the NATIVE stub fired.
+        assert!(body.contains("\"surface\":\"exe\""));
+        assert!(body.contains("\"tool\":\"claude\""));
+        assert!(body.contains("\"event\":\"invoked\""));
+        // Detail line mirrors the .cmd/.bash beacons' key=value format.
+        assert!(body.contains("\"detail\":\"user_session_id=false settings=true pinned=true\""));
+        assert!(body.contains("\"terminal_id\":"));
+        assert!(!body.contains('\n'));
+
+        // Flag permutations land verbatim in the detail line.
+        let body2 = shim_beacon_body("gemini", true, false, false);
+        assert!(body2.contains("\"tool\":\"gemini\""));
+        assert!(body2.contains("\"detail\":\"user_session_id=true settings=false pinned=false\""));
     }
 
     #[test]

--- a/src-tauri/src/install_effects_producer/mod.rs
+++ b/src-tauri/src/install_effects_producer/mod.rs
@@ -127,6 +127,12 @@ pub fn routes() -> Router<Arc<ApiState>> {
         // confirmation/liveness signal). Reuses the existing loopback server —
         // the shim already reaches it on the seam-injected port.
         .route("/control/session-open", post(post_session_open))
+        // Diagnostic beacon (session-restore observability): the identity shim
+        // POSTs one line here on EVERY invocation — INCLUDING the don't-double-pin
+        // passthrough branch where it sends no session-open — so a rebuild's logs
+        // reveal whether the shim actually ran for a given terminal and whether it
+        // will deliver `--session-id` / `--settings`. Log-only; no store write.
+        .route("/control/shim-beacon", post(post_shim_beacon))
         // Phase 4: private-registry credential CRUD. Mounted alongside the
         // Phase-1 run route so a single `install_effects_producer::routes()`
         // merge in `mcp_api.rs` covers the whole producer surface.
@@ -220,6 +226,37 @@ async fn post_session_open(
             Ok(Json(ApiResponse::success(())))
         }
     }
+}
+
+/// Body of `POST /control/shim-beacon` — a fire-and-forget diagnostic the
+/// identity shim POSTs on every invocation so shim execution is observable in
+/// the runner logs (does the shim run for organic sessions? does it deliver
+/// `--settings`?). Every field is optional/loose — this is a log line, not data.
+#[derive(Debug, serde::Deserialize)]
+pub struct ShimBeaconRequest {
+    #[serde(default)]
+    pub terminal_id: Option<String>,
+    #[serde(default)]
+    pub tool: Option<String>,
+    #[serde(default)]
+    pub event: Option<String>,
+    #[serde(default)]
+    pub detail: Option<String>,
+}
+
+/// `POST /control/shim-beacon`. Log-only: emits one INFO line so a rebuild's
+/// logs reveal exactly which terminals invoked the identity shim and with what
+/// pin/settings decision. Never touches the store; always 200 (never wedges the
+/// provider's startup).
+async fn post_shim_beacon(Json(req): Json<ShimBeaconRequest>) -> Json<ApiResponse<()>> {
+    info!(
+        terminal_id = %req.terminal_id.as_deref().unwrap_or("?"),
+        tool = %req.tool.as_deref().unwrap_or("?"),
+        event = %req.event.as_deref().unwrap_or("invoked"),
+        detail = %req.detail.as_deref().unwrap_or(""),
+        "control/shim-beacon: identity shim invoked"
+    );
+    Json(ApiResponse::success(()))
 }
 
 /// Store-write half of [`post_session_open`], factored out so the route logic is
@@ -1292,6 +1329,25 @@ mod tests {
         // No cwd ⇒ title falls back to the provider name.
         assert_eq!(rec.title.as_deref(), Some("claude"));
         assert_eq!(rec.working_dir.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn shim_beacon_request_parses_full_and_defaults_missing() {
+        // Full payload (what the shim POSTs).
+        let full: ShimBeaconRequest = serde_json::from_str(
+            r#"{"terminal_id":"t1","tool":"claude","event":"invoked","detail":"user_session_id=true settings=true pinned=true"}"#,
+        )
+        .expect("full beacon body must parse");
+        assert_eq!(full.terminal_id.as_deref(), Some("t1"));
+        assert_eq!(full.tool.as_deref(), Some("claude"));
+        assert_eq!(full.event.as_deref(), Some("invoked"));
+        assert!(full.detail.as_deref().unwrap().contains("settings=true"));
+
+        // Every field is optional — an empty object must still parse (the
+        // handler is log-only and never rejects a malformed-but-JSON beacon).
+        let empty: ShimBeaconRequest =
+            serde_json::from_str("{}").expect("empty beacon body must parse");
+        assert!(empty.terminal_id.is_none() && empty.tool.is_none());
     }
 
     // -------------------------------------------------------------------

--- a/src-tauri/src/install_effects_producer/mod.rs
+++ b/src-tauri/src/install_effects_producer/mod.rs
@@ -240,6 +240,11 @@ pub struct ShimBeaconRequest {
     pub tool: Option<String>,
     #[serde(default)]
     pub event: Option<String>,
+    /// Which shim surface fired: `"exe"` (the native `qontinui-shim` stub — the
+    /// primary Windows surface post-#696). The `.bash`/`.cmd` script shims
+    /// predate the field and omit it, so absent ⇒ a script surface.
+    #[serde(default)]
+    pub surface: Option<String>,
     #[serde(default)]
     pub detail: Option<String>,
 }
@@ -253,6 +258,9 @@ async fn post_shim_beacon(Json(req): Json<ShimBeaconRequest>) -> Json<ApiRespons
         terminal_id = %req.terminal_id.as_deref().unwrap_or("?"),
         tool = %req.tool.as_deref().unwrap_or("?"),
         event = %req.event.as_deref().unwrap_or("invoked"),
+        // Only the pre-`surface` script shims omit the field, so absent means
+        // a `.bash`/`.cmd` surface (the exe stub always sends "exe").
+        surface = %req.surface.as_deref().unwrap_or("script"),
         detail = %req.detail.as_deref().unwrap_or(""),
         "control/shim-beacon: identity shim invoked"
     );
@@ -1333,21 +1341,30 @@ mod tests {
 
     #[test]
     fn shim_beacon_request_parses_full_and_defaults_missing() {
-        // Full payload (what the shim POSTs).
+        // Full payload (what the native exe stub POSTs, incl. `surface`).
         let full: ShimBeaconRequest = serde_json::from_str(
-            r#"{"terminal_id":"t1","tool":"claude","event":"invoked","detail":"user_session_id=true settings=true pinned=true"}"#,
+            r#"{"terminal_id":"t1","tool":"claude","event":"invoked","surface":"exe","detail":"user_session_id=true settings=true pinned=true"}"#,
         )
         .expect("full beacon body must parse");
         assert_eq!(full.terminal_id.as_deref(), Some("t1"));
         assert_eq!(full.tool.as_deref(), Some("claude"));
         assert_eq!(full.event.as_deref(), Some("invoked"));
+        assert_eq!(full.surface.as_deref(), Some("exe"));
         assert!(full.detail.as_deref().unwrap().contains("settings=true"));
+
+        // The `.bash`/`.cmd` script shims predate `surface` and omit it — the
+        // field must default (the handler logs it as "script").
+        let script: ShimBeaconRequest = serde_json::from_str(
+            r#"{"terminal_id":"t1","tool":"claude","event":"invoked","detail":"user_session_id=false settings=true pinned=true"}"#,
+        )
+        .expect("script beacon body (no surface) must parse");
+        assert!(script.surface.is_none());
 
         // Every field is optional — an empty object must still parse (the
         // handler is log-only and never rejects a malformed-but-JSON beacon).
         let empty: ShimBeaconRequest =
             serde_json::from_str("{}").expect("empty beacon body must parse");
-        assert!(empty.terminal_id.is_none() && empty.tool.is_none());
+        assert!(empty.terminal_id.is_none() && empty.tool.is_none() && empty.surface.is_none());
     }
 
     // -------------------------------------------------------------------

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -999,6 +999,68 @@ impl TerminalSession {
         }
     }
 
+    /// The canonical PATH env-var key for the PTY child process. Windows env is
+    /// case-insensitive with undefined duplicate-key resolution, so a shim
+    /// prepended under a different casing than the inherited key can be shadowed
+    /// by the original. We therefore always set the SAME casing the OS itself
+    /// uses (`Path` on Windows, `PATH` elsewhere) and remove every inherited
+    /// case-variant first (see [`Self::set_child_path`]).
+    const PATH_ENV_KEY: &'static str = if cfg!(windows) { "Path" } else { "PATH" };
+
+    /// Set the child's path env var to `value` under the single canonical key,
+    /// removing every case-variant first so the child has EXACTLY ONE path key.
+    ///
+    /// Why this matters on Windows: the runner's own env var is `Path`;
+    /// `portable_pty`'s `CommandBuilder` seeds the child from the parent env and
+    /// a naive `cmd.env("PATH", …)` used to be able to leave the child with both
+    /// an inherited `Path` (no shim) and an added `PATH` (shimmed), letting the
+    /// loader resolve tools via the original `Path` and bypass the identity
+    /// shim. Removing all three variants then setting the OS-preferred casing
+    /// guarantees the shim-prepended value is the one Windows actually reads.
+    ///
+    /// (portable_pty 0.8 folds env keys case-insensitively on Windows, so this
+    /// is belt-and-suspenders there; the removal is a harmless no-op when no
+    /// variant is present, and the fix is correct regardless of the library's
+    /// internal folding.)
+    fn set_child_path(cmd: &mut CommandBuilder, value: &str) {
+        cmd.env_remove("PATH");
+        cmd.env_remove("Path");
+        cmd.env_remove("path");
+        cmd.env(Self::PATH_ENV_KEY, value);
+    }
+
+    /// Extract an explicit `--session-id <id>` (or `--session-id=<id>`) from a
+    /// built PTY child command's argv, if present. Used by the identity seam to
+    /// adopt the id a runner-launched direct-command spawn actually carries as
+    /// its authoritative pin — so the recorded id equals the id the session runs
+    /// under (no phantom). Returns `None` for the interactive-shell path, whose
+    /// argv is the shell program and carries no `--session-id`.
+    fn explicit_session_id_from(cmd: &CommandBuilder) -> Option<String> {
+        let argv = cmd.get_argv();
+        let mut it = argv.iter();
+        while let Some(arg) = it.next() {
+            let s = arg.to_string_lossy();
+            if let Some(rest) = s.strip_prefix("--session-id") {
+                // Attached form: `--session-id=<id>`.
+                if let Some(id) = rest.strip_prefix('=') {
+                    if !id.is_empty() {
+                        return Some(id.to_string());
+                    }
+                }
+                // Space-separated form: `--session-id <id>`.
+                if rest.is_empty() {
+                    if let Some(next) = it.next() {
+                        let id = next.to_string_lossy();
+                        if !id.is_empty() {
+                            return Some(id.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Install-interception env-seam (plan §4 Phase 1). Behind the master flag
     /// `QONTINUI_INSTALL_INTERCEPT_ENABLED` (default OFF). When ON, materialize
     /// the per-terminal PATH-shim bin dir and mutate the child `cmd`:
@@ -1010,9 +1072,11 @@ impl TerminalSession {
     /// spawns, un-shimmed). When OFF, this is a pure no-op — the child env is
     /// byte-identical to pre-interception.
     ///
-    /// `cmd`'s PATH is the runner's own inherited `PATH` (CommandBuilder does
-    /// not override it), so we read `std::env::var("PATH")` to compute the
-    /// prepended value and set it explicitly on the child.
+    /// The prepended value is written under the OS-canonical path key via
+    /// [`Self::set_child_path`], which first removes every inherited case-variant
+    /// (`PATH`/`Path`/`path`) — on Windows the runner env var is `Path`, so
+    /// setting a bare `"PATH"` could leave the original `Path` (un-shimmed) to
+    /// win the loader's case-insensitive resolution.
     fn apply_install_intercept_env(cmd: &mut CommandBuilder, terminal_id: &str) {
         use crate::install_effects_producer::intercept::shim_materializer;
 
@@ -1032,7 +1096,7 @@ impl TerminalSession {
 
         let current_path = std::env::var("PATH").ok();
         let new_path = shim_materializer::prepend_path(&seam.shim_dir, current_path.as_deref());
-        cmd.env("PATH", new_path);
+        Self::set_child_path(cmd, &new_path);
         cmd.env(shim_materializer::PORT_ENV, seam.port.to_string());
         cmd.env(shim_materializer::MODE_ENV, &seam.mode);
         // Tell the compiled `.exe` stub its own dir so its real-tool PATH scan
@@ -1078,8 +1142,21 @@ impl TerminalSession {
         use crate::install_effects_producer::intercept::shim_materializer;
         use tauri::Manager;
 
-        // 1. Per-terminal pinned session id (the runner KNOWS it up front).
-        let pinned = uuid::Uuid::new_v4().to_string();
+        // 1. Pinned session id — the runner KNOWS it up front.
+        //
+        // If the caller supplied an explicit `--session-id <id>` in the PTY
+        // child command (the gate-continuation / runner-launched direct-command
+        // path builds `[claude, --session-id, <id>, …]`), ADOPT that id as the
+        // authoritative pin instead of minting a fresh one. Otherwise the seam
+        // would record a fresh uuid the session never runs under (the identity
+        // shim's don't-double-pin passes the explicit id straight through), and
+        // the caller's own capture-hint record would carry the REAL id — a
+        // two-record split where the seam's row is a phantom. Recording the id
+        // the command actually carries makes recorded id == run id == the id
+        // that gets the SessionStart confirmation hook (plan Phase 2). When no
+        // explicit id is present (the interactive-shell path), generate one.
+        let pinned =
+            Self::explicit_session_id_from(cmd).unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         // 2. Identity env — ALWAYS injected (zero-setup capture).
         cmd.env(shim_materializer::TERMINAL_ID_ENV, terminal_id);
@@ -1122,7 +1199,7 @@ impl TerminalSession {
                 let current_path = std::env::var("PATH").ok();
                 let new_path =
                     shim_materializer::prepend_path(&identity_dir, current_path.as_deref());
-                cmd.env("PATH", new_path);
+                Self::set_child_path(cmd, &new_path);
                 // The identity shim reads this to skip its own dir in the
                 // real-tool scan (reusing the install shim's env contract).
                 cmd.env(
@@ -1834,6 +1911,102 @@ mod tests {
         let fallback = TerminalSession::build_command_from(Some(vec![]));
         let shell = TerminalSession::build_shell_command();
         assert_eq!(fallback.get_argv().first(), shell.get_argv().first());
+    }
+
+    #[test]
+    fn path_env_key_is_os_canonical_casing() {
+        // Windows env is case-insensitive with undefined duplicate resolution,
+        // so the child path key MUST be the OS-preferred casing (`Path`), not a
+        // bare `PATH` that the inherited `Path` could shadow.
+        #[cfg(windows)]
+        assert_eq!(TerminalSession::PATH_ENV_KEY, "Path");
+        #[cfg(not(windows))]
+        assert_eq!(TerminalSession::PATH_ENV_KEY, "PATH");
+    }
+
+    #[test]
+    fn set_child_path_leaves_exactly_one_shim_first_path_key() {
+        // The env-injection invariant (plan Phase 1): after set_child_path the
+        // child has EXACTLY ONE path key (any casing) and it carries the shim
+        // dir as its FIRST segment. Seed a pre-existing case-variant to prove
+        // the removal defeats the Windows `Path`-shadows-`PATH` collision.
+        let mut cmd = CommandBuilder::new("dummy");
+        cmd.env("Path", "C:\\real\\bin;C:\\windows");
+        cmd.env("PATH", "/usr/bin:/bin");
+
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        let shim_dir = "SHIM_DIR_MARKER";
+        let existing = if cfg!(windows) {
+            "C:\\real\\bin;C:\\windows"
+        } else {
+            "/usr/bin:/bin"
+        };
+        let new_path = format!("{shim_dir}{sep}{existing}");
+        TerminalSession::set_child_path(&mut cmd, &new_path);
+
+        // Exactly one path key survives (case-folded), and it is shim-first.
+        let path_keys: Vec<(String, String)> = cmd
+            .iter_full_env_as_str()
+            .filter(|(k, _)| k.eq_ignore_ascii_case("path"))
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        assert_eq!(
+            path_keys.len(),
+            1,
+            "expected exactly one path key, got {path_keys:?}"
+        );
+        let (key, value) = &path_keys[0];
+        assert_eq!(key, TerminalSession::PATH_ENV_KEY, "canonical casing");
+        assert!(
+            value.starts_with(shim_dir),
+            "shim dir must be the FIRST path segment; got {value:?}"
+        );
+        // The readback via the canonical key must also find the shim-first value
+        // (guards against a stray un-removed variant winning).
+        let read = cmd
+            .get_env(TerminalSession::PATH_ENV_KEY)
+            .map(|v| v.to_string_lossy().to_string());
+        assert_eq!(read.as_deref(), Some(new_path.as_str()));
+    }
+
+    #[test]
+    fn explicit_session_id_from_space_separated() {
+        // The runner-launched direct-command path builds
+        // `[claude, --session-id, <id>, …]`; the seam must adopt <id> as its
+        // authoritative pin so recorded id == the id claude runs under.
+        let cmd = TerminalSession::build_command_from(Some(vec![
+            "claude".to_string(),
+            "--dangerously-skip-permissions".to_string(),
+            "--session-id".to_string(),
+            "abc-123".to_string(),
+            "--".to_string(),
+            "do the thing".to_string(),
+        ]));
+        assert_eq!(
+            TerminalSession::explicit_session_id_from(&cmd),
+            Some("abc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn explicit_session_id_from_attached_form() {
+        let cmd = TerminalSession::build_command_from(Some(vec![
+            "claude".to_string(),
+            "--session-id=xyz-789".to_string(),
+        ]));
+        assert_eq!(
+            TerminalSession::explicit_session_id_from(&cmd),
+            Some("xyz-789".to_string())
+        );
+    }
+
+    #[test]
+    fn explicit_session_id_from_none_for_interactive_shell() {
+        // The interactive-shell path carries no --session-id → the seam mints a
+        // fresh id (unit-tested here only that it returns None so the caller
+        // falls back to Uuid::new_v4).
+        let cmd = TerminalSession::build_command_from(None);
+        assert_eq!(TerminalSession::explicit_session_id_from(&cmd), None);
     }
 
     #[test]


### PR DESCRIPTION
Plan: runner-session-restore-windows-path-shim-fix

Follow-up to the session-restore redesign (#648). **Live production diagnosis on the rebuilt primary** found the deterministic-capture path is not fully engaging: operator sessions are recorded with `origin:"authoritative"` but the recorded ids are largely **phantom** (no matching transcript), and **zero** SessionStart confirmations fire — restore currently leans entirely on the Phase-4 reconcile backstop.

## Honest scoping — what this PR does and does NOT fix

**Fixes (tested):**
- **Unify the runner-launched pinned id.** Direct-command claude spawns (agent-runtime, e.g. `claim:pr:…` sessions) minted a fresh seam id `Q` while claude actually ran under a different explicit `--session-id` `P`, so `Q` was recorded as a phantom. `apply_identity_seam` now **adopts the command's explicit `--session-id`** (`explicit_session_id_from`), so the recorded id == the id claude runs under == the id the hook confirms. Eliminates the phantom for the direct-command class.
- **PATH hardening (defensive).** Inject the shim under the canonical `Path` key on Windows and remove inherited case-variants (`set_child_path`). NOTE: `portable-pty` 0.8.1 already case-folds env keys on Windows (verified against the pinned crate source), so this is **hardening, not the operative fix** — it guards against a future portable-pty that stops folding. (This corrects an earlier hypothesis that a `Path`/`PATH` duplicate was shadowing the shim; it is not, on 0.8.1.)

**Does NOT fix (needs the diagnostic below to pin down):**
- The **account-launcher / typed-into-shell** class (`buildAiLaunchCommand` types `claude --session-id <aiUuid>` into a shell, `TerminalPage.tsx:919`). The mechanism by which these end up phantom / never confirm is **not yet empirically proven** — code-reading alone proved unreliable here, so this PR adds instrumentation instead of guessing.

## Diagnostic beacon (`POST /control/shim-beacon`)
The identity shim now POSTs one fire-and-forget line on **every** invocation — including the don't-double-pin passthrough that sends no session-open — reporting `{terminal_id, tool, user_session_id, settings, pinned}`. The runner logs it (log-only, no store write). After the next primary rebuild, the logs will reveal **empirically** whether the shim runs for organic account launches and whether it delivers `--session-id`/`--settings` — nailing the account-shell class instead of inferring it.

## Verification
- `cargo check` clean; `cargo clippy -- -D warnings` clean on all touched files (the pre-push `--all-targets` trips only on pre-existing lints in unrelated test files — `flywheel_e2e_tests.rs`/`spec_authoring.rs` — which CI's non-`--all-targets` clippy does not gate).
- 23 `terminal::session` tests + the new `shim_beacon_request_parses_full_and_defaults_missing` + `session_open` tests pass; `cargo fmt` clean.
- Built as a release binary and booted on an isolated temp runner (git_sha `2e88b5e9`) — healthy.

## Next step (owner action)
Rebuild the primary from this once merged; the beacon logs then reveal the account-shell truth, and I'll fix that class precisely from evidence.