### PR TITLE
fix(ci): authenticate postgresql_embedded build-script GitHub API calls (kill the 403 flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Authenticate the `postgresql_embedded` (bundled) build script's GitHub
+  # API calls (it enumerates theseus-rs/postgresql-binaries releases at
+  # compile time). Unauthenticated api.github.com is 60 req/hr keyed on the
+  # shared GitHub-hosted-runner IP, which the multi-page enumeration blows
+  # through → intermittent 403 build failures. The Actions token moves it to
+  # the ~1000/hr per-token budget. Plan: 2026-07-04-runner-ci-postgresql-embedded-403-fix.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   test:

--- a/.github/workflows/clorinde-bindings-fresh.yml
+++ b/.github/workflows/clorinde-bindings-fresh.yml
@@ -46,6 +46,16 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  # The `cargo check` re-run against fresh bindings compiles the whole
+  # workspace, including the `postgresql_embedded` (bundled) build script — a
+  # compile-time GitHub API release enumeration that 403s on the unauthenticated
+  # 60/hr shared-IP budget. The existing GITHUB_TOKEN/CLORINDE_AUTOCOMMIT_TOKEN
+  # refs are only on the checkout/push steps, not the build env; this
+  # workflow-level export reaches the cargo step.
+  # Plan: 2026-07-04-runner-ci-postgresql-embedded-403-fix.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   # ---------------------------------------------------------------------
   # detect: short-circuit when the PR doesn't touch Clorinde-relevant

--- a/.github/workflows/qontinui-types-drift.yml
+++ b/.github/workflows/qontinui-types-drift.yml
@@ -36,6 +36,13 @@ on:
       - "src-tauri/src/relay_envelopes.rs"
       - "src-tauri/scripts/generate_types.sh"
 
+env:
+  # generate_types.sh runs `cargo build --bin export_schemas`, which compiles
+  # the `postgresql_embedded` (bundled) build script → a compile-time GitHub API
+  # release enumeration that 403s on the unauthenticated 60/hr shared-IP budget.
+  # Authenticate it. Plan: 2026-07-04-runner-ci-postgresql-embedded-403-fix.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   check-drift:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  # The `build` job's `tauri build` runs `cargo build`, compiling the
+  # `postgresql_embedded` (bundled) build script — a compile-time GitHub API
+  # release enumeration that 403s on the unauthenticated 60/hr shared-IP budget.
+  # Authenticate it here at workflow scope (the build job had no GITHUB_TOKEN).
+  # Plan: 2026-07-04-runner-ci-postgresql-embedded-403-fix.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   # Build Python executor for bundling (optional). Opt-in via workflow_dispatch

--- a/.github/workflows/reproducibility-gate.yml
+++ b/.github/workflows/reproducibility-gate.yml
@@ -33,6 +33,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Authenticate the `postgresql_embedded` (bundled) build script's compile-time
+  # GitHub API release enumeration — else the unauthenticated 60/hr shared-IP
+  # budget 403s intermittently. Plan: 2026-07-04-runner-ci-postgresql-embedded-403-fix.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   repro-build:


### PR DESCRIPTION
## Problem
`postgresql_embedded` (bundled, added by #681) runs a build script that enumerates `theseus-rs/postgresql-binaries` releases via the GitHub REST API **at compile time**, paginating every release page unconditionally (`postgresql_archive-0.20.4/src/repository/github/repository.rs:106-146` — it selects the max matching version, so it never short-circuits). Unauthenticated api.github.com is **60 req/hr keyed on the source IP**, and GitHub-hosted runners share egress IPs across *all* Actions customers — so the multi-page enumeration intermittently **403s and fails the build**. Observed live on #703; it's a latent flake on every runner PR that compiles the crate.

## Fix
Export `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` (the auto-provisioned Actions token — no new secret/PAT) at the **workflow level** of every runner-compiling workflow. The crate honors `GITHUB_TOKEN` (`repository.rs:31` → `Authorization: Bearer` at `:211`), moving the calls onto the **~1000/hr per-token** budget.

| Workflow | Why | Was covered? |
|---|---|---|
| `ci.yml` | `cargo clippy`/`test` (where the flake was seen) | no |
| `reproducibility-gate.yml` | `cargo build --release` ×2 | no |
| `qontinui-types-drift.yml` | `cargo build --bin export_schemas` | no |
| `clorinde-bindings-fresh.yml` | whole-workspace `cargo check` | token was only on checkout/push steps, not the build env |
| `release.yml` | `tauri build` → `cargo build` (tag builds) | no |

## Not included
Version pinning (`POSTGRESQL_VERSION`) — it does **not** reduce the API calls (the enumeration is exhaustive) and would silently change the bundled binary (a runtime concern out of scope). See the plan for the full alternatives analysis.

## Expected guard behavior
`ci.yml`, `reproducibility-gate.yml`, `clorinde-bindings-fresh.yml`, and `qontinui-types-drift.yml` are all in the CI-integrity `GATING` list, so this PR goes **red on "Guard gating workflows from self-edits" by design** and needs operator review/merge — same flow as the audit-ignore PRs #678/#680. One merge clears the batch.

Additive only (34 lines, all `GITHUB_TOKEN` + explanatory comments); all 5 YAMLs validated.