### PR TITLE
fix(release): auto-publish releases (publish-update-json was silently skipped)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,9 +380,31 @@ jobs:
   publish-update-json:
     needs: [create-release, build]
     runs-on: ubuntu-latest
+    # Run even when the non-blocking (continue-on-error) macOS/Linux legs fail.
+    # A failed leg makes `needs.build` non-success, which was SILENTLY SKIPPING
+    # this whole job — so releases never actually auto-published (v1.0.0 and
+    # v1.0.1 both had to be un-drafted by hand). `always()` lets it run; the
+    # asset-verify step below still guarantees we never publish an assetless
+    # release, keeping Windows the sole hard gate.
+    if: ${{ always() && needs.create-release.result == 'success' }}
 
     steps:
       - uses: actions/checkout@v5
+
+      # Hard gate: only proceed if the Windows installer actually built and
+      # uploaded. Fails the job (leaving the release a draft) otherwise, so a
+      # broken Windows leg never yields a published-but-empty "latest" release.
+      - name: Verify Windows installer uploaded
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          names=$(gh release view "v${{ needs.create-release.outputs.release_version }}" \
+            --repo "${{ github.repository }}" --json assets --jq '.assets[].name')
+          echo "Release assets:"; echo "$names"
+          echo "$names" | grep -qi 'setup\.exe' || {
+            echo "::error::No Windows -setup.exe asset on the release — refusing to publish an empty release.";
+            exit 1;
+          }
 
       - name: Generate update manifest
         run: |
@@ -406,7 +428,7 @@ jobs:
               },
               "windows-x86_64": {
                 "signature": "",
-                "url": "https://github.com/${{ github.repository }}/releases/download/v${{ needs.create-release.outputs.release_version }}/qontinui-runner_${{ needs.create-release.outputs.release_version }}_x64.msi"
+                "url": "https://github.com/${{ github.repository }}/releases/download/v${{ needs.create-release.outputs.release_version }}/Qontinui.Runner_${{ needs.create-release.outputs.release_version }}_x64-setup.exe"
               }
             }
           }


### PR DESCRIPTION
## Problem
`publish-update-json` never ran on a real tagged release. Its bare `needs: [create-release, build]` (no `if:`) meant that when a `continue-on-error` macOS/Linux leg failed — which is every run — `needs.build` was non-success and the whole job **skipped**. So the draft release was never un-drafted: **v1.0.0 and v1.0.1 were both published by hand**.

Also, the generated `update.json` `windows-x86_64` URL pointed at a non-existent `qontinui-runner_<v>_x64.msi`; the real asset is the NSIS `Qontinui.Runner_<v>_x64-setup.exe`.

## Fix
- `if: ${{ always() && needs.create-release.result == 'success' }}` so the job runs regardless of the non-blocking legs.
- New **"Verify Windows installer uploaded"** step: fails the job (leaving the release a draft) unless a `-setup.exe` asset exists — so Windows stays the sole hard gate and we never publish an assetless "latest" release.
- Correct the `update.json` Windows URL to the real `-setup.exe`.

Effect: the next tagged release with a green Windows leg auto-publishes (un-draft + non-prerelease) instead of needing a manual `gh release edit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)