### PR TITLE
fix(deps): patch runtime security advisories — js-yaml + dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "graphql-ws": "^6.0.7",
     "html2canvas": "^1.4.1",
     "html5-qrcode": "^2.3.8",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.15.0",
     "prism-react-renderer": "^2.4.1",
@@ -129,7 +129,7 @@
   "pnpm": {
     "overrides": {
       "@qontinui/shared-types": "^0.6.0",
-      "dompurify@<3.4.0": ">=3.4.0"
+      "dompurify": ">=3.4.11"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@qontinui/shared-types': ^0.6.0
-  dompurify@<3.4.0: '>=3.4.0'
+  dompurify: '>=3.4.11'
 
 importers:
 
@@ -142,8 +142,8 @@ importers:
         specifier: ^2.3.8
         version: 2.3.8
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.3.0
       lucide-react:
         specifier: ^1.7.0
         version: 1.14.0(react@19.2.5)
@@ -3002,8 +3002,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -3708,8 +3708,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -7709,7 +7709,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -7719,7 +7719,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -8033,7 +8033,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.8:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8892,7 +8892,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -9241,7 +9241,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.8
+      dompurify: 3.4.11
       es-toolkit: 1.46.1
       katex: 0.16.45
       khroma: 2.1.0
@@ -9476,7 +9476,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.4.11
       marked: 14.0.0
 
   ms@2.1.3: {}


### PR DESCRIPTION
Patches the two **runtime-reachable** Dependabot advisories on the runner
frontend. (Part 1 of 2 — the dev/build-tooling sweep is a separate PR.)

| Alert | Pkg | Sev | Reachability | Fix |
|---|---|---|---|---|
| GHSA-h67p-54hq-rp68 (#49) | js-yaml | med | **Runtime.** Direct dep; `yaml.load()` runs on user/repo-supplied workflow YAML in the DAG editor (`src/components/dag-workflow-editor/*.tsx`) → quadratic DoS could hang the editor. | `4.1.1` → `4.3.0`, range bumped to `^4.2.0` |
| GHSA-cmwh-pvxp-8882 (#46) + GHSA-vxr8-fq34-vvx9 (#44) | dompurify | med / low | **Runtime.** Transitive via `mermaid` + `monaco-editor` → reachable rendering diagrams from untrusted repo/agent content. | `3.4.8` → `3.4.11` via raising the existing `pnpm.overrides` floor `>=3.4.0` → `>=3.4.11` |

`tsc --noEmit` clean; mermaid + monaco resolved against dompurify 3.4.11 with no
conflict. Lockfile + one override + one range bump — no source changes.

**Deferred (analyzed, intentionally not here):** opentelemetry_sdk (#47/#48 —
0.27→0.32.1 is a multi-minor Rust upgrade with API breaks; the W3C-Baggage vuln
isn't reachable, runner is an OTLP client) and cmov (#50 — transitive,
aarch64-only correctness; runner is x86_64). Dev/build-tooling advisories
(vite/esbuild/babel/form-data/shell-quote) are in the companion PR.