### PR TITLE
feat: enable interactive-agent-logs by default (flip gate ON, keep kill-switch)

### DIFF
--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -82,16 +82,19 @@ fn registration_enabled() -> bool {
     }
 }
 
-/// Default-OFF env gate for streaming interactive-session activity to coord's
-/// `agent_logs` ingest (Phase 1c). ONLY a truthy value — `1` / `true` / `on` /
-/// `yes` (case-insensitive) — turns it ON; anything else (including unset)
-/// leaves it OFF, so the emitter is a strict no-op by default and never adds
-/// always-on coord traffic.
+/// Default-ON gate for streaming interactive-session activity to coord's
+/// `agent_logs` ingest (Phase 1c). The feature is enabled by default — the
+/// rollout burn-in passed and the Phase-2 `session_started` flood fix
+/// (runner#637) landed — so deployed AND dev runners emit with no
+/// per-environment config (no dev-start.ps1 flag, no machine env var). Set
+/// `QONTINUI_AGENT_LOGS_FROM_SESSIONS` to an explicit falsy value — `0` /
+/// `false` / `off` / `no` (case-insensitive) — as an ops kill-switch to turn
+/// it off; unset (the production default) and any other value leave it ON.
 pub fn agent_logs_from_sessions_enabled() -> bool {
-    matches!(
+    !matches!(
         std::env::var("QONTINUI_AGENT_LOGS_FROM_SESSIONS")
             .map(|v| v.trim().to_ascii_lowercase()),
-        Ok(ref v) if matches!(v.as_str(), "1" | "true" | "on" | "yes")
+        Ok(ref v) if matches!(v.as_str(), "0" | "false" | "off" | "no")
     )
 }
 
@@ -984,24 +987,27 @@ mod tests {
     }
 
     #[test]
-    fn agent_logs_gate_defaults_off_and_only_truthy_enables() {
+    fn agent_logs_gate_defaults_on_and_only_falsy_disables() {
         let _env = env_lock();
         std::env::remove_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS");
-        // Default (unset) is OFF — strict no-op posture.
-        assert!(!agent_logs_from_sessions_enabled());
+        // Default (unset) is ON — the feature is standard after the rollout
+        // burn-in; deployed runners need no per-environment config.
+        assert!(agent_logs_from_sessions_enabled());
 
-        for off in ["0", "false", "off", "", "no", "garbage"] {
+        // Only an explicit falsy value disables it (the ops kill-switch).
+        for off in ["0", "false", "off", "no", "FALSE", "Off", "No"] {
             std::env::set_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS", off);
             assert!(
                 !agent_logs_from_sessions_enabled(),
-                "value {off:?} must NOT enable the gate"
+                "value {off:?} must disable the gate (kill-switch)"
             );
         }
-        for on in ["1", "true", "on", "yes", "TRUE", "On", "Yes"] {
+        // Unset, truthy, empty, or unrecognized all leave it ON.
+        for on in ["1", "true", "on", "yes", "", "garbage"] {
             std::env::set_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS", on);
             assert!(
                 agent_logs_from_sessions_enabled(),
-                "value {on:?} must enable the gate"
+                "value {on:?} must leave the gate ON (only explicit falsy disables)"
             );
         }
         std::env::remove_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS");

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -145,8 +145,9 @@ pub struct ClaudeSession {
     /// Interactive-agent log emitter (Phase 1b/1c). When `Some`, the stdout
     /// reader streams each line to coord's `agent_logs` ingest and the waiter
     /// thread emits the terminal `session_closed` line + final flush. `None`
-    /// when the `QONTINUI_AGENT_LOGS_FROM_SESSIONS` gate is OFF (default) or
-    /// the coord session id / device id couldn't be resolved — a strict no-op.
+    /// when the `QONTINUI_AGENT_LOGS_FROM_SESSIONS` gate is disabled (the
+    /// default is ON) or the coord session id / device id couldn't be
+    /// resolved — a strict no-op.
     agent_log_emitter: Option<super::coord_register::AgentLogEmitter>,
 }
 

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -476,8 +476,9 @@ pub async fn create_ai_session(
     let coord_session_id = ai_coord_registrar.register_session(&task_run_id, &name, None);
 
     // Phase 1b/1c — build the interactive-agent log emitter when the
-    // `QONTINUI_AGENT_LOGS_FROM_SESSIONS` gate is ON and the coord session id
-    // resolved. `None` (the default) is a strict no-op threaded through spawn.
+    // `QONTINUI_AGENT_LOGS_FROM_SESSIONS` gate is ON (the default) and the
+    // coord session id resolved. `None` (gate disabled, or id unresolved) is a
+    // strict no-op threaded through spawn.
     let agent_log_emitter =
         coord_session_id.and_then(crate::claude_session::coord_register::AgentLogEmitter::start);
 


### PR DESCRIPTION
## What
The interactive-session → `coord.agent_logs` feature (plan 2026-06-17; streams interactive + PTY-CLI Claude sessions to `/admin/coord/agents`) was gated **default-OFF** for the rollout burn-in. That burn-in passed (device→tenant resolution + Phase-3 `is_interactive` verified against live coord) and the Phase-2 `session_started` flood fix (#637) landed, so the feature is now standard behavior.

**Flip `agent_logs_from_sessions_enabled()` to default-ON.** Every runner — dev AND deployed/production — now emits with **no per-environment config**: no `dev-start.ps1` flag, no machine env var. (Companion: qontinui-claude-config #109 removes the now-redundant `dev-start.ps1` line.)

## Kill-switch
`QONTINUI_AGENT_LOGS_FROM_SESSIONS` is now an **ops kill-switch**: set an explicit falsy value — `0` / `false` / `off` / `no` (case-insensitive) — to disable without a redeploy. Unset (the default) or any other value leaves it ON.

## Changes (3 files)
- `coord_register.rs`: flip the gate fn (`!matches!(… falsy …)`) + rewrite its unit test to the new semantics (default-ON, only-falsy-disables, empty/garbage stay ON).
- `session.rs` + `commands/ai_session.rs`: correct the now-stale "default OFF" doc comments.

## Verify
Gate unit test passes (`agent_logs_gate_defaults_on_and_only_falsy_disables ... ok`); clippy clean.

## Note for later (not in scope)
This streams session content (assistant text, tool_use) to `coord.agent_logs`. For **multi-tenant hosted** runners, a future per-tenant coord flag may be preferable to global default-ON; the kill-switch env var is the interim per-runner override.