### PR TITLE
chore(lint): tier clippy levels + diff-scoped T3 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ on:
     # integration branch must be listed here for stacked-PR CI to fire. CI has
     # no `paths:` filter, so adding the branch suffices.
     branches: [main, develop, 'session-restore-**']
+  # Nightly cron drives `clippy-nightly-unscoped` (whole-tree, all-targets) so
+  # test-module / untouched-file lint rot is surfaced loudly on a schedule
+  # rather than ambushing an unrelated PR at push time. Added by plan
+  # 2026-07-05-lint-tiers-and-diff-scoped-gates; does not replace push/PR.
+  schedule:
+    - cron: '23 7 * * *'
+  # Manual trigger for the nightly unscoped clippy sweep (on-demand rot check).
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -232,9 +240,14 @@ jobs:
           cargo fmt -- --check
 
       - name: Clippy check
+        # Plain `cargo clippy` (no `-D warnings`): lint levels come solely from
+        # src-tauri/Cargo.toml [lints.clippy]. T1 correctness/suspicious groups
+        # are `deny` there, so a correctness lint still exits non-zero and fails
+        # this required check; T3 style/complexity/perf stay `warn` (emitted,
+        # non-blocking). See plan 2026-07-05-lint-tiers-and-diff-scoped-gates.
         run: |
           cd src-tauri
-          cargo clippy -- -D warnings
+          cargo clippy
 
       - name: Run Rust tests
         # Accessibility integration tests that require a real desktop session are
@@ -534,3 +547,253 @@ jobs:
 
       - name: Run pnpm audit
         run: pnpm audit --audit-level=moderate || true
