### PR TITLE
fix(runner): abort-path postmortem (panic log + dump dir) + aws-lc dev-assertions off + tolerant trigger loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,20 @@ resolver = "2"
 debug = 0
 split-debuginfo = "packed"
 
+# 2026-07-03: the primary (debug build) hard-aborted with 0xc0000409 — a Rust
+# std debug-assertion UB check ("Alignment::new_unchecked requires a power of
+# two") fired inside AWS-LC's jitter-entropy path
+# (aws_lc_..._jent_entropy_switch_notime_impl) across an FFI/nounwind boundary,
+# turning a rare, timing-dependent bogus alignment value into a process abort.
+# Release builds never compile this check in; disabling debug-assertions for
+# these two crates ONLY restores release-parity there while keeping assertions
+# everywhere else. Escalation path if the same panic recurs from another dep:
+# widen to [profile.dev.package."*"].
+[profile.dev.package.aws-lc-rs]
+debug-assertions = false
+[profile.dev.package.aws-lc-sys]
+debug-assertions = false
+
 [profile.test]
 debug = 0
 

--- a/src-tauri/src/database/pg/triggers.rs
+++ b/src-tauri/src/database/pg/triggers.rs
@@ -37,7 +37,7 @@ impl PgDb {
 
         Ok(rows
             .iter()
-            .map(|r| Self::trigger_row_to_workflow_trigger(r))
+            .filter_map(Self::tolerant_trigger_from_row)
             .collect())
     }
 
@@ -65,7 +65,7 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG get_trigger: {}", e))?;
 
-        Ok(row.map(|r| Self::trigger_row_to_workflow_trigger(&r)))
+        Ok(row.and_then(|r| Self::tolerant_trigger_from_row(&r)))
     }
 
     /// Get all enabled triggers.
@@ -94,7 +94,7 @@ impl PgDb {
 
         Ok(rows
             .iter()
-            .map(|r| Self::trigger_row_to_workflow_trigger(r))
+            .filter_map(Self::tolerant_trigger_from_row)
             .collect())
     }
 
