### PR TITLE
style(runner): fix 8 clippy --all-targets lints in test code

### DIFF
--- a/src-tauri/src/flywheel_e2e_tests.rs
+++ b/src-tauri/src/flywheel_e2e_tests.rs
@@ -17,22 +17,22 @@
 //!
 //!   1. flywheel_full_walk_synthetic_page_through_promotion
 //!      — write_pending_ir → simulate green → promote → assert canonical IR
-//!        exists with provenance.status = Promoted.
+//!      exists with provenance.status = Promoted.
 //!   2. flywheel_demotes_on_single_red
 //!      — write_pending_ir → simulate red → demote → assert _pending/ gone
-//!        and no canonical IR was written.
+//!      and no canonical IR was written.
 //!   3. flywheel_skips_existing_specs_in_scan
 //!      — pre-create canonical IR for spec_id → list_pages exposes it →
-//!        scan filter would skip it.
+//!      scan filter would skip it.
 //!   4. flywheel_dedupes_concurrent_scans
 //!      — insert_proposal twice with same kind+pathname → second returns
-//!        Ok(false) per the UNIQUE constraint.
+//!      Ok(false) per the UNIQUE constraint.
 //!   5. flywheel_patch_preserves_hand_authored
 //!      — merge_patch_into_ir on hand-authored state → rejects with the
-//!        "pinned state" sentinel.
+//!      "pinned state" sentinel.
 //!   6. flywheel_validator_rejects_low_coverage
 //!      — synthetic IR with no transitions → gate_coverage returns
-//!        CoverageBelowFloor.
+//!      CoverageBelowFloor.
 //!
 //! Pretty much all of these rely on integration-time visibility of
 //! `spec_api`, `workflow_generation`, and (for the validator inner helper +
@@ -596,8 +596,10 @@ async fn flywheel_patch_preserves_hand_authored() {
     // `add_transitions: Vec<IrTransition>`. We populate just the required-
     // elements bucket — the merge helper validates BEFORE applying so it
     // never half-mutates.
-    let mut crit = IrElementCriteria::default();
-    crit.id = Some("new-elem".into());
+    let crit = IrElementCriteria {
+        id: Some("new-elem".into()),
+        ..Default::default()
+    };
 
     let mut patch = IrPatch::default();
     patch

--- a/src-tauri/src/workflow_generation/spec_authoring.rs
+++ b/src-tauri/src/workflow_generation/spec_authoring.rs
@@ -1192,9 +1192,10 @@ mod tests {
     }
 
     fn make_criteria(id: &str) -> IrElementCriteria {
-        let mut c = IrElementCriteria::default();
-        c.id = Some(id.into());
-        c
+        IrElementCriteria {
+            id: Some(id.into()),
+            ..Default::default()
+        }
     }
 
     fn make_transition(id: &str, from: &str, to: &str) -> IrTransition {


### PR DESCRIPTION
Fixes the 8 pre-existing clippy lints surfaced while shipping the Dependabot PRs
(#700/#702). The pre-push hook runs `cargo clippy --all-targets -- -D warnings`,
which lints `#[cfg(test)]` code that CI's `cargo clippy -- -D warnings` (no
`--all-targets`, ci.yml:230) never compiles — so these lints blocked pushes of
otherwise-clean branches (e.g. dependency-only ones) even though CI stayed green.

**8 lints, all in test code:**
- **2× `field_reassign_with_default`** — `let mut x = T::default(); x.f = v;` →
  struct-literal `T { f: v, ..Default::default() }`
  (`flywheel_e2e_tests.rs`, `workflow_generation/spec_authoring.rs`).
- **6× `doc_overindented_list_items`** — de-indented the wrapped continuation
  lines of the numbered-invariant doc list in `flywheel_e2e_tests.rs` from 8→6
  spaces so they align under the list-item text.

**Verified:** `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt`
clean; pre-push hook passes (the same hook that rejected #702). Test code only —
no behavior change.

Independent of #700/#702 (touches only Rust test files); can land in any order.