### PR TITLE
feat(spec-api): implement SSM credential fetch for auth injection (Phase 2)

### DIFF
--- a/src-tauri/src/spec_api/auth_injection.rs
+++ b/src-tauri/src/spec_api/auth_injection.rs
@@ -153,38 +153,131 @@ pub async fn create_auth_setup_step(
 
 /// Fetch app credentials from AWS SSM Parameter Store.
 ///
-/// Attempts to retrieve credentials from `/qontinui/apps/{app_id}/login`.
+/// Retrieves the SecureString parameter `/qontinui/apps/{app_id}/login`
+/// (JSON: `{"email": "...", "password": "...", "email_selector"?: ...}`)
+/// by shelling out to the `aws` CLI. The CLI is the fleet's established
+/// SSM access path (dev machines and CI carry configured CLIs; the runner
+/// deliberately has no AWS SDK dependency — adding aws-config/aws-sdk-ssm
+/// for this one read would swell the build for a call most installs never
+/// make). Region defaults to `eu-central-1` (where `/qontinui/*` params
+/// live); override with `QONTINUI_SSM_REGION`.
 ///
 /// # Return Values
 ///
 /// - `Ok(Some(creds))` — Credentials found and parsed successfully
 /// - `Ok(None)` — Credentials not found or AWS unavailable (fail-open, logs warning)
-/// - `Err(_)` — Credential parsing failed (should not occur in normal operation)
+/// - `Err(_)` — Credentials present but malformed (operator must fix the parameter)
 ///
 /// # Fail-Open Behavior
 ///
-/// Network failures, missing parameters, and AWS SDK errors return `Ok(None)`
-/// and log a warning. The caller should skip auth injection and allow
-/// spec-check to proceed without authentication.
+/// A missing `aws` binary, missing AWS credentials, network failures, and
+/// `ParameterNotFound` all return `Ok(None)` and log. The caller should
+/// skip auth injection and allow spec-check to proceed without
+/// authentication. Only a parameter that EXISTS but carries malformed
+/// JSON returns `Err` — that is an operator configuration error worth
+/// surfacing loudly rather than silently running unauthenticated.
+///
+/// The decrypted parameter value is never logged.
 pub async fn fetch_app_credentials(
     app_id: &str,
 ) -> Result<Option<AppCredentials>, AuthInjectionError> {
-    // TODO: Implement AWS SDK integration once dependencies are added to Cargo.toml
-    // For now, return None to implement fail-open path and allow testing
+    let param = format!("/qontinui/apps/{}/login", app_id);
+    let region =
+        std::env::var("QONTINUI_SSM_REGION").unwrap_or_else(|_| "eu-central-1".to_string());
 
-    debug!(
-        app_id = %app_id,
-        "credential fetch not yet implemented (will support AWS SSM in production)"
-    );
+    let output = tokio::process::Command::new("aws")
+        .args([
+            "ssm",
+            "get-parameter",
+            "--name",
+            &param,
+            "--with-decryption",
+            "--region",
+            &region,
+            "--output",
+            "json",
+        ])
+        .output()
+        .await;
 
-    // In production, this would:
-    // 1. Load AWS configuration from environment
-    // 2. Create Secrets Manager client
-    // 3. Fetch `/qontinui/apps/{app_id}/login` secret
-    // 4. Parse JSON and validate required fields
-    // 5. Return Ok(Some(creds)) on success, Ok(None) on not-found
+    let output = match output {
+        Ok(o) => o,
+        Err(e) => {
+            warn!(
+                app_id = %app_id,
+                error = %e,
+                "aws CLI unavailable — skipping auth injection (fail-open)"
+            );
+            return Ok(None);
+        }
+    };
 
-    Ok(None)
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("ParameterNotFound") {
+            debug!(
+                app_id = %app_id,
+                param = %param,
+                "no login credentials configured in SSM (fail-open)"
+            );
+        } else {
+            warn!(
+                app_id = %app_id,
+                param = %param,
+                "SSM get-parameter failed — skipping auth injection (fail-open): {}",
+                stderr.trim()
+            );
+        }
+        return Ok(None);
+    }
+
+    let creds = parse_ssm_get_parameter_output(&output.stdout, &param)?;
+    if creds.is_some() {
+        info!(app_id = %app_id, param = %param, "fetched login credentials from SSM");
+    }
+    Ok(creds)
+}
+
+/// Parse the `aws ssm get-parameter --output json` envelope and the
+/// credential JSON inside `Parameter.Value`. Factored out of
+/// [`fetch_app_credentials`] so the parse contract is unit-testable
+/// without AWS.
+///
+/// An unreadable ENVELOPE (aws CLI output shape changed / truncated) is
+/// fail-open `Ok(None)`; a readable envelope whose VALUE is malformed or
+/// missing required fields is `Err(InvalidCredentials)` — the parameter
+/// exists, so someone configured it wrong.
+fn parse_ssm_get_parameter_output(
+    stdout: &[u8],
+    param: &str,
+) -> Result<Option<AppCredentials>, AuthInjectionError> {
+    let envelope: serde_json::Value = match serde_json::from_slice(stdout) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(param = %param, error = %e, "unparseable aws CLI envelope (fail-open)");
+            return Ok(None);
+        }
+    };
+    let value = match envelope
+        .pointer("/Parameter/Value")
+        .and_then(|v| v.as_str())
+    {
+        Some(v) => v,
+        None => {
+            warn!(param = %param, "aws CLI envelope missing Parameter.Value (fail-open)");
+            return Ok(None);
+        }
+    };
+
+    let creds: AppCredentials = serde_json::from_str(value).map_err(|e| {
+        AuthInjectionError::InvalidCredentials(format!("malformed credential JSON in {param}: {e}"))
+    })?;
+    if creds.email.is_empty() || creds.password.is_empty() {
+        return Err(AuthInjectionError::InvalidCredentials(format!(
+            "{param}: email and password must be non-empty"
+        )));
+    }
+    Ok(Some(creds))
 }
 
 // ============================================================================
