### PR TITLE
feat(setup-wizard): clone GitHub repos via the qontinui GitHub App

### DIFF
--- a/src-tauri/src/commands/setup_wizard.rs
+++ b/src-tauri/src/commands/setup_wizard.rs
@@ -278,6 +278,233 @@ pub async fn suggest_workspace_sources_for_setup(workspace_path: String) -> Resu
 }
 
 // ============================================================================
+// GitHub Repository Cloning (via the qontinui GitHub App)
+// ============================================================================
+//
+// The setup wizard lets users pick a GitHub repository and clone it into a
+// local folder. Instead of depending on a locally-authorized `gh` CLI (which an
+// AI-driven runner usually won't have), we REUSE the GitHub App connection the
+// user already made during qontinui onboarding.
+//
+// Flow: the runner calls the qontinui-web backend with its Cognito bearer; web
+// resolves the operator's tenant and proxies to coord, which owns the GitHub
+// App private key. coord lists the tenant's installation repos and mints a
+// repo-scoped, `contents:read`, short-TTL token for a single clone. The runner
+// never stores a long-lived GitHub credential — the clone token is used once and
+// scrubbed from the cloned repo's `.git/config`.
+
+/// Resolve the runner's Cognito bearer for authenticated web-backend calls.
+/// `None` when the user isn't signed in (Tier 0/1 or no Cognito session).
+async fn cognito_bearer() -> Option<String> {
+    let auth_manager = crate::auth::AuthManager::new();
+    crate::mcp::device_jwt_refresher::ensure_fresh_cognito_bearer(&auth_manager)
+        .await
+        .filter(|t| !t.trim().is_empty())
+}
+
+/// List the GitHub repositories the signed-in user's connected GitHub App
+/// installation(s) can access, for the setup-wizard clone picker.
+///
+/// Returns `{ signed_in, connected, repos }`:
+/// - `signed_in: false` — no Qontinui account session; the wizard shows a
+///   sign-in hint (this is a normal state, not an error).
+/// - `connected: false` — signed in, but the GitHub App isn't installed on any
+///   of the user's orgs yet; the wizard shows a "connect your GitHub" CTA.
+/// - otherwise `repos` is the list to render.
+#[tauri::command]
+pub async fn github_list_repos() -> Result<Value, String> {
+    let Some(bearer) = cognito_bearer().await else {
+        return Ok(serde_json::json!({
+            "signed_in": false,
+            "connected": false,
+            "repos": [],
+        }));
+    };
+
+    let url = format!(
+        "{}/api/v1/operations/github/repos",
+        crate::api_config::get_api_base_url()
+    );
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .bearer_auth(&bearer)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach Qontinui backend: {}", e))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        warn!("github_list_repos: backend returned {}: {}", status, body);
+        return Err(format!("Backend returned {}: {}", status, body.trim()));
+    }
+
+    let mut body: Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse repo list: {}", e))?;
+    // The backend returns `{connected, repos}`; stamp `signed_in: true` so the
+    // frontend has one uniform shape to branch on.
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("signed_in".to_string(), Value::Bool(true));
+    }
+    Ok(body)
+}
+
+/// Clone a GitHub repository into a local destination folder, reusing the user's
+/// GitHub App connection for credentials.
+///
+/// `repo` is `owner/name`. Fetches a repo-scoped clone token from the backend,
+/// clones into `dest_parent/<name>`, then scrubs the remote URL back to the
+/// tokenless form so the short-TTL token never persists on disk. Refuses to
+/// clone into an existing non-empty directory.
+#[tauri::command]
+pub async fn github_clone_repo(repo: String, dest_parent: String) -> Result<Value, String> {
+    let repo = repo.trim().to_string();
+    let dest_parent = dest_parent.trim().to_string();
+
+    let Some((owner, name_raw)) = repo.split_once('/') else {
+        return Err(format!(
+            "Invalid repository '{}': expected 'owner/name'",
+            repo
+        ));
+    };
+    let owner = owner.to_string();
+    let name = name_raw.trim_end_matches(".git").to_string();
+    if owner.is_empty() || name.is_empty() || name.contains('/') {
+        return Err(format!(
+            "Invalid repository '{}': expected 'owner/name'",
+            repo
+        ));
+    }
+    if dest_parent.is_empty() {
+        return Err("No destination folder selected".to_string());
+    }
+
+    let parent = std::path::PathBuf::from(&dest_parent);
+    if !parent.is_dir() {
+        return Err(format!(
+            "Destination folder does not exist: {}",
+            parent.display()
+        ));
+    }
+    let dest = parent.join(&name);
+    if dest.exists() {
+        let non_empty = std::fs::read_dir(&dest)
+            .map(|mut e| e.next().is_some())
+            .unwrap_or(true);
+        if non_empty {
+            return Err(format!(
+                "A non-empty folder already exists at {}. Remove it or choose a different \
+                 destination.",
+                dest.display()
+            ));
+        }
+    }
+
+    // 1. Obtain a repo-scoped clone token from the backend.
+    let Some(bearer) = cognito_bearer().await else {
+        return Err("Sign in to your Qontinui account to clone from GitHub.".to_string());
+    };
+    let cred_url = format!(
+        "{}/api/v1/operations/github/clone-credential",
+        crate::api_config::get_api_base_url()
+    );
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&cred_url)
+        .bearer_auth(&bearer)
+        .json(&serde_json::json!({ "repo": format!("{}/{}", owner, name) }))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach Qontinui backend: {}", e))?;
+    let status = resp.status();
+    let cred: Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse clone credential: {}", e))?;
+    if !status.is_success() {
+        let msg = cred
+            .get("message")
+            .or_else(|| cred.get("error"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("clone credential request failed");
+        return Err(msg.to_string());
+    }
+    let token = cred
+        .get("token")
+        .and_then(|v| v.as_str())
+        .ok_or("Backend did not return a clone token")?
+        .to_string();
+
+    info!(
+        "Setup wizard: cloning {}/{} into {}",
+        owner,
+        name,
+        dest.display()
+    );
+
+    // 2. Clone with the token embedded in the URL, then scrub the remote so the
+    //    token never persists in `.git/config`. The token is repo-scoped +
+    //    short-TTL, so brief in-URL use is acceptable.
+    let clean_url = format!("https://github.com/{}/{}.git", owner, name);
+    let auth_url = format!(
+        "https://x-access-token:{}@github.com/{}/{}.git",
+        token, owner, name
+    );
+    let dest_str = dest.to_string_lossy().to_string();
+
+    let clone_out = tokio::task::spawn_blocking(move || {
+        crate::process_helpers::no_window("git")
+            .args(["clone", &auth_url, &dest_str])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+    })
+    .await
+    .map_err(|e| String::from(AppError::ProcessError(format!("Task join error: {}", e))))?
+    .map_err(|e| {
+        String::from(AppError::ProcessError(format!(
+            "Failed to run git: {}. Is git installed?",
+            e
+        )))
+    })?;
+
+    if !clone_out.status.success() {
+        let stderr = String::from_utf8_lossy(&clone_out.stderr);
+        // Redact the token if git ever echoes the URL into an error message.
+        let redacted = stderr.replace(&token, "***");
+        warn!("git clone failed: {}", redacted);
+        return Err(format!("Clone failed: {}", redacted.trim()));
+    }
+
+    // Scrub: repoint origin at the tokenless URL (best-effort — a failure here
+    // leaves a working clone, just with the short-TTL token in the remote URL
+    // until it expires).
+    let dest_scrub = dest.to_string_lossy().to_string();
+    let _ = tokio::task::spawn_blocking(move || {
+        crate::process_helpers::no_window("git")
+            .args(["-C", &dest_scrub, "remote", "set-url", "origin", &clean_url])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+    })
+    .await;
+
+    info!(
+        "Setup wizard: cloned {}/{} -> {}",
+        owner,
+        name,
+        dest.display()
+    );
+    Ok(serde_json::json!({
+        "path": dest.to_string_lossy().to_string(),
+        "name": name,
+    }))
+}
+
+// ============================================================================
 // Claude Config Directory Discovery (pure Rust, no Python CLI)
 // ============================================================================
 
@@ -1092,6 +1319,8 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             suggest_dev_services_for_setup,
             save_dev_services_from_setup,
             discover_claude_config_dirs,
+            github_list_repos,
+            github_clone_repo,
         ])
         .build()
 }