+
+  # ---------------------------------------------------------------------------
+  # T3 lint tiering jobs — plan 2026-07-05-lint-tiers-and-diff-scoped-gates.
+  # ---------------------------------------------------------------------------
+
+  # Nightly UNSCOPED clippy sweep. The per-PR `Clippy check` step runs plain
+  # `cargo clippy` (default target only, levels from Cargo.toml) so it never
+  # ambushes an unrelated PR with test-module / whole-tree lint rot. This job
+  # restores that whole-tree coverage on a schedule instead: `--all-targets`
+  # compiles #[cfg(test)] modules too, surfacing warn-tier rot loudly once a
+  # day (and on-demand via workflow_dispatch) without gating any PR. It is
+  # allowed to fail on its own to make rot visible; it is NOT a required check
+  # and blocks nothing. Runs on schedule/manual only.
+  clippy-nightly-unscoped:
+    name: Clippy nightly (unscoped, all-targets)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Same sibling checkouts the matrix `test` job needs: qontinui-schemas
+      # for the `qontinui-types` path dep, and (for --all-targets test compile)
+      # ui-bridge for the SDK↔runner manifest diff test source.
+      - name: Checkout sibling repos
+        run: |
+          cd "$GITHUB_WORKSPACE/.."
+          git clone --depth 1 https://github.com/qontinui/qontinui-schemas.git
+          git clone --depth 1 https://github.com/qontinui/qontinui-web.git
+          git clone --depth 1 https://github.com/qontinui/ui-bridge.git
+        shell: bash
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+          components: rustfmt, clippy
+
+      - name: Install dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libdbus-1-dev \
+            libatspi2.0-dev \
+            at-spi2-core
+
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+
+      - name: Add swapfile (Ubuntu — guard against link-time OOM)
+        run: |
+          sudo swapoff -a || true
+          sudo fallocate -l 12G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src-tauri/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      # tauri::generate_context!() reads ../dist at compile time; clippy compiles
+      # the crate, so the frontend must be built first (same as the matrix job).
+      - name: Build frontend
+        run: pnpm run build
+
+      - name: Clippy (unscoped, all-targets)
+        # No `-D warnings`: report rot, don't deny-block the world. Levels come
+        # from Cargo.toml; --all-targets adds the test-module coverage the PR
+        # gate intentionally drops. A deny-tier lint anywhere in the tree still
+        # fails this job (by design — that's the loud signal), but this job
+        # gates no PR.
+        env:
+          CARGO_BUILD_JOBS: 1
+        run: |
+          cd src-tauri
+          cargo clippy --all-targets
+
+  # DIFF-SCOPED T3 style gate (reviewdog). Runs plain `cargo clippy` with JSON
+  # output and pipes it through reviewdog with -filter-mode=diff_context so it
+  # comments/fails ONLY on findings introduced on the lines this PR changed —
+  # style rot elsewhere in the tree is ignored. This is the T3 mechanism: warn-
+  # tier lints (style/complexity/perf) stay non-blocking globally but a NEW one
+  # you introduce is surfaced on your diff.
+  #
+  # ADVISORY / NOT A REQUIRED CHECK — do NOT add to required-status-checks or
+  # branch protection. Promote to required only after burn-in (plan Phase 2).
+  # Being non-required guarantees it cannot wedge the coord merge train even if
+  # reviewdog misbehaves.
+  #
+  # NOT LIVE-VERIFIED: reviewdog's clippy errorformat + diff_context behavior on
+  # this Tauri crate has not been exercised in real CI (a full clippy compile is
+  # 40-70 min and was not run locally). Treat the first live PR run as the
+  # verification; keep it non-required until confirmed green-and-useful.
+  clippy-diff:
+    name: Clippy diff-scoped (advisory)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Checkout sibling repos
+        run: |
+          cd "$GITHUB_WORKSPACE/.."
+          git clone --depth 1 https://github.com/qontinui/qontinui-schemas.git
+          git clone --depth 1 https://github.com/qontinui/qontinui-web.git
+          git clone --depth 1 https://github.com/qontinui/ui-bridge.git
+        shell: bash
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+          components: rustfmt, clippy
+
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Install dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libdbus-1-dev \
+            libatspi2.0-dev \
+            at-spi2-core
+
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+
+      - name: Add swapfile (Ubuntu — guard against link-time OOM)
+        run: |
+          sudo swapoff -a || true
+          sudo fallocate -l 12G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src-tauri/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend
+        run: pnpm run build
+
+      - name: Clippy diff-scoped via reviewdog
+        # Capture clippy JSON to a file first so cargo's non-zero exit (a deny
+        # lint) does NOT abort the step under `set -eo pipefail` before
+        # reviewdog runs — reviewdog owns the pass/fail decision here, scoped to
+        # the diff. `-filter-mode=diff_context` = fail only on findings on
+        # changed lines; `-fail-on-error=true` makes those diff findings fail
+        # THIS (advisory, non-required) check only.
+        env:
+          CARGO_BUILD_JOBS: 1
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd src-tauri
+          cargo clippy --message-format=json > clippy-report.json 2>/dev/null || true
+          reviewdog \
+            -f=clippy \
+            -name="clippy-diff" \
+            -filter-mode=diff_context \
+            -reporter=github-pr-check \
+            -fail-on-error=true \
+            < clippy-report.json
+        shell: bash

--- a/.pre-commit-hooks/cargo-prepush.sh
+++ b/.pre-commit-hooks/cargo-prepush.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Pre-push guard: mirrors CI's Rust gate (cargo fmt --check + clippy -D
-# warnings) so the failure is surfaced in 60-90s of local cycle time
-# instead of 8-15 min of CI roundtrip per push.
+# Pre-push guard: mirrors CI's Rust gate so a correctness failure is surfaced
+# in 60-90s of local cycle time instead of 8-15 min of CI roundtrip per push.
+# Tiered per plan 2026-07-05-lint-tiers-and-diff-scoped-gates: formatting
+# auto-applies (never blocks), and clippy runs plain (no `-D warnings`) so only
+# deny-tier (correctness/suspicious) lints from Cargo.toml [lints.clippy] block.
 #
 # Skip with `git push --no-verify` if you genuinely want CI to be the
 # source of truth (e.g. you're pushing a WIP branch you don't expect to
@@ -56,19 +58,30 @@ restore_lock() {
 }
 trap restore_lock EXIT
 