@@ -442,10 +442,43 @@ impl PgDb {
 
     // -- helpers --
 
-    fn trigger_row_to_workflow_trigger(row: &tokio_postgres::Row) -> WorkflowTrigger {
-        let config_str: String = row.get::<_, Option<String>>(4).unwrap_or_default();
-        let conditions_str: String = row.get::<_, Option<String>>(7).unwrap_or_default();
-        let overrides_str: Option<String> = row.get(6);
+    /// Decode a trigger row, tolerating malformed rows.
+    ///
+    /// Converts a decode failure from [`Self::trigger_row_to_workflow_trigger`]
+    /// into a logged skip (`None`) so one bad row can never take down a loader
+    /// — or the runner. Live incident 2026-07-03: the primary crash-looped at
+    /// startup because the old panicking `row.get(5)` hit a `workflow_id`
+    /// value that does not decode as TEXT (the canonical column is `uuid`;
+    /// this mapper reads it as `Option<String>`).
+    fn tolerant_trigger_from_row(row: &tokio_postgres::Row) -> Option<WorkflowTrigger> {
+        match Self::trigger_row_to_workflow_trigger(row) {
+            Ok(trigger) => Some(trigger),
+            Err(e) => {
+                let row_id = row
+                    .try_get::<_, String>(0)
+                    .unwrap_or_else(|_| "<unreadable id>".to_string());
+                // tokio-postgres 0.7's `Display` impl prints only a generic
+                // "error deserializing column N" / "db error" — the `{:?}`
+                // debug format carries the failing column and source cause,
+                // so log that.
+                tracing::error!("skipping malformed trigger row id={}: {:?}", row_id, e);
+                None
+            }
+        }
+    }
+
+    /// Decode one `workflow_triggers` row.
+    ///
+    /// Every column goes through `try_get` so a malformed / unexpected-type
+    /// value surfaces as an `Err` for the caller to skip instead of a panic
+    /// that aborts the process. Nullable numeric/bool columns fall back to
+    /// the same defaults `WorkflowTrigger`'s serde derives use.
+    fn trigger_row_to_workflow_trigger(
+        row: &tokio_postgres::Row,
+    ) -> Result<WorkflowTrigger, tokio_postgres::Error> {
+        let config_str: String = row.try_get::<_, Option<String>>(4)?.unwrap_or_default();
+        let conditions_str: String = row.try_get::<_, Option<String>>(7)?.unwrap_or_default();
+        let overrides_str: Option<String> = row.try_get(6)?;
 
         let trigger_config: TriggerConfig = serde_json::from_str(&config_str).unwrap_or_else(|e| {
             tracing::error!(
@@ -465,27 +498,27 @@ impl PgDb {
         let workflow_overrides: Option<serde_json::Value> =
             overrides_str.and_then(|s| serde_json::from_str(&s).ok());
 
-        WorkflowTrigger {
-            id: row.get(0),
-            name: row.get(1),
-            description: row.get(2),
-            trigger_type: row.get(3),
+        Ok(WorkflowTrigger {
+            id: row.try_get(0)?,
+            name: row.try_get(1)?,
+            description: row.try_get(2)?,
+            trigger_type: row.try_get(3)?,
             trigger_config,
-            workflow_id: row.get(5),
+            workflow_id: row.try_get(5)?,
             workflow_overrides,
             conditions,
-            debounce_ms: row.get::<_, i64>(8) as u64,
-            cooldown_seconds: row.get::<_, i64>(9) as u64,
-            max_concurrent: row.get::<_, i32>(10) as u32,
-            retry_count: row.get::<_, i32>(11) as u32,
-            retry_delay_seconds: row.get::<_, i64>(12) as u64,
-            enabled: row.get(13),
-            last_triggered_at: row.get(14),
-            last_execution_id: row.get(15),
-            trigger_count: row.get::<_, i64>(16) as u64,
-            created_at: row.get(17),
-            updated_at: row.get(18),
-        }
+            debounce_ms: row.try_get::<_, Option<i64>>(8)?.unwrap_or(1000) as u64,
+            cooldown_seconds: row.try_get::<_, Option<i64>>(9)?.unwrap_or(60) as u64,
+            max_concurrent: row.try_get::<_, Option<i32>>(10)?.unwrap_or(1) as u32,
+            retry_count: row.try_get::<_, Option<i32>>(11)?.unwrap_or(0) as u32,
+            retry_delay_seconds: row.try_get::<_, Option<i64>>(12)?.unwrap_or(30) as u64,
+            enabled: row.try_get::<_, Option<bool>>(13)?.unwrap_or(false),
+            last_triggered_at: row.try_get(14)?,
+            last_execution_id: row.try_get(15)?,
+            trigger_count: row.try_get::<_, Option<i64>>(16)?.unwrap_or(0) as u64,
+            created_at: row.try_get(17)?,
+            updated_at: row.try_get(18)?,
+        })
     }
 }
 

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -16,6 +16,12 @@ use crate::tracing_layers::{JsonlSpanLayer, SpanLayerConfig};
 /// Flag to track if we're already handling a crash (prevent recursive crashes)
 static CRASH_HANDLING: AtomicBool = AtomicBool::new(false);
 
+/// Re-entrancy guard for the `runner-panic.log` write inside `log_panic`.
+/// A panic raised while writing the panic log re-enters the hook; without
+/// this latch that recursion would be unbounded (each nested panic runs the
+/// hook synchronously before unwinding).
+static PANIC_LOG_WRITING: AtomicBool = AtomicBool::new(false);
+
 /// Safely write to stderr, ignoring errors if the pipe is closed.
 /// This prevents panics when stderr is unavailable
 /// (e.g., when the parent terminal/process has closed the pipe - Windows error 232).
@@ -201,32 +207,45 @@ macro_rules! log_debug {
     };
 }
 
+/// Walk up from `exe_path` looking for an ancestor directory that already
+/// contains a `.dev-logs` child, and return that child.
+///
+/// This replaces a fixed five-`.parent()` walk written for the
+/// pre-workspace `src-tauri\target\debug\` exe layout. The workspace root
+/// moved `target/` one level up (`qontinui-runner\target\debug\`), so the
+/// fixed count overshot to the drive root — the 2026-07-03 primary crash
+/// dumps landed at `D:\.dev-logs` instead of `D:\qontinui-root\.dev-logs`.
+/// A marker-based search survives any future layout move (slot pools,
+/// deeper target dirs, worktrees) as long as a `.dev-logs` dir exists
+/// somewhere above the exe.
+fn find_dev_logs_ancestor(exe_path: &std::path::Path) -> Option<PathBuf> {
+    // `ancestors()` yields the path itself first — skip it (it's the exe
+    // file, not a directory).
+    exe_path.ancestors().skip(1).find_map(|dir| {
+        let candidate = dir.join(".dev-logs");
+        if candidate.is_dir() {
+            Some(candidate)
+        } else {
+            None
+        }
+    })
+}
+
 /// Get the crash dump directory.
 ///
 /// Scoped per-runner for secondary instances so the `latest_crash.txt` file
 /// from one runner doesn't overwrite another's.
 pub fn get_crash_dump_dir() -> PathBuf {
-    // Try to use the .dev-logs directory in the parent directory
-    let base = if let Ok(exe_path) = std::env::current_exe() {
-        // Navigate from exe to qontinui-root/.dev-logs
-        exe_path
-            .parent()
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-            .and_then(|p| p.parent())
-            .map(|parent_dir| parent_dir.join(".dev-logs"))
-            .filter(|dev_logs| dev_logs.exists() || std::fs::create_dir_all(dev_logs).is_ok())
-    } else {
-        None
-    }
-    .unwrap_or_else(|| {
-        // Fallback to local app data
-        dirs::data_local_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("qontinui-runner")
-            .join("crash-dumps")
-    });
+    let base = std::env::current_exe()
+        .ok()
+        .and_then(|exe_path| find_dev_logs_ancestor(&exe_path))
+        .unwrap_or_else(|| {
+            // Fallback to local app data
+            dirs::data_local_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("qontinui-runner")
+                .join("crash-dumps")
+        });
 
     crate::instance::scope_path(&base)
 }
@@ -329,6 +348,32 @@ pub fn log_panic(info: &std::panic::PanicHookInfo) {
 
         let backtrace = format!("{:?}", std::backtrace::Backtrace::capture());
 
+        // ALSO write the supervisor-visible `runner-panic.log`. This hook
+        // REPLACES the early `startup_panic` hook at init, and the
+        // supervisor's postmortem path (`check_and_record_panic_log` /
+        // `parse_panic_file`) reads ONLY that file — before this call,
+        // any post-init crash left `recent_panic: null` on `GET /runners`
+        // (observed live 3x on 2026-07-03). `startup_panic::write_panic_log`
+        // is deliberately self-contained: dir resolution via
+        // `QONTINUI_RUNNER_LOG_DIR` (set by the supervisor) with a
+        // data_local_dir fallback, and no settings reads that could panic
+        // or poison a OnceLock mid-panic.
+        if !PANIC_LOG_WRITING.swap(true, Ordering::SeqCst) {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let thread_name = std::thread::current()
+                    .name()
+                    .unwrap_or("<unnamed>")
+                    .to_string();
+                crate::startup_panic::write_panic_log(
+                    &message,
+                    &location,
+                    &thread_name,
+                    &backtrace,
+                );
+            }));
+            PANIC_LOG_WRITING.store(false, Ordering::SeqCst);
+        }
+
         // Write crash dump to file
         write_crash_dump(&location, &message, &backtrace);
 
@@ -353,4 +398,107 @@ pub fn setup_panic_handler() {
     std::panic::set_hook(Box::new(|info| {
         log_panic(info);
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    /// Create `dir` and every missing parent, panicking on failure (tests only).
+    fn mk(dir: &Path) {
+        std::fs::create_dir_all(dir).expect("create test dir");
+    }
+
+    /// All three deployed exe layouts must resolve to `<root>/.dev-logs`
+    /// when it exists. The old fixed five-`.parent()` walk only handled the
+    /// pre-workspace `src-tauri\target\debug\` layout and overshot to the
+    /// drive root for the others (live evidence 2026-07-03: dumps at
+    /// `D:\.dev-logs` instead of `D:\qontinui-root\.dev-logs`).
+    #[test]
+    fn find_dev_logs_ancestor_resolves_all_known_exe_layouts() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let dev_logs = root.join(".dev-logs");
+        mk(&dev_logs);
+
+        let layouts = [
+            // Workspace-root target (current deployed layout).
+            root.join("qontinui-runner")
+                .join("target")
+                .join("debug")
+                .join("qontinui-runner-primary.exe"),
+            // Pre-workspace layout (the one the old fixed walk assumed).
+            root.join("qontinui-runner")
+                .join("src-tauri")
+                .join("target")
+                .join("debug")
+                .join("qontinui-runner.exe"),
+            // Supervisor build-pool slot layout.
+            root.join("qontinui-runner")
+                .join("target-pool")
+                .join("slot-0")
+                .join("debug")
+                .join("qontinui-runner.exe"),
+        ];
+
+        for exe in &layouts {
+            mk(exe.parent().unwrap());
+            assert_eq!(
+                find_dev_logs_ancestor(exe).as_deref(),
+                Some(dev_logs.as_path()),
+                "layout {:?} must resolve to the fixture .dev-logs",
+                exe
+            );
+        }
+    }
+
+    /// The NEAREST ancestor with a `.dev-logs` child wins — a repo-local
+    /// `.dev-logs` must shadow one further up the tree.
+    #[test]
+    fn find_dev_logs_ancestor_prefers_nearest() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        mk(&root.join(".dev-logs"));
+        let near = root.join("qontinui-runner").join(".dev-logs");
+        mk(&near);
+
+        let exe = root
+            .join("qontinui-runner")
+            .join("target")
+            .join("debug")
+            .join("qontinui-runner.exe");
+        mk(exe.parent().unwrap());
+
+        assert_eq!(
+            find_dev_logs_ancestor(&exe).as_deref(),
+            Some(near.as_path())
+        );
+    }
+
+    /// A `.dev-logs` FILE (not dir) must not be picked up.
+    #[test]
+    fn find_dev_logs_ancestor_ignores_plain_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::write(root.join(".dev-logs"), b"not a dir").unwrap();
+
+        let exe = root
+            .join("qontinui-runner")
+            .join("target")
+            .join("debug")
+            .join("qontinui-runner.exe");
+        mk(exe.parent().unwrap());
+
+        // Either nothing is found, or (on a dev box that genuinely has a
+        // `.dev-logs` dir above the temp dir) the hit must lie OUTSIDE the
+        // fixture — never the plain file inside it.
+        if let Some(found) = find_dev_logs_ancestor(&exe) {
+            assert!(
+                !found.starts_with(root),
+                "must not resolve to the .dev-logs FILE inside the fixture: {:?}",
+                found
+            );
+        }
+    }
 }

--- a/src-tauri/src/startup_panic.rs
+++ b/src-tauri/src/startup_panic.rs
@@ -21,7 +21,11 @@
 //! chains to whatever hook was previously installed (which is the default
 //! stderr printer during this early window). Later, `logging::setup_panic_handler`
 //! overwrites the hook with the richer crash-dump version; by then early
-//! init has succeeded and the simpler hook has done its job.
+//! init has succeeded and the simpler hook has done its job. The late hook
+//! (`logging::log_panic`) calls back into [`write_panic_log`] so post-init
+//! panics keep producing the supervisor-parseable `runner-panic.log` too —
+//! before 2026-07-03 they didn't, and a crashed primary showed
+//! `recent_panic: null` on the supervisor's `/runners`.
 //!
 //! # File semantics
 //!


### PR DESCRIPTION
## What

Phases 2 + 3 (+ an implement-time addendum) of `plans/2026-07-03-primary-runner-crash-resilience.md` — the runner half of the primary-crash-resilience work.

### Phase 2 — suppress the aws-lc debug-assertion abort trigger
`[profile.dev.package.aws-lc-rs]` / `aws-lc-sys` `debug-assertions = false` at the **workspace root** `Cargo.toml`. Removes the debug-only UB check that turned a jitter-entropy alignment race into the `0xc0000409` `__fastfail` abort that killed the primary for 5h13m on 2026-07-03. Release-parity for those two crates only; escalation path (`package."*"`) documented inline. (per-package `[profile.*]` is ignored under a workspace — must live at the root.)

### Phase 3 — fix the abort-path postmortem gap
Two root causes, both confirmed live:
1. **Late panic hook never wrote `runner-panic.log`.** `logging::setup_panic_handler` replaces `startup_panic.rs`'s early hook after init; its `log_panic` wrote only `crash_*.txt`, so the supervisor's `check_and_record_panic_log` always saw `recent_panic: null` for post-init crashes. `log_panic` now also writes the supervisor-parseable `runner-panic.log` via `startup_panic::write_panic_log` (re-entrancy latched).
2. **`get_crash_dump_dir` overshot to the drive root.** A fixed five-`.parent()` walk written for the pre-workspace layout landed dumps at `D:\.dev-logs` instead of `D:\qontinui-root\.dev-logs`. Replaced with a marker-based ancestor search for an existing `.dev-logs` dir (nearest wins), `dirs::data_local_dir()` fallback. 3 unit tests across the exe layouts.

### Addendum — tolerant trigger-row loader (found live during implementation)
The primary crash-looped a **second, unrelated** way: `trigger_row_to_workflow_trigger` used panicking `row.get(5)` and died ~15s after every start. Root cause (confirmed against the live DB): `project.workflow_triggers.workflow_id` is **`uuid`** in the canonical DB but the mapper/DDL reads **`text`** — every row fails `String::accepts(Uuid)` before the value is even read. Now returns `Result` with `try_get` on every column; loaders **log-and-skip** malformed rows (`{:?}` format — tokio-postgres `Display` hides the cause) instead of crash-looping.

> ⚠️ **Operator follow-up (not fixed here):** until the `workflow_id` uuid/text drift is reconciled, the runner boots healthy but loads **zero** triggers — git/spec supervision triggers stay inactive. The hardening makes this loud (ERROR per row), not fatal. `create_trigger`/`update_trigger` also bind `String` and will fail against the uuid column.

## Verification
- `cargo check -p qontinui-runner --lib` green; 8 unit tests pass (3 new dump-dir walk + 5 startup_panic).
- **Temp runner built from this branch booted healthy** and served `GET /triggers` (200, empty) where the old binary crash-looped, logging the expected "skipping malformed trigger row … WrongType { postgres: Uuid }" errors.
- Edit-effect verify: `composed_outcome: confirmed`.

> **Note:** the pre-push clippy hook trips on **pre-existing clippy-1.95 lints in files this PR does not touch** (`flywheel_e2e_tests.rs`, `spec_authoring.rs` — e.g. `doc_overindented_list_items`). This PR's own files are clippy-clean; pushed with `QONTINUI_PREPUSH_SKIP=1` so CI is the gate.

Plan: `2026-07-03-primary-runner-crash-resilience`.