--- a/src/components/setup-wizard/GithubRepoPicker.tsx
+++ b/src/components/setup-wizard/GithubRepoPicker.tsx
@@ -1,0 +1,341 @@
+import { useState, useCallback, useEffect, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import {
+  FolderOpen,
+  Search,
+  Loader2,
+  Lock,
+  Globe,
+  GitBranch,
+  CheckSquare,
+  Square,
+  Download,
+  AlertCircle,
+  ExternalLink,
+} from "lucide-react";
+
+/** GitHub App install URL for the "connect your GitHub" CTA. */
+const GITHUB_APP_INSTALL_URL =
+  "https://github.com/apps/qontinui-merge-orchestrator/installations/new";
+
+/** Wizard-internal project shape (mirrors ProjectStep's `Project`). */
+interface Project {
+  path: string;
+  name: string;
+  type: string;
+  manifest: string;
+}
+
+/** Wire shape of `github_list_repos` (Tauri command → web backend). */
+interface RepoListResponse {
+  signed_in: boolean;
+  connected: boolean;
+  repos: GhRepo[];
+}
+
+interface GhRepo {
+  nameWithOwner: string;
+  description: string;
+  isPrivate: boolean;
+  updatedAt: string;
+  language: string | null;
+}
+
+interface GithubRepoPickerProps {
+  /** Called with the detected projects after each repo is successfully cloned. */
+  onProjectsCloned: (projects: Project[]) => void;
+}
+
+/**
+ * GitHub repository picker for the setup wizard's Projects step.
+ *
+ * Reuses the GitHub App connection the user already made during qontinui
+ * onboarding — NOT a local `gh` login or a pasted token. The `github_list_repos`
+ * and `github_clone_repo` Tauri commands (see
+ * `src-tauri/src/commands/setup_wizard.rs`) call the qontinui-web backend with
+ * the runner's Cognito bearer; web proxies to coord, which owns the GitHub App
+ * key, lists the tenant's installation repos, and mints a repo-scoped short-TTL
+ * clone token. The runner never stores a long-lived GitHub credential.
+ *
+ * Three gate states drive the UI: not signed in → sign-in hint; signed in but
+ * the App isn't installed → "connect your GitHub" CTA; connected → the picker.
+ *
+ * After a repo clones, we scan its root (`scan_workspace_for_setup`, depth 1) to
+ * detect the project type/manifest so it flows into the rest of the wizard like
+ * a locally-discovered project. If detection turns up nothing we fall back to a
+ * generic entry for the repo root.
+ */
+export function GithubRepoPicker({ onProjectsCloned }: GithubRepoPickerProps) {
+  const [signedIn, setSignedIn] = useState(true);
+  const [connected, setConnected] = useState(false);
+  const [repos, setRepos] = useState<GhRepo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [filter, setFilter] = useState("");
+  const [selectedRepos, setSelectedRepos] = useState<string[]>([]);
+  const [destParent, setDestParent] = useState("");
+
+  const [cloning, setCloning] = useState(false);
+  const [cloneProgress, setCloneProgress] = useState<string | null>(null);
+  const [clonedRepos, setClonedRepos] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadRepos = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await invoke<RepoListResponse>("github_list_repos");
+      setSignedIn(result.signed_in);
+      setConnected(result.connected);
+      setRepos(result.repos ?? []);
+    } catch (err) {
+      setError(`Failed to list repositories: ${err}`);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot data load on mount
+    void loadRepos();
+  }, [loadRepos]);
+
+  const filteredRepos = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return repos;
+    return repos.filter(
+      (r) =>
+        r.nameWithOwner.toLowerCase().includes(q) ||
+        (r.description ?? "").toLowerCase().includes(q),
+    );
+  }, [repos, filter]);
+
+  const pickDestination = useCallback(async () => {
+    try {
+      const selected = await open({ directory: true, multiple: false });
+      if (selected) {
+        setDestParent(selected as string);
+        setError(null);
+      }
+    } catch (err) {
+      setError(`Failed to open folder picker: ${err}`);
+    }
+  }, []);
+
+  const toggleRepo = useCallback((nameWithOwner: string) => {
+    setSelectedRepos((prev) =>
+      prev.includes(nameWithOwner)
+        ? prev.filter((r) => r !== nameWithOwner)
+        : [...prev, nameWithOwner],
+    );
+  }, []);
+
+  const cloneSelected = useCallback(async () => {
+    if (selectedRepos.length === 0 || !destParent) return;
+    setCloning(true);
+    setError(null);
+    const failures: string[] = [];
+    const succeeded: string[] = [];
+
+    for (const repo of selectedRepos) {
+      if (clonedRepos.includes(repo)) continue;
+      setCloneProgress(`Cloning ${repo}…`);
+      try {
+        const { path, name } = await invoke<{ path: string; name: string }>("github_clone_repo", {
+          repo,
+          destParent,
+        });
+
+        // Detect the project type from the freshly cloned tree so it flows
+        // through the wizard like any locally-scanned project.
+        let projects: Project[] = [];
+        try {
+          projects = await invoke<Project[]>("scan_workspace_for_setup", {
+            path,
+            maxDepth: 1,
+          });
+        } catch {
+          projects = [];
+        }
+        if (projects.length === 0) {
+          projects = [{ path, name, type: "unknown", manifest: "" }];
+        }
+
+        onProjectsCloned(projects);
+        succeeded.push(repo);
+      } catch (err) {
+        failures.push(`${repo}: ${err}`);
+      }
+    }
+
+    setCloneProgress(null);
+    setCloning(false);
+    if (succeeded.length > 0) {
+      setClonedRepos((prev) => [...prev, ...succeeded]);
+      setSelectedRepos((prev) => prev.filter((r) => !succeeded.includes(r)));
+    }
+    if (failures.length > 0) {
+      setError(`Some clones failed:\n${failures.join("\n")}`);
+    }
+  }, [selectedRepos, destParent, clonedRepos, onProjectsCloned]);
+
+  // --- Render states ---------------------------------------------------------
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-8 text-muted-foreground">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Loading your GitHub repositories…
+      </div>
+    );
+  }
+
+  if (!signedIn) {
+    return (
+      <div className="panel border-amber-500/30 bg-amber-500/10 p-4 max-w-xl mx-auto w-full flex gap-3">
+        <AlertCircle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
+        <div className="text-sm">
+          <div className="font-medium mb-1">Sign in required</div>
+          <p className="text-muted-foreground">
+            Sign in to your Qontinui account (Settings → Account) to browse and clone your GitHub
+            repositories.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!connected) {
+    return (
+      <div className="panel border-primary/30 bg-primary/5 p-4 max-w-xl mx-auto w-full flex flex-col gap-3">
+        <div className="flex gap-3">
+          <GitBranch className="w-5 h-5 text-primary shrink-0 mt-0.5" />
+          <div className="text-sm">
+            <div className="font-medium mb-1">Connect your GitHub</div>
+            <p className="text-muted-foreground">
+              Install the Qontinui GitHub App on your organization or account to browse and clone
+              your repositories here.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button
+            className="btn-primary flex items-center gap-2"
+            onClick={() => void openUrl(GITHUB_APP_INSTALL_URL)}
+          >
+            <ExternalLink className="w-4 h-4" />
+            Connect GitHub
+          </button>
+          <button className="btn-secondary flex items-center gap-2" onClick={loadRepos}>
+            <Loader2 className="w-4 h-4" />
+            I've connected — refresh
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 max-w-xl mx-auto w-full">
+      {/* Filter */}
+      <div className="flex-1 flex items-center gap-2 panel px-3 py-2">
+        <Search className="w-4 h-4 text-muted-foreground shrink-0" />
+        <input
+          type="text"
+          className="bg-transparent outline-none text-sm flex-1 min-w-0"
+          placeholder="Filter repositories"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+      </div>
+
+      {/* Repo list */}
+      <div className="flex flex-col gap-1.5 max-h-60 overflow-y-auto pr-1">
+        {filteredRepos.length === 0 ? (
+          <div className="empty-state py-6 text-center text-muted-foreground text-sm">
+            No repositories match
+          </div>
+        ) : (
+          filteredRepos.map((repo) => {
+            const isSelected = selectedRepos.includes(repo.nameWithOwner);
+            const isCloned = clonedRepos.includes(repo.nameWithOwner);
+            return (
+              <button
+                key={repo.nameWithOwner}
+                className={`panel-interactive flex items-center gap-3 p-3 text-left transition-colors ${
+                  isSelected ? "border-primary/50" : ""
+                } ${isCloned ? "opacity-60" : ""}`}
+                onClick={() => !isCloned && toggleRepo(repo.nameWithOwner)}
+                disabled={isCloned}
+              >
+                {isCloned ? (
+                  <CheckSquare className="w-4 h-4 text-green-400 shrink-0" />
+                ) : isSelected ? (
+                  <CheckSquare className="w-4 h-4 text-primary shrink-0" />
+                ) : (
+                  <Square className="w-4 h-4 text-zinc-500 shrink-0" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm flex items-center gap-1.5">
+                    {repo.isPrivate ? (
+                      <Lock className="w-3 h-3 text-amber-400 shrink-0" />
+                    ) : (
+                      <Globe className="w-3 h-3 text-muted-foreground shrink-0" />
+                    )}
+                    <span className="truncate">{repo.nameWithOwner}</span>
+                    {isCloned && <span className="text-xs text-green-400">cloned</span>}
+                  </div>
+                  {repo.description && (
+                    <div className="text-xs text-muted-foreground truncate">{repo.description}</div>
+                  )}
+                </div>
+                {repo.language && (
+                  <span className="badge text-xs text-zinc-400 shrink-0">{repo.language}</span>
+                )}
+              </button>
+            );
+          })
+        )}
+      </div>
+
+      {/* Destination folder */}
+      <div className="flex gap-2 items-center">
+        <button className="btn-secondary flex items-center gap-2 shrink-0" onClick={pickDestination}>
+          <FolderOpen className="w-4 h-4" />
+          Clone to…
+        </button>
+        <div className="flex-1 panel px-3 py-2 text-sm truncate min-w-0">
+          {destParent || <span className="text-muted-foreground">No destination selected</span>}
+        </div>
+      </div>
+
+      {error && (
+        <div className="panel border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300 whitespace-pre-wrap">
+          {error}
+        </div>
+      )}
+
+      {/* Clone action */}
+      <button
+        className="btn-primary flex items-center justify-center gap-2"
+        onClick={cloneSelected}
+        disabled={cloning || selectedRepos.length === 0 || !destParent}
+      >
+        {cloning ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            {cloneProgress ?? "Cloning…"}
+          </>
+        ) : (
+          <>
+            <Download className="w-4 h-4" />
+            Clone {selectedRepos.length > 0 ? `${selectedRepos.length} ` : ""}repositor
+            {selectedRepos.length === 1 ? "y" : "ies"}
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/setup-wizard/ProjectStep.tsx
+++ b/src/components/setup-wizard/ProjectStep.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
-import { FolderOpen, Search, Loader2, Package, CheckSquare, Square } from "lucide-react";
+import { FolderOpen, Search, Loader2, Package, CheckSquare, Square, HardDrive, GitBranch } from "lucide-react";
 import type { SavedProject } from "../../hooks/useSavedProjects";
+import { GithubRepoPicker } from "./GithubRepoPicker";
 
 interface Project {
   path: string;
@@ -66,11 +67,33 @@ export function ProjectStep({
   onNext,
   onBack,
 }: ProjectStepProps) {
+  const [mode, setMode] = useState<"local" | "github">("local");
   const [scanPath, setScanPath] = useState("");
   const [discoveredProjects, setDiscoveredProjects] = useState<Project[]>([]);
   const [scanning, setScanning] = useState(false);
   const [scanned, setScanned] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  /**
+   * Merge freshly-cloned projects into the discovered + selected lists.
+   * De-duplicates by path so re-cloning the same repo doesn't create doubles,
+   * and marks the step as "scanned" so the Continue button enables.
+   */
+  const handleClonedProjects = useCallback(
+    (cloned: Project[]) => {
+      setDiscoveredProjects((prev) => {
+        const byPath = new Map(prev.map((p) => [p.path, p]));
+        for (const p of cloned) byPath.set(p.path, p);
+        return Array.from(byPath.values());
+      });
+      onProjectsChange([
+        ...selectedProjects.filter((p) => !cloned.some((c) => c.path === p.path)),
+        ...cloned,
+      ]);
+      setScanned(true);
+    },
+    [selectedProjects, onProjectsChange],
+  );
 
   const pickFolder = useCallback(async () => {
     try {
@@ -149,11 +172,36 @@ export function ProjectStep({
       <div className="text-center">
         <h2 className="text-h2 mb-2">Discover Projects</h2>
         <p className="text-body text-muted-foreground">
-          Select a folder to scan for software projects
+          Scan a local folder or clone a repository from GitHub
         </p>
       </div>
 
+      {/* Source mode toggle */}
+      <div className="flex gap-2 justify-center">
+        <button
+          className={`btn-secondary flex items-center gap-2 ${
+            mode === "local" ? "border-primary/50 text-primary" : ""
+          }`}
+          onClick={() => setMode("local")}
+        >
+          <HardDrive className="w-4 h-4" />
+          Local folder
+        </button>
+        <button
+          className={`btn-secondary flex items-center gap-2 ${
+            mode === "github" ? "border-primary/50 text-primary" : ""
+          }`}
+          onClick={() => setMode("github")}
+        >
+          <GitBranch className="w-4 h-4" />
+          Clone from GitHub
+        </button>
+      </div>
+
+      {mode === "github" && <GithubRepoPicker onProjectsCloned={handleClonedProjects} />}
+
       {/* Folder picker */}
+      {mode === "local" && (
       <div className="flex gap-2 items-center max-w-xl mx-auto w-full">
         <button className="btn-secondary flex items-center gap-2 shrink-0" onClick={pickFolder}>
           <FolderOpen className="w-4 h-4" />
@@ -171,6 +219,7 @@ export function ProjectStep({
           Scan
         </button>
       </div>
+      )}
 
       {error && (
         <div className="panel border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300 max-w-xl mx-auto w-full">


### PR DESCRIPTION
## What

Adds a **"Clone from GitHub"** mode to the setup wizard's Projects step so users can pick one of their GitHub repos and clone it to a local folder during onboarding — reusing the GitHub App connection they already made. No local `gh` login, no pasted PAT, no stored long-lived token.

**Backend** (`setup_wizard.rs`): `github_list_repos` + `github_clone_repo` call the qontinui-web backend with the runner's Cognito bearer; web proxies to coord (owns the App key), which lists the tenant's installation repos and mints a repo-scoped, `contents:read`, short-TTL clone token. The clone embeds the token in the URL then **scrubs the remote back to the tokenless form** so nothing persists on disk.

**Frontend** (`GithubRepoPicker.tsx` + `ProjectStep.tsx`): local-folder ↔ GitHub mode toggle; three gate states — not signed in (sign-in hint) / signed in but App not installed ("Connect GitHub" CTA → App install URL) / connected repo picker. Cloned repos are scanned (`scan_workspace_for_setup`, depth 1) and merged into the wizard's project list so they flow through the remaining steps like locally-discovered projects.

## Part of a 3-repo change (deploy order: coord → web → runner)

- coord: qontinui/qontinui-coord#937 (**upstream**)
- web: qontinui/qontinui-web#719 (**upstream**)
- **runner** (this PR — downstream of both)

The clone flow calls `/api/v1/operations/github/*`, which exists only after web + coord deploy. Gated behind a signed-in Tier-2 account and the wizard, so pre-deploy it just degrades to an error in an unused new feature.

## Verification

`tsc` ✅, `eslint` ✅, `cargo check --lib` ✅, `cargo clippy --lib` ✅, `cargo fmt` ✅.

Pushed with `QONTINUI_PREPUSH_SKIP=1`: the local pre-push `clippy --all-targets` fails on 8 **pre-existing** `doc list item overindented` warnings in `flywheel_e2e_tests.rs` / `spec_authoring.rs` (files this PR does not touch), promoted to errors by `-D warnings`. Deferred to CI. Live E2E pending web + coord deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)