-echo "[pre-push] cargo fmt -- --check"
-if ! cargo fmt -- --check; then
-  echo
-  echo "[pre-push] FAIL — cargo fmt found unformatted code."
-  echo "          Run 'cd src-tauri && cargo fmt' to fix, then re-push."
-  exit 1
-fi
+# T2 (formatting) — auto-apply, never block. Run `cargo fmt` (writes) instead
+# of `cargo fmt -- --check` (fails). Re-stage anything it rewrote so the
+# formatted result rides in this push rather than failing it. Formatting is
+# mechanical; there is no value in bouncing a push over whitespace.
+echo "[pre-push] cargo fmt (auto-apply)"
+cargo fmt
+# Re-stage any src-tauri files fmt rewrote. `git add -u` on the src-tauri tree
+# picks up tracked-file modifications only (no new/untracked files). Best-effort:
+# if nothing changed this is a no-op.
+git -C "$ROOT" add -u -- src-tauri || true
 
-echo "[pre-push] cargo clippy --all-targets -- -D warnings"
-if ! cargo clippy --all-targets -- -D warnings; then
+# T1 (correctness) — block. Plain `cargo clippy`: NO `--all-targets` (that
+# compiles #[cfg(test)] modules this PR didn't touch — stricter than CI and a
+# frequent source of unrelated-lint push blocks) and NO `-D warnings` (that
+# would promote every warning to an error and neuter the Cargo.toml tiering).
+# Lint levels come solely from `[lints.clippy]` in src-tauri/Cargo.toml: a
+# `deny`-tier (correctness/suspicious) lint still exits non-zero and blocks,
+# while `warn`-tier (style/complexity/perf) lints are emitted but do not fail
+# the push. See plan 2026-07-05-lint-tiers-and-diff-scoped-gates.
+echo "[pre-push] cargo clippy (levels from Cargo.toml [lints.clippy]; deny-tier blocks)"
+if ! cargo clippy; then
   echo
-  echo "[pre-push] FAIL — clippy lints. Either fix the lints or"
-  echo "          QONTINUI_PREPUSH_SKIP=1 git push   if you want CI to gate."
+  echo "[pre-push] FAIL — a deny-tier (correctness/suspicious) clippy lint fired."
+  echo "          Fix the lint, or QONTINUI_PREPUSH_SKIP=1 git push to let CI gate."
   exit 1
 fi
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -316,6 +316,17 @@ complexity = { level = "warn", priority = 0 }
 style = { level = "warn", priority = 0 }
 pedantic = { level = "allow", priority = 0 }
 nursery = { level = "allow", priority = 0 }
+# Grandfathered pre-existing exceptions. These three were in the prior
+# hand-curated allow-list, so the runner code trips them today — they belong to
+# the now-`deny` correctness/suspicious groups, and re-denying them would newly
+# block EVERY runner push (the opposite of this plan's goal). Keep them `allow`
+# with higher priority so the specific level wins over the group `deny`; drive
+# the sites to zero and re-deny as a follow-up (plan Phase 3). NEW correctness/
+# suspicious lints not listed here still deny — this is a strict no-new-blocks
+# retier, not a blanket relaxation.
+read_zero_byte_vec = { level = "allow", priority = 2 }
+await_holding_lock = { level = "allow", priority = 2 }
+mut_range_bound = { level = "allow", priority = 2 }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -303,49 +303,19 @@ unused_assignments = "allow"
 unused_mut = "allow"
 
 [lints.clippy]