@@ -242,5 +335,69 @@ mod tests {
 
         let err = AuthInjectionError::InvalidCredentials("missing email".into());
         assert_eq!(err.to_string(), "Invalid credentials: missing email");
+    }
+
+    fn envelope(value: &str) -> Vec<u8> {
+        serde_json::json!({
+            "Parameter": {
+                "Name": "/qontinui/apps/x/login",
+                "Type": "SecureString",
+                "Value": value,
+            }
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn parse_valid_envelope_returns_creds() {
+        let value = r##"{"email":"a@b.c","password":"pw","email_selector":"#e"}"##;
+        let creds = parse_ssm_get_parameter_output(&envelope(value), "/p")
+            .unwrap()
+            .expect("creds");
+        assert_eq!(creds.email, "a@b.c");
+        assert_eq!(creds.password, "pw");
+        assert_eq!(creds.email_selector, Some("#e".into()));
+    }
+
+    #[test]
+    fn parse_garbage_envelope_fails_open() {
+        assert!(parse_ssm_get_parameter_output(b"not json", "/p")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn parse_envelope_without_value_fails_open() {
+        let out = serde_json::json!({"Parameter": {"Name": "/p"}})
+            .to_string()
+            .into_bytes();
+        assert!(parse_ssm_get_parameter_output(&out, "/p")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn parse_malformed_credential_json_is_err() {
+        let r = parse_ssm_get_parameter_output(&envelope("{not creds}"), "/p");
+        assert!(matches!(r, Err(AuthInjectionError::InvalidCredentials(_))));
+    }
+
+    #[test]
+    fn parse_empty_email_or_password_is_err() {
+        let r = parse_ssm_get_parameter_output(&envelope(r#"{"email":"","password":"pw"}"#), "/p");
+        assert!(matches!(r, Err(AuthInjectionError::InvalidCredentials(_))));
+        let r =
+            parse_ssm_get_parameter_output(&envelope(r#"{"email":"a@b.c","password":""}"#), "/p");
+        assert!(matches!(r, Err(AuthInjectionError::InvalidCredentials(_))));
+    }
+
+    #[tokio::test]
+    async fn fetch_fails_open_when_parameter_absent() {
+        // Whatever this environment has (aws CLI or not, creds or not), a
+        // random never-provisioned app_id must resolve to Ok(None) — the
+        // fail-open contract callers rely on.
+        let r = fetch_app_credentials("test-app-that-does-not-exist-xyz").await;
+        assert!(matches!(r, Ok(None)));
     }
 }


### PR DESCRIPTION
## What
Phase 2 of B v1's auth injection (Phase B scaffold landed in #668): `fetch_app_credentials` now actually fetches, replacing the fail-open stub.

## How
Shells out to `aws ssm get-parameter --with-decryption` for the SecureString `/qontinui/apps/{app_id}/login` (JSON: `email`, `password`, optional field selectors). The `aws` CLI is the fleet's established SSM access path — the runner deliberately gains **no AWS SDK dependency** (aws-config + aws-sdk-ssm would swell the build for a call most installs never make). Region defaults to `eu-central-1` (where `/qontinui/*` params live); override via `QONTINUI_SSM_REGION`.

## Fail-open contract (unchanged from Phase B)
- Missing `aws` binary, missing AWS creds, network failure, `ParameterNotFound` → `Ok(None)`, spec-check proceeds unauthenticated
- Parameter **present but malformed** → `Err(InvalidCredentials)` — an operator misconfiguration worth surfacing loudly rather than silently running unauthenticated
- Decrypted values are never logged

## Testing
Envelope/credential parsing factored into `parse_ssm_get_parameter_output` (pure, no AWS): 5 parse-contract unit tests + 1 environment-tolerant fail-open e2e (asserts `Ok(None)` for a never-provisioned app_id regardless of whether the host has a CLI/creds). Full local gauntlet: `cargo check --tests` clean, `cargo fmt` clean, `cargo clippy -- -D warnings` clean, auth_injection suite 9/9.

Next (separate change): wire `create_auth_setup_step` into spec workflow generation for apps with `auth_required=true` — this module is still a leaf.