-too_many_arguments = "allow"
-type_complexity = "allow"
-ptr_arg = "allow"
-enum_variant_names = "allow"
-module_inception = "allow"
-unnecessary_cast = "allow"
-redundant_closure = "allow"
-useless_format = "allow"
-manual_strip = "allow"
-collapsible_if = "allow"
-collapsible_match = "allow"
-clone_on_copy = "allow"
-manual_clamp = "allow"
-iter_cloned_collect = "allow"
-unwrap_or_default = "allow"
-format_in_format_args = "allow"
-needless_return = "allow"
-large_enum_variant = "allow"
-while_let_loop = "allow"
-manual_let_else = "allow"
-needless_range_loop = "allow"
-unused_self = "allow"
-wrong_self_convention = "allow"
-struct_field_names = "allow"
-doc_lazy_continuation = "allow"
-redundant_clone = "allow"
-unnecessary_to_owned = "allow"
-unnecessary_unwrap = "allow"
-filter_map_bool_then = "allow"
-struct_excessive_bools = "allow"
-match_single_binding = "allow"
-single_match = "allow"
-needless_pass_by_value = "allow"
-explicit_deref_methods = "allow"
-deref_addrof = "allow"
-await_holding_lock = "allow"
-read_zero_byte_vec = "allow"
-mut_range_bound = "allow"
-if_same_then_else = "allow"
-same_item_push = "allow"
-result_large_err = "allow"
-unnecessary_literal_unwrap = "allow"
-regex_creation_in_loops = "allow"
+# Tiered lint policy (plan 2026-07-05-lint-tiers-and-diff-scoped-gates).
+# T1 correctness = deny (blocks); T3 style/pedantic = warn (emitted, non-blocking).
+# Levels live here as the SINGLE source of truth — the gate runs plain
+# `cargo clippy` (no `-D warnings`), so a warn never hard-blocks a push while
+# a deny still does. Style lints stay `warn` (NOT allow) so Phase 2 reviewdog
+# diff-scoping and the nightly unscoped job still see them in clippy's JSON.
+correctness = { level = "deny", priority = 1 }
+suspicious = { level = "deny", priority = 1 }
+perf = { level = "warn", priority = 1 }
+complexity = { level = "warn", priority = 0 }
+style = { level = "warn", priority = 0 }
+pedantic = { level = "allow", priority = 0 }
+nursery = { level = "allow", priority = 0 }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Re-tiers linting so cosmetic clippy lints stop blocking unrelated pushes, while correctness lints still block. Implements the qontinui-runner portion of plan `2026-07-05-lint-tiers-and-diff-scoped-gates`.

## Three principles
- **T1 correctness = block**: `correctness` + `suspicious` groups are `deny` in `[lints.clippy]`; a deny-tier lint still exits non-zero and fails both the pre-push gate and the required CI Clippy check.
- **T2 formatting = auto-apply, never block**: pre-push runs `cargo fmt` (writes) + re-stages, instead of `--check`-failing.
- **T3 style = diff-scoped warn**: `style`/`complexity`/`perf` stay `warn` (emitted, non-blocking globally); a new NON-REQUIRED reviewdog job flags only style findings introduced on changed lines.

## Changes
- **`src-tauri/Cargo.toml`** — replace the ~43-entry hand-maintained allow-list with grouped, priority-ordered tier levels (correctness/suspicious=deny, perf/complexity/style=warn, pedantic/nursery=allow). Cargo.toml is now the single source of truth for lint levels.
- **`.pre-commit-hooks/cargo-prepush.sh`** — fmt auto-applies + re-stages; clippy runs plain (drop `--all-targets` and `-D warnings`) so only deny-tier lints block.
- **`.github/workflows/ci.yml`** — drop `-D warnings` from the required Clippy step; add `schedule`+`workflow_dispatch` triggers; add two jobs:
  - `clippy-nightly-unscoped` — nightly/on-demand `cargo clippy --all-targets` to surface whole-tree / test-module rot loudly. Gates no PR.
  - `clippy-diff` — per-PR reviewdog diff-scoped gate. **Advisory / NOT a required check** — do not add to branch protection until Phase 2 burn-in. Being non-required means it cannot wedge the coord merge train.

## Verification (config-only; no full clippy run — 40-70 min compile)
- `cargo metadata --no-deps` parses the manifest / `[lints]` table: OK
- `bash -n` on the hook: OK
- `yaml.safe_load` on ci.yml: OK

## Needs live-CI confirmation
- reviewdog's `-f=clippy` + `-filter-mode=diff_context` behavior on this Tauri crate was NOT exercised locally. Kept non-required so a first-run misbehavior blocks nothing.

## Behavior-change to watch
Three previously-allowed lints belong to now-`deny` groups and could newly fail if existing code trips them: `await_holding_lock` (suspicious), `read_zero_byte_vec` (correctness), `mut_range_bound` (suspicious). Not verified locally (no full clippy). If any fires, either fix the site or grandfather that specific lint back to `allow` with a higher `priority`.

Plan: `2026-07-05-lint-tiers-and-diff-scoped-gates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)