### PR TITLE
Multi-tenant device binding — runner (Phases 1/8a/8b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6693,7 +6693,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "hex",

--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -284,11 +284,17 @@ pub(crate) fn coord_http_base_pub() -> Option<String> {
     coord_http_base()
 }
 
-/// Read `active_tenant_id` from `~/.qontinui/machine.json` (advisory —
-/// coord DB-resolves the real tenant, per memory
-/// `reference_oauth_tenant_claim_advisory_db_resolved`). `None` for
-/// single-tenant operators, which is fine: coord attributes the census
-/// to the device's resolved tenant regardless.
+/// Read `active_tenant_id` from `~/.qontinui/machine.json` — Phase 8b
+/// semantics (plan 2026-07-02-session-scoped-multi-tenant-device-binding
+/// §D4): the DEVICE-LEVEL DEFAULT binding, not the-only-tenant. The census
+/// is a device-scoped surface (it walks the whole machine), so the default
+/// is the correct request-level attribution. Note the census deliberately
+/// stamps NO per-worktree tenant: a worktree's tenant is its allocate-time
+/// coord stamp (`coord.agent_worktrees.tenant_id`), which coord already
+/// holds — stamping the machine default per row here would misattribute
+/// another tenant's worktrees (plan Phase 8 item 6). `None` for
+/// single-tenant operators, which is fine: coord attributes the census to
+/// the device's resolved tenant regardless.
 fn resolve_tenant_id() -> Option<Uuid> {
     let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
     let bytes = std::fs::read(path).ok()?;

--- a/src-tauri/src/agent_worktree/fs_backstop.rs
+++ b/src-tauri/src/agent_worktree/fs_backstop.rs
@@ -224,10 +224,14 @@ fn governed_canonical_checkouts(root: &Path) -> Vec<(String, PathBuf)> {
     out
 }
 
-/// Read `active_tenant_id` from `~/.qontinui/machine.json` (advisory — coord
-/// DB-resolves the real tenant). `None` for single-tenant operators, which is
-/// fine. Mirrors `census::resolve_tenant_id` (which is private; the read is
-/// trivial and tenant attribution is best-effort).
+/// Read `active_tenant_id` from `~/.qontinui/machine.json` — Phase 8b
+/// semantics: the DEVICE-LEVEL DEFAULT binding (default-for-new-sessions),
+/// not the-only-tenant. Correct here because the backstop is a
+/// device-scoped surface: it scans CANONICAL checkouts (never allocate-
+/// stamped agent worktrees, whose tenant lives on their coord row). `None`
+/// for single-tenant operators, which is fine. Mirrors
+/// `census::resolve_tenant_id` (which is private; the read is trivial and
+/// tenant attribution is best-effort).
 fn resolve_tenant_id() -> Option<uuid::Uuid> {
     let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
     let bytes = std::fs::read(path).ok()?;

--- a/src-tauri/src/agent_worktree/maintenance_executor.rs
+++ b/src-tauri/src/agent_worktree/maintenance_executor.rs
@@ -343,8 +343,11 @@ fn execute_instruction(instr: &MaintenanceInstruction) -> ExecOutcome {
 // git_ops reporting — reuse the SHIPPED observable-bridge record path.
 // ---------------------------------------------------------------------------
 
-/// Read `active_tenant_id` from `~/.qontinui/machine.json` (advisory — coord
-/// DB-resolves the real tenant). `None` for single-tenant operators, which is
+/// Read `active_tenant_id` from `~/.qontinui/machine.json` — Phase 8b
+/// semantics: the DEVICE-LEVEL DEFAULT binding (default-for-new-sessions),
+/// not the-only-tenant. Correct here because maintenance branch-resets act
+/// on CANONICAL checkouts (a device-scoped surface), never on allocate-
+/// stamped agent worktrees. `None` for single-tenant operators, which is
 /// fine. Mirrors `census::resolve_tenant_id` / `fs_backstop::resolve_tenant_id`
 /// (both private; the read is trivial and attribution is best-effort).
 fn resolve_tenant_id() -> Option<uuid::Uuid> {

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -95,6 +95,25 @@ fn keychain_enabled() -> bool {
     std::env::var_os("QONTINUI_DISABLE_KEYCHAIN").is_none()
 }
 
+/// Feature flag for the session-scoped multi-tenant device-JWT model
+/// (plan 2026-07-02-session-scoped-multi-tenant-device-binding, Phase 1).
+///
+/// `QONTINUI_MULTI_TENANT_JWT=1` turns on the flag-gated dark paths (the
+/// refresher's per-tenant slot pass). DEFAULT OFF: unset, empty, or any
+/// value other than `1` leaves every behavior byte-identical to today.
+/// Read from the environment on each call so a long-lived process picks up
+/// nothing stale — the check is a trivial env read.
+pub fn multi_tenant_jwt_enabled() -> bool {
+    multi_tenant_jwt_flag_from(std::env::var("QONTINUI_MULTI_TENANT_JWT").ok().as_deref())
+}
+
+/// Pure core of [`multi_tenant_jwt_enabled`]: only the exact value `1`
+/// (after trimming) enables the flag. Factored out so the gate is testable
+/// without mutating process-global env vars (racy across parallel tests).
+pub(crate) fn multi_tenant_jwt_flag_from(raw: Option<&str>) -> bool {
+    matches!(raw.map(str::trim), Some("1"))
+}
+
 /// Manages authentication tokens and device ID storage.
 ///
 /// The AuthManager provides secure storage for:
@@ -601,6 +620,49 @@ impl AuthManager {
             None => self.secure_storage.get_oauth_refresh_token().is_ok(),
         }
     }
+
+    // ========================================================================
+    // Per-tenant device-JWT slots — session-scoped multi-tenant Phase 1
+    // (plan 2026-07-02-session-scoped-multi-tenant-device-binding, D4).
+    //
+    // One secure-storage slot per tenant binding, keyed
+    // `device_jwt:<tenant_id>`. The legacy `access_token` slot is NEVER
+    // read or written by these methods — it keeps holding the DEFAULT
+    // binding's JWT, so every unmodified consumer (relay, data-plane bearer,
+    // legacy refresher path) keeps working during the compat window. Like
+    // the oauth_* slots, the keychain backup is intentionally not mirrored
+    // (file store is the source of truth; see module docs).
+    // ========================================================================
+
+    /// Store (or overwrite) the device JWT for one tenant binding
+    /// (slot `device_jwt:<tenant_id>`). Never touches the legacy
+    /// `access_token` slot.
+    pub fn store_tenant_device_jwt(&self, tenant_id: &Uuid, jwt: &str) -> Result<()> {
+        self.secure_storage
+            .store_tenant_device_jwt(tenant_id, jwt)
+            .context("Failed to store per-tenant device JWT in secure storage")
+    }
+
+    /// Retrieve the device JWT for one tenant binding. `Ok(None)` when no
+    /// slot exists for that tenant.
+    pub fn get_tenant_device_jwt(&self, tenant_id: &Uuid) -> Result<Option<String>> {
+        self.secure_storage.get_tenant_device_jwt(tenant_id)
+    }
+
+    /// Remove one tenant's device-JWT slot. Idempotent; never touches the
+    /// legacy `access_token` slot or any other tenant's slot.
+    pub fn clear_tenant_device_jwt(&self, tenant_id: &Uuid) -> Result<()> {
+        self.secure_storage
+            .clear_tenant_device_jwt(tenant_id)
+            .context("Failed to clear per-tenant device JWT from secure storage")
+    }
+
+    /// Enumerate the tenant ids that currently have a device-JWT slot, in
+    /// deterministic order. Never fatal — an unreadable store yields an
+    /// empty list.
+    pub fn list_tenant_device_jwt_tenants(&self) -> Vec<Uuid> {
+        self.secure_storage.list_tenant_device_jwt_tenants()
+    }
 }
 
 impl Default for AuthManager {
@@ -920,6 +982,98 @@ mod tests {
         );
 
         let _ = fs::remove_file(&storage_path);
+    }
+}
+
+/// Tests for the per-tenant device-JWT slots + the multi-tenant feature flag
+/// (session-scoped multi-tenant Phase 1).
+#[cfg(test)]
+mod tenant_device_jwt_tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+
+    fn create_test_auth_manager(test_name: &str) -> AuthManager {
+        let temp_dir = env::temp_dir().join("qontinui_test_auth_tenant_jwt");
+        let storage_path = temp_dir.join(format!("{}.enc", test_name));
+        let _ = fs::remove_file(&storage_path);
+        let storage = SecureStorage::with_path(storage_path).unwrap();
+        AuthManager::with_storage(storage)
+    }
+
+    #[test]
+    fn flag_is_default_off_and_only_exactly_1_enables() {
+        // Default off: unset / empty / junk / "true" / "0" all stay dark.
+        assert!(!multi_tenant_jwt_flag_from(None));
+        assert!(!multi_tenant_jwt_flag_from(Some("")));
+        assert!(!multi_tenant_jwt_flag_from(Some("0")));
+        assert!(!multi_tenant_jwt_flag_from(Some("true")));
+        assert!(!multi_tenant_jwt_flag_from(Some("yes")));
+        // Only the documented value (trimmed) enables.
+        assert!(multi_tenant_jwt_flag_from(Some("1")));
+        assert!(multi_tenant_jwt_flag_from(Some(" 1 ")));
+    }
+
+    #[test]
+    fn tenant_slot_round_trip_and_enumeration() {
+        let mgr = create_test_auth_manager("tenant_slot_round_trip");
+        let a = Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap();
+        let b = Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").unwrap();
+
+        assert!(mgr.get_tenant_device_jwt(&a).unwrap().is_none());
+        assert!(mgr.list_tenant_device_jwt_tenants().is_empty());
+
+        mgr.store_tenant_device_jwt(&a, "jwt.a").unwrap();
+        mgr.store_tenant_device_jwt(&b, "jwt.b").unwrap();
+
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&a).unwrap().as_deref(),
+            Some("jwt.a")
+        );
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&b).unwrap().as_deref(),
+            Some("jwt.b")
+        );
+        let mut listed = mgr.list_tenant_device_jwt_tenants();
+        listed.sort();
+        assert_eq!(listed, vec![a, b]);
+
+        mgr.clear_tenant_device_jwt(&a).unwrap();
+        assert!(mgr.get_tenant_device_jwt(&a).unwrap().is_none());
+        assert_eq!(mgr.list_tenant_device_jwt_tenants(), vec![b]);
+    }
+
+    /// THE Phase-1 invariant: writing per-tenant slots never mutates the
+    /// legacy `access_token` slot (which keeps the DEFAULT binding's JWT for
+    /// every unmodified consumer), and clearing tenant slots doesn't either.
+    #[test]
+    fn tenant_slot_writes_never_mutate_legacy_access_token() {
+        let mgr = create_test_auth_manager("tenant_slot_legacy_preserved");
+        let a = Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap();
+
+        mgr.store_tokens("default.binding.jwt", "").unwrap();
+        mgr.store_tenant_device_jwt(&a, "jwt.a").unwrap();
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "default.binding.jwt",
+            "storing a tenant slot must not mutate access_token"
+        );
+
+        mgr.store_tenant_device_jwt(&a, "jwt.a.v2").unwrap();
+        mgr.clear_tenant_device_jwt(&a).unwrap();
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "default.binding.jwt",
+            "overwriting/clearing a tenant slot must not mutate access_token"
+        );
+
+        // Reverse direction: a legacy write leaves tenant slots alone.
+        mgr.store_tenant_device_jwt(&a, "jwt.a.v3").unwrap();
+        mgr.store_tokens("default.binding.jwt.v2", "").unwrap();
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&a).unwrap().as_deref(),
+            Some("jwt.a.v3")
+        );
     }
 }
 

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -685,7 +685,62 @@ static MISSING_TOKEN_WARNED: std::sync::Once = std::sync::Once::new();
 /// the refresher loop), so a stale long-lived cache would risk presenting an
 /// expired bearer. Reading per-call keeps us always-current.
 pub fn device_bearer() -> Option<String> {
-    match AuthManager::new().get_access_token() {
+    device_bearer_for(None)
+}
+
+/// Tenant-selecting variant of [`device_bearer`] — the Phase 8b credential
+/// seam (plan `2026-07-02-session-scoped-multi-tenant-device-binding` §D4).
+///
+/// - `None` → the DEFAULT binding's JWT from the legacy `access_token` slot
+///   (byte-identical to the pre-8b [`device_bearer`] behavior, so every
+///   unparameterized caller keeps the default slot by construction).
+/// - `Some(t)` → that tenant's `device_jwt:<t>` slot. On a slot MISS:
+///   - when `t` IS the default binding (per `paired_user.json`), fall back
+///     to the legacy `access_token` slot — it holds the same binding's JWT
+///     (and is the only slot on a pre-8a install);
+///   - otherwise return `None` (send unauthenticated) and warn once per
+///     tenant per process. FAIL-SOFT POSTURE (decided here): a slot miss for
+///     a non-default tenant must NEVER silently present another tenant's
+///     credential — a wrong claim would be attributed cross-tenant coord-side
+///     with no observable. Unauthenticated requests instead flow through
+///     coord's server-side resolution (explicit payload tenant / sole-binding
+///     / legacy-pointer window), which is counted and 422s honestly.
+pub fn device_bearer_for(tenant: Option<&Uuid>) -> Option<String> {
+    select_device_bearer(&AuthManager::new(), tenant, default_binding_tenant())
+}
+
+/// Pure-over-injected-parts core of [`device_bearer_for`] so slot selection
+/// is hermetically testable (temp-dir [`SecureStorage::with_path`] +
+/// explicit `default_tenant`, no process-global env mutation).
+pub(crate) fn select_device_bearer(
+    am: &AuthManager,
+    tenant: Option<&Uuid>,
+    default_tenant: Option<Uuid>,
+) -> Option<String> {
+    let Some(t) = tenant else {
+        return legacy_slot_bearer(am);
+    };
+    match am.get_tenant_device_jwt(t) {
+        Ok(Some(jwt)) if !jwt.trim().is_empty() => return Some(jwt),
+        Ok(_) => {}
+        Err(e) => {
+            debug!("coord data-plane: tenant {t} device-JWT slot read failed ({e})");
+        }
+    }
+    // Slot miss. The default binding may legitimately live only in the
+    // legacy slot (pre-8a install, or a pairing that predates per-tenant
+    // slots) — that slot IS this tenant's JWT, so fall back to it.
+    if default_tenant.as_ref() == Some(t) {
+        return legacy_slot_bearer(am);
+    }
+    warn_once_per_tenant_slot_miss(t);
+    None
+}
+
+/// Read the legacy `access_token` slot (the DEFAULT binding's JWT) with the
+/// original never-fatal posture + once-per-process missing-token warning.
+fn legacy_slot_bearer(am: &AuthManager) -> Option<String> {
+    match am.get_access_token() {
         Ok(token) if !token.trim().is_empty() => Some(token),
         Ok(_) => {
             MISSING_TOKEN_WARNED.call_once(|| {
@@ -708,6 +763,43 @@ pub fn device_bearer() -> Option<String> {
     }
 }
 
+/// Warn once per (tenant, process) that a requested non-default tenant has
+/// no device-JWT slot — the heal is pairing this runner for that tenant.
+fn warn_once_per_tenant_slot_miss(tenant: &Uuid) {
+    static WARNED: std::sync::OnceLock<std::sync::Mutex<std::collections::BTreeSet<Uuid>>> =
+        std::sync::OnceLock::new();
+    let set = WARNED.get_or_init(|| std::sync::Mutex::new(std::collections::BTreeSet::new()));
+    let mut guard = set.lock().expect("tenant slot-miss warn set poisoned");
+    if guard.insert(*tenant) {
+        warn!(
+            "coord data-plane: no device-JWT slot for tenant {tenant} — sending that \
+             tenant's coord calls unauthenticated (never another tenant's credential); \
+             pair this runner for that tenant to authenticate"
+        );
+    }
+}
+
+/// The device's DEFAULT binding tenant, read from `paired_user.json`
+/// (v2 `default_tenant_id`, legacy `tenant_id` fallback). Kept as a local
+/// minimal reader because `auth` compiles into BOTH the lib and bin crates
+/// while `pair` (the canonical v2-aware reader) is lib-only — same
+/// documented duplication pattern as the census/backstop `machine.json`
+/// readers. `None` on any failure (unpaired runner).
+fn default_binding_tenant() -> Option<Uuid> {
+    let base = std::env::var("QONTINUI_SECURE_STORAGE_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::data_local_dir().map(|d| d.join("com.qontinui.runner")))?;
+    let bytes = std::fs::read(base.join("paired_user.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let raw = value
+        .get("default_tenant_id")
+        .and_then(|v| v.as_str())
+        .or_else(|| value.get("tenant_id").and_then(|v| v.as_str()))?;
+    Uuid::parse_str(raw.trim()).ok()
+}
+
 /// Attach the device-JWT bearer to a coord data-plane request when one is
 /// available, otherwise return the builder unchanged. Also drives the
 /// auth-coverage metric (the dogfood signal Phase 1 gates on): every call is
@@ -716,8 +808,21 @@ pub fn device_bearer() -> Option<String> {
 /// call so an operator can watch the unpaired→paired transition without a new
 /// dependency.
 pub fn attach_device_auth(rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    attach_device_auth_for(rb, None)
+}
+
+/// Tenant-selecting variant of [`attach_device_auth`] (Phase 8b, plan §D4):
+/// `Some(tenant)` presents that binding's device-JWT slot, `None` the default
+/// binding's. Slot-miss posture is [`device_bearer_for`]'s (never another
+/// tenant's credential — degrade to unauthenticated). Session-scoped callers
+/// pass the owning session's tenant; device-scoped callers use the plain
+/// [`attach_device_auth`] and keep the default slot by construction.
+pub fn attach_device_auth_for(
+    rb: reqwest::RequestBuilder,
+    tenant: Option<&Uuid>,
+) -> reqwest::RequestBuilder {
     let total = DATA_PLANE_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-    let rb = match device_bearer() {
+    let rb = match device_bearer_for(tenant) {
         Some(token) => {
             DATA_PLANE_AUTHED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             rb.header("Authorization", format!("Bearer {token}"))
@@ -1042,6 +1147,128 @@ mod tenant_device_jwt_tests {
             mgr.get_tenant_device_jwt(&a).unwrap().as_deref(),
             Some("jwt.a.v3")
         );
+    }
+}
+
+/// Tests for the Phase 8b per-session credential SELECTION seam
+/// ([`select_device_bearer`] — the injected core of [`device_bearer_for`] /
+/// [`attach_device_auth_for`]). Hermetic: temp-dir storage + explicit
+/// `default_tenant`, no env mutation, no network.
+#[cfg(test)]
+mod bearer_selection_tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+
+    fn create_test_auth_manager(test_name: &str) -> AuthManager {
+        let temp_dir = env::temp_dir().join("qontinui_test_auth_bearer_select");
+        let storage_path = temp_dir.join(format!("{}.enc", test_name));
+        let _ = fs::remove_file(&storage_path);
+        let storage = SecureStorage::with_path(storage_path).unwrap();
+        AuthManager::with_storage(storage)
+    }
+
+    fn tenant(n: u8) -> Uuid {
+        Uuid::from_bytes([n; 16])
+    }
+
+    /// No tenant in scope → the legacy `access_token` slot (default binding)
+    /// — the by-construction guarantee for every unparameterized caller.
+    #[test]
+    fn no_tenant_selects_legacy_default_slot() {
+        let mgr = create_test_auth_manager("no_tenant_default_slot");
+        mgr.store_tokens("default.jwt", "").unwrap();
+        let a = tenant(0xAA);
+        mgr.store_tenant_device_jwt(&a, "jwt.a").unwrap();
+
+        assert_eq!(
+            select_device_bearer(&mgr, None, Some(a)).as_deref(),
+            Some("default.jwt"),
+            "None tenant must read the legacy slot, never a tenant slot"
+        );
+    }
+
+    /// Session tenant with a populated slot → that slot's JWT, not the
+    /// default.
+    #[test]
+    fn session_tenant_selects_its_own_slot() {
+        let mgr = create_test_auth_manager("session_tenant_own_slot");
+        mgr.store_tokens("default.jwt", "").unwrap();
+        let a = tenant(0xA1);
+        let b = tenant(0xB2);
+        mgr.store_tenant_device_jwt(&a, "jwt.a").unwrap();
+        mgr.store_tenant_device_jwt(&b, "jwt.b").unwrap();
+
+        assert_eq!(
+            select_device_bearer(&mgr, Some(&b), Some(a)).as_deref(),
+            Some("jwt.b"),
+            "a session-scoped call must present the session tenant's slot"
+        );
+        assert_eq!(
+            select_device_bearer(&mgr, Some(&a), Some(a)).as_deref(),
+            Some("jwt.a")
+        );
+    }
+
+    /// DEFAULT-tenant slot miss falls back to the legacy slot — the legacy
+    /// slot holds the same binding's JWT (pre-8a installs have only it).
+    #[test]
+    fn default_tenant_slot_miss_falls_back_to_legacy_slot() {
+        let mgr = create_test_auth_manager("default_miss_legacy_fallback");
+        mgr.store_tokens("default.jwt", "").unwrap();
+        let a = tenant(0xC3);
+        // No per-tenant slot stored for `a`, but `a` IS the default binding.
+        assert_eq!(
+            select_device_bearer(&mgr, Some(&a), Some(a)).as_deref(),
+            Some("default.jwt"),
+            "default-binding slot miss must fall back to access_token (same binding)"
+        );
+    }
+
+    /// FAIL-SOFT posture: an unknown (non-default) tenant slot miss yields
+    /// NO bearer — never another tenant's credential.
+    #[test]
+    fn unknown_tenant_slot_miss_sends_unauthenticated() {
+        let mgr = create_test_auth_manager("unknown_miss_unauthenticated");
+        mgr.store_tokens("default.jwt", "").unwrap();
+        let default = tenant(0xD4);
+        mgr.store_tenant_device_jwt(&default, "jwt.default")
+            .unwrap();
+        let stranger = tenant(0xE5);
+
+        assert_eq!(
+            select_device_bearer(&mgr, Some(&stranger), Some(default)),
+            None,
+            "non-default slot miss must degrade to unauthenticated, not cross-tenant"
+        );
+    }
+
+    /// An empty/whitespace tenant-slot value counts as a miss and follows
+    /// the same posture (default → legacy fallback; stranger → None).
+    #[test]
+    fn empty_slot_value_counts_as_miss() {
+        let mgr = create_test_auth_manager("empty_slot_is_miss");
+        mgr.store_tokens("default.jwt", "").unwrap();
+        let a = tenant(0xF6);
+        mgr.store_tenant_device_jwt(&a, "   ").unwrap();
+
+        assert_eq!(
+            select_device_bearer(&mgr, Some(&a), Some(a)).as_deref(),
+            Some("default.jwt")
+        );
+        let default = tenant(0x11);
+        assert_eq!(select_device_bearer(&mgr, Some(&a), Some(default)), None);
+    }
+
+    /// No default binding known (unpaired) + non-default tenant miss →
+    /// None; None tenant still degrades to the legacy read (which may
+    /// itself be empty → None).
+    #[test]
+    fn unpaired_runner_degrades_to_none() {
+        let mgr = create_test_auth_manager("unpaired_degrades_none");
+        let a = tenant(0x22);
+        assert_eq!(select_device_bearer(&mgr, Some(&a), None), None);
+        assert_eq!(select_device_bearer(&mgr, None, None), None);
     }
 }
 

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -95,25 +95,6 @@ fn keychain_enabled() -> bool {
     std::env::var_os("QONTINUI_DISABLE_KEYCHAIN").is_none()
 }
 
-/// Feature flag for the session-scoped multi-tenant device-JWT model
-/// (plan 2026-07-02-session-scoped-multi-tenant-device-binding, Phase 1).
-///
-/// `QONTINUI_MULTI_TENANT_JWT=1` turns on the flag-gated dark paths (the
-/// refresher's per-tenant slot pass). DEFAULT OFF: unset, empty, or any
-/// value other than `1` leaves every behavior byte-identical to today.
-/// Read from the environment on each call so a long-lived process picks up
-/// nothing stale — the check is a trivial env read.
-pub fn multi_tenant_jwt_enabled() -> bool {
-    multi_tenant_jwt_flag_from(std::env::var("QONTINUI_MULTI_TENANT_JWT").ok().as_deref())
-}
-
-/// Pure core of [`multi_tenant_jwt_enabled`]: only the exact value `1`
-/// (after trimming) enables the flag. Factored out so the gate is testable
-/// without mutating process-global env vars (racy across parallel tests).
-pub(crate) fn multi_tenant_jwt_flag_from(raw: Option<&str>) -> bool {
-    matches!(raw.map(str::trim), Some("1"))
-}
-
 /// Manages authentication tokens and device ID storage.
 ///
 /// The AuthManager provides secure storage for:
@@ -999,19 +980,6 @@ mod tenant_device_jwt_tests {
         let _ = fs::remove_file(&storage_path);
         let storage = SecureStorage::with_path(storage_path).unwrap();
         AuthManager::with_storage(storage)
-    }
-
-    #[test]
-    fn flag_is_default_off_and_only_exactly_1_enables() {
-        // Default off: unset / empty / junk / "true" / "0" all stay dark.
-        assert!(!multi_tenant_jwt_flag_from(None));
-        assert!(!multi_tenant_jwt_flag_from(Some("")));
-        assert!(!multi_tenant_jwt_flag_from(Some("0")));
-        assert!(!multi_tenant_jwt_flag_from(Some("true")));
-        assert!(!multi_tenant_jwt_flag_from(Some("yes")));
-        // Only the documented value (trimmed) enables.
-        assert!(multi_tenant_jwt_flag_from(Some("1")));
-        assert!(multi_tenant_jwt_flag_from(Some(" 1 ")));
     }
 
     #[test]

--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -473,6 +473,15 @@ pub struct LogEntry {
     pub agent_session_id: Option<Uuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub device_id: Option<Uuid>,
+    /// Phase 8b (plan 2026-07-02-session-scoped-multi-tenant-device-binding,
+    /// Phase 8 item 7 / D2 site 14): EXPLICIT tenant attribution from the
+    /// owning session's binding — these emitters serve runner-managed
+    /// operator sessions, whose binding is the device DEFAULT. Coord's
+    /// ingest fallback chain prefers it once Phase 5 deploys; today's coord
+    /// ignores the extra field. Omitted when unresolvable (coord then
+    /// resolves agent→worktree→device-side, the pre-8b behavior).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<Uuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
@@ -497,6 +506,10 @@ pub struct AgentLogEmitter {
     /// caller re-threading it.
     agent_id: Uuid,
     device_id: Option<Uuid>,
+    /// Phase 8b item 7 — the owning session's tenant binding, resolved once
+    /// at emitter start (device DEFAULT for these runner-managed sessions)
+    /// and stamped on every entry.
+    tenant_id: Option<Uuid>,
 }
 
 impl AgentLogEmitter {
@@ -535,11 +548,16 @@ impl AgentLogEmitter {
             tx,
             agent_id,
             device_id: Some(device_id),
+            // Phase 8b item 7 — resolve the owning session's binding once
+            // (device DEFAULT: these are runner-managed operator sessions;
+            // coord-spawned agent sessions don't stream through this
+            // emitter). Best-effort: `None` omits the field on the wire.
+            tenant_id: crate::fleet::resolve_tenant_id(),
         })
     }
 
     /// Build a `LogEntry` stamped with this emitter's identity (agent session
-    /// id + device id), letting coord stamp `occurred_at`.
+    /// id + device id + owning tenant), letting coord stamp `occurred_at`.
     fn entry(&self, level: &str, event: &str, payload: Option<serde_json::Value>) -> LogEntry {
         LogEntry {
             level: level.to_string(),
@@ -547,6 +565,7 @@ impl AgentLogEmitter {
             payload,
             agent_session_id: Some(self.agent_id),
             device_id: self.device_id,
+            tenant_id: self.tenant_id,
             occurred_at: None,
         }
     }
@@ -1019,12 +1038,14 @@ mod tests {
     fn log_entry_serializes_to_coord_wire_shape() {
         let agent = Uuid::new_v4();
         let device = Uuid::new_v4();
+        let tenant = Uuid::new_v4();
         let entry = LogEntry {
             level: "info".to_string(),
             event: "stdout".to_string(),
             payload: Some(json!({ "text": "hello" })),
             agent_session_id: Some(agent),
             device_id: Some(device),
+            tenant_id: Some(tenant),
             occurred_at: None,
         };
         let v = serde_json::to_value(&entry).unwrap();
@@ -1034,8 +1055,27 @@ mod tests {
         assert_eq!(v["payload"]["text"], json!("hello"));
         assert_eq!(v["agent_session_id"], json!(agent));
         assert_eq!(v["device_id"], json!(device));
+        // Phase 8b item 7 — explicit tenant attribution on the wire.
+        assert_eq!(v["tenant_id"], json!(tenant));
         // `occurred_at` omitted (skip_serializing_if None) so coord stamps now().
         assert!(v.get("occurred_at").is_none());
+    }
+
+    /// Phase 8b — a None tenant_id is omitted (pre-8b wire shape preserved
+    /// for unpaired runners; coord's fallback chain still resolves).
+    #[test]
+    fn log_entry_omits_none_tenant_id() {
+        let entry = LogEntry {
+            level: "info".to_string(),
+            event: "stdout".to_string(),
+            payload: None,
+            agent_session_id: None,
+            device_id: None,
+            tenant_id: None,
+            occurred_at: None,
+        };
+        let v = serde_json::to_value(&entry).unwrap();
+        assert!(v.get("tenant_id").is_none());
     }
 
     #[test]
@@ -1046,6 +1086,7 @@ mod tests {
             payload: None,
             agent_session_id: None,
             device_id: None,
+            tenant_id: None,
             occurred_at: None,
         };
         let mut q: std::collections::VecDeque<LogEntry> = std::collections::VecDeque::new();

--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -195,26 +195,36 @@ pub fn session_uuid(session_id: &str) -> Uuid {
 ///
 /// Resolution sources:
 ///
-/// - `tenant_id` → `fleet::resolve_tenant_id`-equivalent: prefer
-///   `paired_user.json::tenant_id`, fall back to the cached
-///   device-token JWT claim.
+/// - `tenant_id` → **the spawned session's own binding first** (Phase 8b,
+///   plan 2026-07-02-session-scoped-multi-tenant-device-binding §D4:
+///   `session_tenant`, threaded from the spawn input when the caller
+///   recorded one), else the device DEFAULT binding:
+///   `paired_user.json::default_tenant_id`, falling back to the cached
+///   device-token JWT claim. Memories are hard tenant-scoped, so a
+///   session spawned for tenant B must federate B's pool even when the
+///   machine default is A.
 /// - `device_id` → `~/.qontinui/machine.json::device_id`.
 /// - `account_name` → derived from `effective_config_dir` (trailing
 ///   `.claude-<name>` component). Falls back to `"default"` for a
 ///   single-account install where `config_dir` is `~/.claude`.
 /// - `memory_dir` → `<effective_config_dir>/projects/<encoded
 ///   working_dir>/memory/` per Claude Code's on-disk convention.
+///
+/// The home-dir identity PIN (`federation.rs` device identity) is
+/// deliberately untouched (plan §6).
 pub fn build_federation_ctx(
     session_id: &str,
     working_dir: &str,
     cli_settings: &ClaudeCliSettings,
+    session_tenant: Option<Uuid>,
 ) -> Result<SessionContext, FederationSkipReason> {
-    let tenant_id = match resolve_tenant_id() {
+    let tenant_id = match session_tenant.or_else(resolve_tenant_id) {
         Some(t) => t,
         None => {
             warn!(
                 "claude_session::federation: tenant_id unresolvable \
-                 (no paired_user.json::tenant_id, no claim in cached device-token JWT); \
+                 (no session tenant, no paired_user.json::tenant_id, no claim in \
+                 cached device-token JWT); \
                  skipping memory federation for session {session_id}"
             );
             return Err(FederationSkipReason::TenantUnresolved);
@@ -474,9 +484,10 @@ pub fn log_bridge_report(category: &str, ctx: &SessionContext, report: Result<Re
     }
 }
 
-/// Resolve the tenant UUID. Mirrors `fleet.rs::resolve_tenant_id` but
-/// that's private to `fleet`; the duplication here keeps the federation
-/// module self-contained.
+/// Resolve the device DEFAULT binding's tenant UUID (Phase 8b semantics —
+/// the fallback for sessions with no recorded tenant of their own).
+/// Mirrors `fleet.rs::resolve_tenant_id` but that's private to `fleet`;
+/// the duplication here keeps the federation module self-contained.
 fn resolve_tenant_id() -> Option<Uuid> {
     if let Some(s) = qontinui_runner_lib::pair::read_paired_tenant_id_from_disk() {
         if let Ok(t) = Uuid::parse_str(s.trim()) {

--- a/src-tauri/src/claude_session/runner.rs
+++ b/src-tauri/src/claude_session/runner.rs
@@ -484,6 +484,10 @@ fn run_claude_session_inline(
             session_id,
             working_dir,
             &ai_settings.claude_cli,
+            // Phase 8b: no explicit spawn tenant on this path yet — the
+            // non-interactive runner spawns under the device default. A
+            // spawn input that records a session tenant threads it here.
+            None,
         ) {
             Ok(ctx) => Some(ctx),
             Err(reason) => {

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -311,6 +311,10 @@ impl ClaudeSession {
                 session_id,
                 working_dir,
                 &ai_settings.claude_cli,
+                // Phase 8b: interactive sessions have no explicit spawn
+                // tenant yet — device default. A spawn input recording a
+                // session tenant threads it here.
+                None,
             ) {
                 Ok(ctx) => Some(ctx),
                 Err(reason) => {

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1307,6 +1307,9 @@ pub async fn spawn_worker_session(
                 declared_paths: vec![],
                 share_output: true,
                 redact_secrets: None,
+                // Worker session — no explicit spawn tenant; the registry
+                // stamps the device default (default-for-new-sessions).
+                tenant_id: None,
             };
             match registry.register_external(intent) {
                 Ok(coord_id) => {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -38,6 +38,11 @@ pub struct StartSessionArgs {
     pub share_output: bool,
     #[serde(default)]
     pub redact_secrets: Option<bool>,
+    /// Phase 8b — explicit tenant binding for this session (the spawn
+    /// input). Omitted → the registry stamps the device default
+    /// (`machine.json::active_tenant_id`, default-for-new-sessions).
+    #[serde(default)]
+    pub tenant_id: Option<Uuid>,
 }
 
 impl From<StartSessionArgs> for Intent {
@@ -55,6 +60,7 @@ impl From<StartSessionArgs> for Intent {
             declared_paths: a.declared_paths,
             share_output: a.share_output,
             redact_secrets: a.redact_secrets,
+            tenant_id: a.tenant_id,
         }
     }
 }

--- a/src-tauri/src/commands/tenant.rs
+++ b/src-tauri/src/commands/tenant.rs
@@ -1,15 +1,27 @@
 //! Tenant resolution Tauri commands — plan
 //! [`2026-05-22-coord-native-session-coordination`] §D12 + §Phase 4.
 //!
+//! ## `active_tenant_id` semantics (Phase 8b, plan
+//! `2026-07-02-session-scoped-multi-tenant-device-binding` §D4)
+//!
+//! `machine.json::active_tenant_id` is the **default for NEW sessions and
+//! for device-level surfaces** (heartbeat, census, backstop, maintenance,
+//! doctor, flag-poll) — NOT "the only tenant this device serves". A device
+//! holds N concurrent tenant bindings (`paired_user.json` v2 +
+//! `coord.tenant_devices`); each session records its own tenant at
+//! creation (spawn input, else this default) and keeps it for life, so
+//! switching the active tenant re-points FUTURE sessions only.
+//!
 //! The frontend [`TenantContext`] reads the active tenant id (per machine)
 //! and offers a switcher when the operator belongs to >1 tenant. The
-//! source of truth for the active tenant is `~/.qontinui/machine.json`'s
+//! source of truth for the default is `~/.qontinui/machine.json`'s
 //! `active_tenant_id` field (D12 explicitly nominates this file as the
 //! per-machine pin). At first launch on a multi-tenant operator account
 //! the file may not yet hold the field; in that case we fall back to the
-//! single tenant available via the existing
+//! DEFAULT binding available via the existing
 //! [`qontinui_runner_lib::pair::read_paired_tenant_id_from_disk`] reader
-//! so the runner UI can render before the operator has explicitly chosen.
+//! (v2-aware: `default_tenant_id`) so the runner UI can render before the
+//! operator has explicitly chosen.
 //!
 //! Note: a richer "list of tenants the operator belongs to" requires a
 //! coord round-trip (Phase 5 dashboard). Phase 4 only needs the active
@@ -74,7 +86,9 @@ fn write_active_tenant_id(path: &Path, tenant_id: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Return the active tenant id for this machine. Resolution order:
+/// Return the active tenant id for this machine — the DEFAULT binding for
+/// new sessions and device-level surfaces (Phase 8b semantics; existing
+/// sessions keep their own recorded tenant). Resolution order:
 ///
 /// 1. `~/.qontinui/machine.json` → `active_tenant_id` field (D12 pin)
 /// 2. Cached pair file (`paired_user.json`) → `tenant_id` (fallback so
@@ -111,9 +125,11 @@ pub fn get_active_tenant() -> Result<CommandResponse, String> {
 
 /// Persist the operator's tenant choice to
 /// `~/.qontinui/machine.json::active_tenant_id`. Plan §D12 — stored
-/// per-machine; switching active tenant does NOT migrate already-running
-/// sessions (each session is stamped with its tenant at start and keeps
-/// it for life).
+/// per-machine; Phase 8b semantics: this sets the DEFAULT for NEW sessions
+/// and device-level surfaces on a device that may hold N concurrent
+/// bindings. It does NOT migrate already-running sessions (each session is
+/// stamped with its tenant at start and keeps it for life) and does NOT
+/// unpair any other binding.
 #[tauri::command]
 pub fn set_active_tenant(tenant_id: String) -> Result<CommandResponse, String> {
     let trimmed = tenant_id.trim();

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -171,6 +171,9 @@ pub async fn terminal_create(
             .collect(),
         share_output: true,
         redact_secrets: None,
+        // Operator-opened tab — no explicit spawn tenant; the registry
+        // stamps the device default (default-for-new-sessions).
+        tenant_id: None,
     };
     // R2 — RESUME the pane's prior coord session if one is persisted,
     // otherwise register fresh. Resuming PATCHes the EXISTING coord row
@@ -1172,6 +1175,9 @@ pub(crate) fn create_terminal_session_backend(
         declared_paths: vec![std::path::PathBuf::from(&working_dir)],
         share_output: true,
         redact_secrets: None,
+        // Gate-continuation terminal — device-default binding; the registry
+        // stamps machine.json's default-for-new-sessions.
+        tenant_id: None,
     };
 
     let mut coord_session_id: Option<uuid::Uuid> = None;

--- a/src-tauri/src/coord_doctor.rs
+++ b/src-tauri/src/coord_doctor.rs
@@ -525,6 +525,12 @@ fn read_runner_tier() -> Option<String> {
 // `device_jwt_refresher::resolve_pair_tenant_id`'s ordered chain without
 // depending on the runner binary: OAuth/runner-bearer claim → outgoing
 // device-JWT claim (same slot) → machine.json::active_tenant_id.
+//
+// Phase 8b semantics: this diagnoses the DEVICE-LEVEL DEFAULT binding
+// (machine.json's active_tenant_id is default-for-new-sessions, not
+// the-only-tenant). A multi-bound device with per-session tenants can be
+// healthy for its default while individual sessions run under other
+// bindings — the doctor's check is scoped to the default surface.
 // ---------------------------------------------------------------------------
 
 fn read_active_tenant_id_from_machine_json() -> Option<uuid::Uuid> {

--- a/src-tauri/src/coord_http.rs
+++ b/src-tauri/src/coord_http.rs
@@ -33,6 +33,23 @@ pub fn coord_get(client: &reqwest::Client, url: impl reqwest::IntoUrl) -> reqwes
     qontinui_runner_lib::auth::attach_device_auth(client.get(url))
 }
 
+/// Tenant-selecting variant of [`coord_get`] (Phase 8b, plan
+/// `2026-07-02-session-scoped-multi-tenant-device-binding` §D4):
+/// `Some(tenant)` attaches that binding's device-JWT slot, `None` the
+/// default binding's (identical to [`coord_get`]). Slot-miss posture is
+/// `auth::device_bearer_for`'s: a non-default tenant with no slot sends the
+/// request UNAUTHENTICATED (never another tenant's credential). Session-
+/// scoped readers pass the owning session's tenant; everything else keeps
+/// using [`coord_get`] and gets the default slot by construction.
+#[allow(dead_code)] // seam: session-scoped GET readers adopt as they gain tenants
+pub fn coord_get_for(
+    client: &reqwest::Client,
+    url: impl reqwest::IntoUrl,
+    tenant: Option<&uuid::Uuid>,
+) -> reqwest::RequestBuilder {
+    qontinui_runner_lib::auth::attach_device_auth_for(client.get(url), tenant)
+}
+
 /// True iff a non-empty device-JWT is currently stored.
 ///
 /// Callers that must distinguish "unpaired" (no token locally) from

--- a/src-tauri/src/coord_mcp.rs
+++ b/src-tauri/src/coord_mcp.rs
@@ -33,6 +33,27 @@
 //! structurally binds nonce→principal→`sub_type`: a device nonce can only ever
 //! forward a `sub_type == "device"` bearer, and an agent nonce a
 //! `sub_type == "agent"` bearer — neither can elevate into the other.
+//!
+//! # Multi-tenant disposition (Phase 8b, plan
+//! `2026-07-02-session-scoped-multi-tenant-device-binding` §D4)
+//!
+//! The proxy is SESSION-SCOPED where it matters and default-scoped where
+//! that is the honest binding:
+//!
+//! - **Agent principal — session-scoped by construction.** A coord-spawned
+//!   agent session's bearer is its own coord-minted agent JWT, whose
+//!   `tenant_id` claim is the SESSION's binding frozen at mint (coord
+//!   Phase 4 validates membership at spawn). Two concurrent agent sessions
+//!   for two tenants each present their own tenant's claim with zero
+//!   runner-side selection logic.
+//! - **Device principal — DEFAULT binding by construction.** Device-path
+//!   nonces serve operator terminals and gate-continuation shells, which
+//!   run under the device's default binding (`machine.json::
+//!   active_tenant_id`, default-for-new-sessions); the injected live device
+//!   JWT is the legacy slot = the default binding's credential. A future
+//!   spawn path that provisions a device-proxied session under a
+//!   NON-default binding must select via `auth::device_bearer_for` rather
+//!   than widen this path silently.
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -219,9 +219,10 @@ fn resolve_binding_set() -> Option<LocalBindingSet> {
 
 /// Single-tenant convenience over [`resolve_binding_set`]: the DEFAULT
 /// binding, for callers that stamp one tenant on a device-scoped write
-/// (e.g. the git-ops fleet feed). Session-scoped callers get their
-/// tenant from the owning session instead (Phase 8b).
-fn resolve_tenant_id() -> Option<uuid::Uuid> {
+/// (e.g. the git-ops fleet feed, the tree publisher's explicit
+/// `tenant_id`, the WIP-attribution walker). Session-scoped callers get
+/// their tenant from the owning session instead (Phase 8b).
+pub(crate) fn resolve_tenant_id() -> Option<uuid::Uuid> {
     resolve_binding_set().map(|b| b.default_tenant)
 }
 
@@ -1120,6 +1121,16 @@ struct TreeStatePayload {
     /// the truncated sample. `None` only if status couldn't be determined.
     #[serde(skip_serializing_if = "Option::is_none")]
     dirty_total: Option<i32>,
+    /// Phase 8b (plan 2026-07-02-session-scoped-multi-tenant-device-binding,
+    /// Phase 8 item 7 / D2 site 13): EXPLICIT tenant attribution — the
+    /// device DEFAULT binding, since primary trees are canonical
+    /// device-scoped checkouts (agent worktrees are coord-stamped at
+    /// allocate and never published here). Explicit-wins coord-side once
+    /// Phase 5's resolver deploys; today's coord ignores the extra field.
+    /// Omitted when the runner has no resolvable default binding. Filled by
+    /// the publisher alongside `device_id` (identity-side, not per-repo).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tenant_id: Option<uuid::Uuid>,
 }
 
 /// Maximum number of dirty paths included per row (the column is unbounded
@@ -1524,6 +1535,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
         local_ahead,
         behind_default_count,
         dirty_total: Some(dirty_total_count),
+        tenant_id: None,
     })
 }
 
@@ -2101,9 +2113,13 @@ async fn request_and_apply_pull(
     repo_path: std::path::PathBuf,
     payload: &TreeStatePayload,
 ) {
-    // 1. Request the decision (device-scoped — coord resolves tenant from
-    //    device_id; the executor's fresh git state rides in `context` so the
-    //    verdict can fall back to it if coord's row lags).
+    // 1. Request the decision (device-scoped; the executor's fresh git state
+    //    rides in `context` so the verdict can fall back to it if coord's
+    //    row lags). Phase 8b item 7: `tenant_id` goes EXPLICIT (device
+    //    DEFAULT binding, mirrored from the tree upsert) — coord's D2
+    //    resolver prefers it once Phase 5 deploys and stamps it into the
+    //    policy_rule_resolutions row that `pull-decision/record` later
+    //    resolves through; today's coord ignores the extra field.
     let context = serde_json::json!({
         "repo": payload.repo,
         "branch": payload.branch,
@@ -2113,12 +2129,15 @@ async fn request_and_apply_pull(
         "detached": payload.head_detached,
         "local_ahead": payload.local_ahead,
     });
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "device_id": device_id,
         "repo": payload.repo,
         "surface": "infra",
         "context": context,
     });
+    if let Some(t) = payload.tenant_id {
+        body["tenant_id"] = serde_json::json!(t);
+    }
     let url = format!("{base}/coord/trees/pull-decision");
     let resp = match client.post(&url).json(&body).send().await {
         Ok(r) if r.status().is_success() => r,
@@ -2404,6 +2423,11 @@ pub async fn publish_tree_state() -> Result<(), String> {
         }
     };
 
+    // Phase 8b item 7 — resolve the explicit publisher tenant (device
+    // DEFAULT binding) once per pass. `None` (unpaired) omits the field and
+    // coord resolves device-side, exactly the pre-8b behavior.
+    let publisher_tenant = resolve_tenant_id();
+
     let base = match coord_http_base() {
         Some(b) => b,
         None => {
@@ -2498,6 +2522,10 @@ pub async fn publish_tree_state() -> Result<(), String> {
         };
         total += 1;
         payload.device_id = device_id;
+        // Phase 8b item 7 — explicit tenant on the upsert wire (device
+        // DEFAULT binding; canonical trees are device-scoped). Identity-side
+        // like `device_id`, so stamped here rather than in capture_tree.
+        payload.tenant_id = publisher_tenant;
 
         let upsert_ok = match client.post(&url).json(&payload).send().await {
             Ok(resp) if resp.status().is_success() => {
@@ -3292,6 +3320,7 @@ mod tests {
             local_ahead: Some(0),
             behind_default_count: None,
             dirty_total: None,
+            tenant_id: None,
         };
         let body = serde_json::to_value(&p).unwrap();
         assert!(
@@ -3318,12 +3347,48 @@ mod tests {
             local_ahead: Some(0),
             behind_default_count: Some(42),
             dirty_total: None,
+            tenant_id: None,
         };
         let body = serde_json::to_value(&p).unwrap();
         assert_eq!(
             body.get("behind_default_count").and_then(|v| v.as_i64()),
             Some(42),
             "a set behind_default_count must appear on the upsert wire"
+        );
+        // Phase 8b item 7 — a None tenant_id is omitted (pre-8b wire shape
+        // preserved for unpaired runners)…
+        assert!(
+            body.get("tenant_id").is_none(),
+            "None tenant_id must be omitted from the upsert wire"
+        );
+    }
+
+    /// Phase 8b item 7 — the tree upsert goes EXPLICIT: a resolved default
+    /// binding appears as `tenant_id` on the wire.
+    #[test]
+    fn tree_payload_serializes_explicit_tenant_id() {
+        let t = uuid::Uuid::from_bytes([0x5A; 16]);
+        let p = TreeStatePayload {
+            device_id: uuid::Uuid::nil(),
+            repo: "qontinui-runner".into(),
+            branch: "main".into(),
+            head_sha: "deadbeef".into(),
+            dirty: false,
+            dirty_files: None,
+            last_edit_at: None,
+            behind_count: Some(0),
+            head_detached: Some(false),
+            untracked_count: Some(0),
+            local_ahead: Some(0),
+            behind_default_count: None,
+            dirty_total: None,
+            tenant_id: Some(t),
+        };
+        let body = serde_json::to_value(&p).unwrap();
+        assert_eq!(
+            body.get("tenant_id").and_then(|v| v.as_str()),
+            Some(t.to_string().as_str()),
+            "an explicit tenant_id must appear on the upsert wire"
         );
     }
 }

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -157,28 +157,51 @@ pub fn canonical_hostname() -> Option<String> {
     })
 }
 
-/// Resolve the device's `tenant_id` for coord-side requests
+/// The device's locally-held tenant bindings, as resolved for coord-side
+/// requests. Phase 8a (plan 2026-07-02, D3/D4): the register heartbeat
+/// sends the WHOLE set (`tenant_ids`) while the legacy single `tenant_id`
+/// field keeps carrying the DEFAULT binding for older coords.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocalBindingSet {
+    /// The default binding — what the legacy `access_token` slot holds a
+    /// JWT for, and what device-level single-tenant surfaces use.
+    pub(crate) default_tenant: uuid::Uuid,
+    /// Every locally-held binding (deduped; always contains
+    /// `default_tenant`).
+    pub(crate) tenant_ids: Vec<uuid::Uuid>,
+}
+
+/// Resolve the device's binding set for coord-side requests
 /// (`POST /coord/devices/register`). Returns the first hit:
 ///
-/// 1. `paired_user.json::tenant_id` — present on newly-paired devices
-///    (written by `pair::persist_pairing` since 2026-05-22).
+/// 1. `paired_user.json` — the v2-migrated binding set (legacy files
+///    yield their one synthesized entry); the default is
+///    `default_tenant_id`/`tenant_id`.
 /// 2. JWT-claim fallback — decode `tenant_id` from the cached
 ///    device-token JWT via
-///    [`qontinui_runner_lib::pair::tenant_id_from_oauth_claim`].
-///    On success, opportunistically rewrites `paired_user.json` with
-///    the resolved value so subsequent heartbeats hit branch 1.
-///    Best-effort: rewrite IO errors are swallowed.
-/// 3. `None` — neither source has a usable tenant_id. Callers must
-///    skip the request (coord rejects with `400 tenant_id_required`).
-fn resolve_tenant_id() -> Option<uuid::Uuid> {
-    // Branch 1 — paired_user.json
+///    [`qontinui_runner_lib::pair::tenant_id_from_oauth_claim`]; the set
+///    is that single tenant. (The pre-8a opportunistic disk backfill is
+///    gone — the register response's `tenant_ids` reconciliation is the
+///    file's healer now, and per-tick resolution works without the
+///    write-back.)
+/// 3. `None` — no source has a usable tenant. Callers must skip the
+///    request (coord rejects with `400 tenant_id_required`).
+fn resolve_binding_set() -> Option<LocalBindingSet> {
+    // Branch 1 — paired_user.json (v2-migrated view)
     if let Some(s) = qontinui_runner_lib::pair::read_paired_tenant_id_from_disk() {
-        if let Ok(t) = uuid::Uuid::parse_str(s.trim()) {
-            return Some(t);
+        if let Ok(default_tenant) = uuid::Uuid::parse_str(s.trim()) {
+            let mut tenant_ids = qontinui_runner_lib::pair::read_paired_binding_tenant_ids();
+            if !tenant_ids.contains(&default_tenant) {
+                tenant_ids.insert(0, default_tenant);
+            }
+            return Some(LocalBindingSet {
+                default_tenant,
+                tenant_ids,
+            });
         }
     }
 
-    // Branch 2 — cached device-token JWT
+    // Branch 2 — cached device-token JWT (the legacy/default slot)
     let token = crate::auth::AuthManager::new()
         .get_access_token()
         .ok()
@@ -188,13 +211,18 @@ fn resolve_tenant_id() -> Option<uuid::Uuid> {
     }
     let claim = qontinui_runner_lib::pair::tenant_id_from_oauth_claim(&token)?;
     let parsed = uuid::Uuid::parse_str(claim.trim()).ok()?;
+    Some(LocalBindingSet {
+        default_tenant: parsed,
+        tenant_ids: vec![parsed],
+    })
+}
 
-    // Opportunistic backfill — best-effort, ignore IO errors.
-    if let Err(e) = qontinui_runner_lib::pair::backfill_paired_tenant_id(&parsed) {
-        tracing::debug!("fleet::resolve_tenant_id: backfill non-fatal: {e}");
-    }
-
-    Some(parsed)
+/// Single-tenant convenience over [`resolve_binding_set`]: the DEFAULT
+/// binding, for callers that stamp one tenant on a device-scoped write
+/// (e.g. the git-ops fleet feed). Session-scoped callers get their
+/// tenant from the owning session instead (Phase 8b).
+fn resolve_tenant_id() -> Option<uuid::Uuid> {
+    resolve_binding_set().map(|b| b.default_tenant)
 }
 
 /// Parse the authoritative `tenant_id` out of a successful
@@ -210,6 +238,46 @@ fn response_tenant_id(body: &str) -> Option<uuid::Uuid> {
         .and_then(|j| j.get("tenant_id"))
         .and_then(|v| v.as_str())
         .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok())
+}
+
+/// Parse the authoritative binding set (`tenant_ids: ["<uuid>", …]`) out
+/// of a register response, if coord sent one (Phase 3 coord — D3).
+///
+/// FAIL-SOFT is the contract: `None` (→ the caller must NOT reconcile)
+/// when the body isn't JSON, the field is ABSENT (today's production
+/// coord), it isn't an array, or ANY element fails to parse as a UUID
+/// string — a partially-parseable set must never drive binding drops.
+/// `Some(vec![])` (present-but-empty) IS meaningful: coord says the
+/// device has zero bindings. Pure (no IO) for unit-testability.
+fn response_tenant_ids(body: &str) -> Option<Vec<uuid::Uuid>> {
+    let json: serde_json::Value = serde_json::from_str(body).ok()?;
+    let arr = json.get("tenant_ids")?.as_array()?;
+    let mut out = Vec::with_capacity(arr.len());
+    for v in arr {
+        let s = v.as_str()?;
+        out.push(uuid::Uuid::parse_str(s.trim()).ok()?);
+    }
+    Some(out)
+}
+
+/// Dedupe the "coord reports a binding this runner holds no JWT for"
+/// warning per tenant per process — the heartbeat ticks every 30s and
+/// the heal (pair for that tenant) is operator-paced.
+static COORD_ONLY_BINDINGS_WARNED: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::BTreeSet<uuid::Uuid>>,
+> = std::sync::OnceLock::new();
+
+fn warn_coord_only_binding_once(tenant: uuid::Uuid) {
+    let set = COORD_ONLY_BINDINGS_WARNED
+        .get_or_init(|| std::sync::Mutex::new(std::collections::BTreeSet::new()));
+    let fresh = set.lock().map(|mut g| g.insert(tenant)).unwrap_or(false);
+    if fresh {
+        warn!(
+            "fleet::heartbeat: coord reports this device bound to tenant {tenant} but the \
+             runner holds no device-JWT for it — pair for that tenant to enable its \
+             sessions. Logging once per tenant per process."
+        );
+    }
 }
 
 /// Dedupe the "tenant_id unresolvable" startup warning — the heartbeat
@@ -616,11 +684,17 @@ struct HeartbeatPayload {
     claude_code_available: bool,
     /// REQUIRED by coord's `post_device_register` handler — absence
     /// produces `400 tenant_id_required` (see qontinui-coord
-    /// `routes_phase3.rs:257-269`). Resolved via [`resolve_tenant_id`]
-    /// before the payload is constructed; if `None` there, the
-    /// heartbeat is skipped rather than 400-spamming coord.
-    /// Phase 2 of the default-tenant-propagation plan.
+    /// `routes_phase3.rs:257-269`). Resolved via [`resolve_binding_set`]
+    /// (the DEFAULT binding) before the payload is constructed; if
+    /// `None` there, the heartbeat is skipped rather than 400-spamming
+    /// coord. Phase 2 of the default-tenant-propagation plan.
     tenant_id: uuid::Uuid,
+    /// Phase 8a (plan 2026-07-02, D3): the runner's WHOLE locally-held
+    /// binding set (always includes `tenant_id`). Phase-3 coord touches
+    /// `tenant_devices.last_active_at` for the intersection with real
+    /// bindings (never inserts); today's production coord simply ignores
+    /// the field (`DeviceRegisterRequest` has no `deny_unknown_fields`).
+    tenant_ids: Vec<uuid::Uuid>,
     /// Capture-backend telemetry (plan 2026-06-07-fleet-capture-backend-
     /// telemetry.md D1) — cumulative WebView2 CapturePreview frames served
     /// since this process started. Straight-write coord-side into
@@ -693,8 +767,8 @@ pub async fn heartbeat_to_coord() -> Result<(), String> {
         }
     };
 
-    let tenant_id = match resolve_tenant_id() {
-        Some(t) => t,
+    let bindings = match resolve_binding_set() {
+        Some(b) => b,
         None => {
             warn_tenant_id_unresolvable_once();
             return Ok(());
@@ -710,7 +784,8 @@ pub async fn heartbeat_to_coord() -> Result<(), String> {
         device_id,
         hostname: device.hostname.clone(),
         claude_code_available,
-        tenant_id,
+        tenant_id: bindings.default_tenant,
+        tenant_ids: bindings.tenant_ids,
         capture_preview_count,
         monitor_crop_count,
         last_capture_fallback_at,
@@ -737,17 +812,39 @@ pub async fn heartbeat_to_coord() -> Result<(), String> {
             "fleet::heartbeat: ok device_id={device_id} hostname={} status={}",
             device.hostname, status
         );
-        // Soft-heal write-back. Coord's response carries the authoritative
-        // (possibly soft-healed) `tenant_id` for this device — if our cached
-        // value was a stale orphan, coord rescued the call using its stored
-        // tenant and returned THAT here. Persist it to paired_user.json so
-        // the next tick's `resolve_tenant_id` branch 1 sends the corrected
-        // value and the loop converges (coord stops soft-healing). The
-        // helper is idempotent (`pair::backfill_paired_tenant_id` no-ops
-        // when unchanged), so steady state is one write then silence.
-        // Best-effort: a parse/IO miss just retries the heal next tick.
+        // Binding reconciliation (Phase 8a, D3). When coord's response
+        // carries the authoritative `tenant_ids` set (Phase 3 coord), the
+        // runner reconciles its local binding state against it: drop
+        // entries (+ their JWT slots) coord no longer has, warn-once for
+        // bindings coord has that this runner holds no JWT for. When the
+        // field is ABSENT — today's production coord — this is a strict
+        // no-op on binding state, and only the LEGACY single-value
+        // echo-heal runs (itself a no-op on v2 multi-entry files: see
+        // `pair::backfill_paired_tenant_id`), preserving the pre-8a
+        // stale-single-tenant convergence for legacy-shape installs.
+        // Best-effort throughout: a parse/IO miss just retries next tick.
         let body = resp.text().await.unwrap_or_default();
-        if let Some(resp_tenant) = response_tenant_id(&body) {
+        if let Some(coord_set) = response_tenant_ids(&body) {
+            match qontinui_runner_lib::pair::reconcile_paired_bindings(&coord_set) {
+                Ok(report) => {
+                    if report.changed() {
+                        info!(
+                            "fleet::heartbeat: reconciled bindings against coord \
+                             (dropped={:?} dropped_slots={:?} default_repointed={:?})",
+                            report.dropped, report.dropped_slots, report.default_repointed
+                        );
+                    }
+                    for t in report.coord_only {
+                        warn_coord_only_binding_once(t);
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("fleet::heartbeat: binding reconcile non-fatal: {e}");
+                }
+            }
+        } else if let Some(resp_tenant) = response_tenant_id(&body) {
+            // Legacy echo-heal (single-value; v2-file-aware no-op).
+            // Scheduled for deletion in Phase 10 item 4.
             if let Err(e) = qontinui_runner_lib::pair::backfill_paired_tenant_id(&resp_tenant) {
                 tracing::debug!("fleet::heartbeat: tenant_id write-back non-fatal: {e}");
             }
@@ -2869,6 +2966,7 @@ mod tests {
             hostname: "test".into(),
             claude_code_available: false,
             tenant_id: uuid::Uuid::nil(),
+            tenant_ids: vec![uuid::Uuid::nil()],
             capture_preview_count: 0,
             monitor_crop_count: 0,
             last_capture_fallback_at: None,
@@ -2887,6 +2985,7 @@ mod tests {
             hostname: "test".into(),
             claude_code_available: true,
             tenant_id: uuid::Uuid::nil(),
+            tenant_ids: vec![uuid::Uuid::nil()],
             capture_preview_count: 0,
             monitor_crop_count: 0,
             last_capture_fallback_at: None,
@@ -2911,6 +3010,7 @@ mod tests {
             hostname: "test".into(),
             claude_code_available: true,
             tenant_id: tenant,
+            tenant_ids: vec![tenant],
             capture_preview_count: 0,
             monitor_crop_count: 0,
             last_capture_fallback_at: None,
@@ -2933,6 +3033,7 @@ mod tests {
             hostname: "test".into(),
             claude_code_available: true,
             tenant_id: uuid::Uuid::nil(),
+            tenant_ids: vec![uuid::Uuid::nil()],
             capture_preview_count: 0,
             monitor_crop_count: 0,
             last_capture_fallback_at: None,
@@ -2961,6 +3062,7 @@ mod tests {
             hostname: "test".into(),
             claude_code_available: false,
             tenant_id: uuid::Uuid::nil(),
+            tenant_ids: vec![uuid::Uuid::nil()],
             capture_preview_count: 7,
             monitor_crop_count: 3,
             last_capture_fallback_at: Some(at),
@@ -2990,6 +3092,7 @@ mod tests {
             hostname: "test".into(),
             claude_code_available: false,
             tenant_id: uuid::Uuid::nil(),
+            tenant_ids: vec![uuid::Uuid::nil()],
             capture_preview_count: 0,
             monitor_crop_count: 0,
             last_capture_fallback_at: None,
@@ -3043,6 +3146,91 @@ mod tests {
             None,
             "non-UUID tenant_id → None"
         );
+    }
+
+    /// Phase 8a reconciliation gate: `response_tenant_ids` must be
+    /// strictly fail-soft. `None` (→ NO reconciliation, the no-op path
+    /// against today's production coord) for: absent field, non-JSON
+    /// body, non-array field, or ANY malformed element. Present-but-empty
+    /// is `Some(vec![])` — a meaningful "zero bindings" statement.
+    #[test]
+    fn response_tenant_ids_is_fail_soft() {
+        let a = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+        let b = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+        // Phase-3 coord shape: full set parses.
+        let body = format!(r#"{{"tenant_id":"{a}","tenant_ids":["{a}","{b}"]}}"#);
+        assert_eq!(
+            response_tenant_ids(&body),
+            Some(vec![
+                uuid::Uuid::parse_str(a).unwrap(),
+                uuid::Uuid::parse_str(b).unwrap()
+            ])
+        );
+
+        // Today's production coord: field ABSENT → None → caller no-ops.
+        assert_eq!(
+            response_tenant_ids(&format!(r#"{{"tenant_id":"{a}"}}"#)),
+            None,
+            "absent tenant_ids (today's coord) must be None — reconciliation no-op"
+        );
+        assert_eq!(response_tenant_ids("not json"), None);
+        assert_eq!(
+            response_tenant_ids(r#"{"tenant_ids":"not-an-array"}"#),
+            None,
+            "non-array tenant_ids → None"
+        );
+        assert_eq!(
+            response_tenant_ids(&format!(r#"{{"tenant_ids":["{a}","junk"]}}"#)),
+            None,
+            "ANY malformed element poisons the set — a partial set must never drive drops"
+        );
+        assert_eq!(
+            response_tenant_ids(&format!(r#"{{"tenant_ids":["{a}",42]}}"#)),
+            None,
+            "non-string element → None"
+        );
+
+        // Present-but-empty IS meaningful (zero server-side bindings).
+        assert_eq!(
+            response_tenant_ids(r#"{"tenant_ids":[]}"#),
+            Some(vec![]),
+            "empty array → Some(empty): coord says zero bindings"
+        );
+    }
+
+    /// Phase 8a wire shape: the register heartbeat carries the whole
+    /// binding set as `tenant_ids` alongside the legacy single
+    /// `tenant_id` (today's coord ignores the new field — its
+    /// `DeviceRegisterRequest` has no `deny_unknown_fields`).
+    #[test]
+    fn heartbeat_payload_serializes_binding_set() {
+        let a = uuid::Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap();
+        let b = uuid::Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").unwrap();
+        let p = HeartbeatPayload {
+            device_id: uuid::Uuid::nil(),
+            hostname: "test".into(),
+            claude_code_available: false,
+            tenant_id: a,
+            tenant_ids: vec![a, b],
+            capture_preview_count: 0,
+            monitor_crop_count: 0,
+            last_capture_fallback_at: None,
+        };
+        let body = serde_json::to_value(&p).unwrap();
+        assert_eq!(
+            body.get("tenant_id").and_then(|v| v.as_str()),
+            Some(a.to_string().as_str()),
+            "legacy single tenant_id (the DEFAULT binding) must stay on the wire"
+        );
+        let ids: Vec<String> = body
+            .get("tenant_ids")
+            .and_then(|v| v.as_array())
+            .expect("tenant_ids array on the wire")
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect();
+        assert_eq!(ids, vec![a.to_string(), b.to_string()]);
     }
 
     // ---- behind_default_count (stale-primary-checkout guard, Phase 1c) ----

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2653,6 +2653,10 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 //   Phase 10 flag-poll only spawns when an `active_tenant_id`
                 //   resolved from machine.json (None → dormant); dual-write
                 //   stays off until `session_coordination_enabled` flips.
+                //   Multi-tenant (Phase 8b) disposition: the flag-poll is a
+                //   DEVICE-scoped surface — it polls the DEFAULT binding's
+                //   tenant policy and presents the default device-JWT slot
+                //   (unparameterized `coord_get`) by construction.
                 let loop_registry = registry.clone();
                 tauri::async_runtime::spawn(async move {
                     let _drain = loop_registry.coord_sync().start_drain_task();

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -110,6 +110,11 @@ pub(crate) fn should_relay_idle_with(
 /// slot from `AuthManager` (filesystem I/O on `~/.qontinui`) and delegates
 /// to the pure inner [`should_relay_idle_with`]. Tests must use the inner
 /// directly to avoid touching user data_local_dir.
+///
+/// Phase 8b tenant disposition: the relay is a DEVICE-scoped surface — it
+/// deliberately reads the legacy `access_token` slot (the DEFAULT
+/// binding's JWT) and stays on the unparameterized seam by construction;
+/// per-session tenants never route through the relay's WS identity.
 pub(crate) fn should_relay_idle(settings: &crate::settings::Settings) -> bool {
     let has_device_jwt = match crate::auth::AuthManager::new().get_access_token() {
         Ok(t) => !t.trim().is_empty(),

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -830,6 +830,170 @@ pub(crate) async fn try_device_self_refresh(
     }
 }
 
+// ===========================================================================
+// Session-scoped multi-tenant Phase 1 (plan 2026-07-02, D4) — flag-gated DARK
+// multi-slot refresh. With `QONTINUI_MULTI_TENANT_JWT` unset (the default)
+// none of this runs and the refresher behaves byte-identically to today.
+// ===========================================================================
+
+/// What to do with one per-tenant device-JWT slot this pass. Pure output of
+/// [`plan_tenant_slot`] so the staleness branching is unit-testable without
+/// storage or a tokio runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TenantSlotPlan {
+    /// Future-exp JWT within [`crate::auth::REFRESH_BEFORE_EXPIRY_SECS`] of
+    /// expiry — self-refresh it now (presenting THAT slot's token).
+    Refresh,
+    /// Future-exp JWT with plenty of TTL left — leave it alone this pass.
+    SkipFresh,
+    /// Absent/opaque exp or already expired — NOT self-refreshable (coord
+    /// would 401 the bearer). Skipped; the slot heals at the next pair for
+    /// that tenant. REPLACE-not-REVOKE: never cleared here.
+    SkipNotRefreshable,
+}
+
+/// Pure per-slot staleness decision. `exp` is the slot JWT's decoded
+/// (unverified) `exp` claim; `now` is unix seconds.
+pub(crate) fn plan_tenant_slot(exp: Option<i64>, now: i64) -> TenantSlotPlan {
+    match exp {
+        // Opaque/undecodable — cannot judge or present it for self-refresh.
+        None => TenantSlotPlan::SkipNotRefreshable,
+        // Already expired — coord would 401 the presented bearer.
+        Some(e) if now >= e => TenantSlotPlan::SkipNotRefreshable,
+        // Within TTL/3 of expiry — refresh now.
+        Some(e) if now + crate::auth::REFRESH_BEFORE_EXPIRY_SECS >= e => TenantSlotPlan::Refresh,
+        // Comfortably fresh.
+        Some(_) => TenantSlotPlan::SkipFresh,
+    }
+}
+
+/// Outcome of one per-tenant slot in a [`refresh_tenant_slots`] pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TenantSlotOutcome {
+    /// Coord 2xx'd and the new JWT was persisted into that tenant's slot.
+    Refreshed,
+    /// Slot JWT still comfortably fresh — nothing to do.
+    SkippedFresh,
+    /// Slot empty/opaque/expired — not self-refreshable this pass.
+    SkippedNotRefreshable,
+    /// Refresh was attempted but failed (coord non-2xx, network error,
+    /// decode failure, empty token, or persist error). The existing slot
+    /// value is left UNTOUCHED (REPLACE-not-REVOKE), and the pass CONTINUES
+    /// with the remaining slots.
+    KeptExisting,
+}
+
+/// Flag-gated multi-tenant slot pass: walk every per-tenant device-JWT slot
+/// and self-refresh each stale one via coord's
+/// `POST /devices/{device_id}/refresh-token`, presenting THAT slot's token as
+/// the bearer (coord re-mints from the presented claim's tenant — verified
+/// plan premise, `tokens.rs:341-348`). Each slot succeeds or fails
+/// independently: a failure on one slot never aborts the others, and the
+/// legacy `access_token` slot is never read or written here.
+///
+/// Returns the per-tenant outcomes (deterministic slot order) for logging and
+/// hermetic tests.
+pub(crate) async fn refresh_tenant_slots(
+    auth_manager: &crate::auth::AuthManager,
+    coord_base: &str,
+    device_id: &str,
+) -> Vec<(uuid::Uuid, TenantSlotOutcome)> {
+    let tenants = auth_manager.list_tenant_device_jwt_tenants();
+    let mut outcomes = Vec::with_capacity(tenants.len());
+    if tenants.is_empty() {
+        return outcomes;
+    }
+    let url = format!(
+        "{}/devices/{}/refresh-token",
+        coord_base.trim_end_matches('/'),
+        device_id
+    );
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => Some(c),
+        Err(e) => {
+            warn!("device_jwt_refresher: tenant-slot refresh client build failed: {e}");
+            None
+        }
+    };
+    let now = chrono::Utc::now().timestamp();
+    for tenant in tenants {
+        let token = match auth_manager.get_tenant_device_jwt(&tenant) {
+            Ok(Some(t)) if !t.trim().is_empty() => t.trim().to_string(),
+            _ => {
+                outcomes.push((tenant, TenantSlotOutcome::SkippedNotRefreshable));
+                continue;
+            }
+        };
+        match plan_tenant_slot(crate::auth::decode_jwt_exp(&token), now) {
+            TenantSlotPlan::SkipFresh => {
+                outcomes.push((tenant, TenantSlotOutcome::SkippedFresh));
+                continue;
+            }
+            TenantSlotPlan::SkipNotRefreshable => {
+                warn!(
+                    "device_jwt_refresher: tenant {tenant} slot JWT is expired/opaque — \
+                     cannot self-refresh; re-pair for that tenant to heal the slot"
+                );
+                outcomes.push((tenant, TenantSlotOutcome::SkippedNotRefreshable));
+                continue;
+            }
+            TenantSlotPlan::Refresh => {}
+        }
+        let Some(client) = client.as_ref() else {
+            outcomes.push((tenant, TenantSlotOutcome::KeptExisting));
+            continue;
+        };
+        // Present THIS slot's token — coord re-mints for the claim's tenant.
+        let resp = match client.post(&url).bearer_auth(&token).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("device_jwt_refresher: tenant {tenant} slot refresh request failed: {e}");
+                outcomes.push((tenant, TenantSlotOutcome::KeptExisting));
+                continue;
+            }
+        };
+        if !resp.status().is_success() {
+            warn!(
+                "device_jwt_refresher: tenant {tenant} slot refresh got HTTP {} \
+                 (existing slot JWT preserved)",
+                resp.status()
+            );
+            outcomes.push((tenant, TenantSlotOutcome::KeptExisting));
+            continue;
+        }
+        let body: DeviceRefreshResponse = match resp.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("device_jwt_refresher: tenant {tenant} slot refresh body decode failed: {e}");
+                outcomes.push((tenant, TenantSlotOutcome::KeptExisting));
+                continue;
+            }
+        };
+        if body.token.trim().is_empty() {
+            warn!("device_jwt_refresher: tenant {tenant} slot refresh returned an empty token");
+            outcomes.push((tenant, TenantSlotOutcome::KeptExisting));
+            continue;
+        }
+        match auth_manager.store_tenant_device_jwt(&tenant, &body.token) {
+            Ok(()) => {
+                info!(
+                    "device_jwt_refresher: tenant {tenant} device-JWT slot refreshed (len={})",
+                    body.token.len()
+                );
+                outcomes.push((tenant, TenantSlotOutcome::Refreshed));
+            }
+            Err(e) => {
+                warn!("device_jwt_refresher: tenant {tenant} slot persist failed: {e}");
+                outcomes.push((tenant, TenantSlotOutcome::KeptExisting));
+            }
+        }
+    }
+    outcomes
+}
+
 /// Ensure the Cognito (oauth) access token is fresh before it's used as the
 /// pair-cli bearer. If a Cognito refresh token is stored and the access token
 /// is within the refresh threshold (or already expired), POST the
@@ -976,6 +1140,45 @@ async fn refresher_loop(
         };
 
         let decision = next_action(settings_snapshot.tier, needs_refresh);
+
+        // Session-scoped multi-tenant Phase 1 (flag-gated DARK, default OFF):
+        // when `QONTINUI_MULTI_TENANT_JWT=1`, refresh every per-tenant
+        // device-JWT slot independently of the legacy `access_token` slot's
+        // own staleness/decision below. With the flag unset this whole block
+        // is a single false env check — behavior byte-identical to today.
+        // Placed before the decision match so the Idle arm (legacy JWT fresh)
+        // still ticks the tenant slots each cadence/kick. Note the
+        // IdleWrongTier arm blocks on kick — acceptable for the dark spike
+        // (the flag is only meaningful on Tier-2 runners).
+        if crate::auth::multi_tenant_jwt_enabled() {
+            let mt_device_id = std::env::var("QONTINUI_MACHINE_ID")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| s.trim().to_string())
+                .or_else(|| qontinui_runner_lib::pair::read_device_id_from_disk().ok());
+            match mt_device_id {
+                Some(did) => {
+                    let coord_base = crate::coord_mcp::coord_base_url();
+                    let outcomes = refresh_tenant_slots(&auth_manager, &coord_base, &did).await;
+                    if !outcomes.is_empty() {
+                        let refreshed = outcomes
+                            .iter()
+                            .filter(|(_, o)| *o == TenantSlotOutcome::Refreshed)
+                            .count();
+                        info!(
+                            "device_jwt_refresher: multi-tenant slot pass — {refreshed}/{} \
+                             refreshed ({outcomes:?})",
+                            outcomes.len()
+                        );
+                    }
+                }
+                None => warn!(
+                    "device_jwt_refresher: QONTINUI_MULTI_TENANT_JWT=1 but no device_id \
+                     (QONTINUI_MACHINE_ID unset, machine.json unreadable) — skipping \
+                     tenant-slot pass"
+                ),
+            }
+        }
 
         match decision {
             Decision::IdleWrongTier => {
@@ -2340,5 +2543,297 @@ mod device_self_refresh_tests {
             existing,
             "existing JWT must be UNCHANGED after a 401"
         );
+    }
+}
+
+#[cfg(test)]
+mod tenant_slot_refresh_tests {
+    //! Session-scoped multi-tenant Phase 1 — hermetic tests for the
+    //! flag-gated per-tenant slot pass (`refresh_tenant_slots`) against an
+    //! in-process mock coord, plus the pure `plan_tenant_slot` staleness
+    //! decision and the `QONTINUI_MULTI_TENANT_JWT` gate. Injected tokens
+    //! only (the established refresher test pattern) — no live coord, no
+    //! `~/.qontinui`, no env-var mutation.
+
+    use super::*;
+    use axum::{
+        extract::{Path, State},
+        http::{HeaderMap, StatusCode},
+        routing::post,
+        Router,
+    };
+    use std::sync::{Arc, Mutex};
+
+    fn b64url(b: &[u8]) -> String {
+        use base64::Engine;
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b)
+    }
+
+    /// Synthetic device-JWT with an `exp` claim and a distinguishing `sub`
+    /// so each tenant's token is unique on the wire.
+    fn synth_jwt(exp: i64, sub: &str) -> String {
+        let header = b64url(b"{\"alg\":\"EdDSA\",\"typ\":\"JWT\"}");
+        let payload = b64url(format!("{{\"exp\":{exp},\"sub\":\"{sub}\"}}").as_bytes());
+        let sig = b64url(b"fake-sig");
+        format!("{header}.{payload}.{sig}")
+    }
+
+    fn test_auth_manager(name: &str) -> crate::auth::AuthManager {
+        let dir = std::env::temp_dir().join("qontinui_test_tenant_slots");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join(format!("{name}.enc"));
+        let _ = std::fs::remove_file(&path);
+        let storage = crate::secure_storage::SecureStorage::with_path(path).expect("storage");
+        crate::auth::AuthManager::with_storage(storage)
+    }
+
+    /// Mock coord: echoes each presented bearer back as `<bearer>.refreshed`
+    /// (so per-slot assertions can prove EACH slot was refreshed with ITS OWN
+    /// token), and 500s any bearer in `fail_bearers` (so failure-isolation is
+    /// testable). Captures every presented bearer in order.
+    #[derive(Clone)]
+    struct MockState {
+        fail_bearers: Arc<Mutex<Vec<String>>>,
+        bearers_seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    async fn handler(
+        State(s): State<MockState>,
+        Path(_device_id): Path<String>,
+        h: HeaderMap,
+    ) -> (StatusCode, String) {
+        let bearer = h
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .unwrap_or("")
+            .to_string();
+        s.bearers_seen.lock().unwrap().push(bearer.clone());
+        if s.fail_bearers.lock().unwrap().contains(&bearer) {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                r#"{"error":"boom"}"#.to_string(),
+            );
+        }
+        (
+            StatusCode::OK,
+            serde_json::json!({ "token": format!("{bearer}.refreshed") }).to_string(),
+        )
+    }
+
+    struct MockCapture {
+        bearers_seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    fn spawn_mock(
+        fail_bearers: Vec<String>,
+    ) -> (String, MockCapture, tokio::sync::oneshot::Sender<()>) {
+        let bearers_seen = Arc::new(Mutex::new(Vec::new()));
+        let bearers_h = bearers_seen.clone();
+        let std_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = std_listener.local_addr().expect("addr").port();
+        std_listener.set_nonblocking(true).expect("nb");
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt");
+            rt.block_on(async move {
+                let state = MockState {
+                    fail_bearers: Arc::new(Mutex::new(fail_bearers)),
+                    bearers_seen: bearers_h,
+                };
+                // axum 0.8 path-param syntax: `{device_id}`.
+                let app: Router = Router::new()
+                    .route("/devices/{device_id}/refresh-token", post(handler))
+                    .with_state(state);
+                let listener =
+                    tokio::net::TcpListener::from_std(std_listener).expect("tokio listener");
+                let _ = axum::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        let _ = rx.await;
+                    })
+                    .await;
+            });
+        });
+        std::thread::sleep(Duration::from_millis(50));
+        (
+            format!("http://127.0.0.1:{port}"),
+            MockCapture { bearers_seen },
+            tx,
+        )
+    }
+
+    const DID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+    fn tenant(n: u8) -> uuid::Uuid {
+        uuid::Uuid::parse_str(&format!(
+            "{c}{c}{c}{c}{c}{c}{c}{c}-{c}{c}{c}{c}-4{c}{c}{c}-8{c}{c}{c}-{c}{c}{c}{c}{c}{c}{c}{c}{c}{c}{c}{c}",
+            c = (b'a' + n) as char
+        ))
+        .expect("valid uuid")
+    }
+
+    // ---- plan_tenant_slot: pure staleness decision ----
+
+    #[test]
+    fn plan_refreshes_stale_but_valid_and_skips_fresh_or_dead() {
+        let now = 1_000_000_000i64;
+        // Opaque/undecodable → not self-refreshable.
+        assert_eq!(
+            plan_tenant_slot(None, now),
+            TenantSlotPlan::SkipNotRefreshable
+        );
+        // Already expired (or exactly at exp) → not self-refreshable.
+        assert_eq!(
+            plan_tenant_slot(Some(now - 1), now),
+            TenantSlotPlan::SkipNotRefreshable
+        );
+        assert_eq!(
+            plan_tenant_slot(Some(now), now),
+            TenantSlotPlan::SkipNotRefreshable
+        );
+        // Future exp within TTL/3 → refresh.
+        assert_eq!(
+            plan_tenant_slot(Some(now + 30 * 60), now),
+            TenantSlotPlan::Refresh
+        );
+        assert_eq!(
+            plan_tenant_slot(Some(now + crate::auth::REFRESH_BEFORE_EXPIRY_SECS), now),
+            TenantSlotPlan::Refresh
+        );
+        // Comfortably fresh → skip.
+        assert_eq!(
+            plan_tenant_slot(Some(now + 3 * 60 * 60), now),
+            TenantSlotPlan::SkipFresh
+        );
+    }
+
+    // ---- refresh_tenant_slots: hermetic multi-slot iteration ----
+
+    #[tokio::test]
+    async fn multi_slot_pass_refreshes_each_slot_with_its_own_token() {
+        // Two tenant slots, both stale-but-valid, plus a legacy access_token.
+        // Each slot must be refreshed by presenting ITS OWN token, persisted
+        // into ITS OWN slot — and the legacy slot must be byte-identical after.
+        let mgr = test_auth_manager("multi_slot_own_tokens");
+        let (ta, tb) = (tenant(0), tenant(1));
+        let now = chrono::Utc::now().timestamp();
+        let jwt_a = synth_jwt(now + 30 * 60, "tenant-a");
+        let jwt_b = synth_jwt(now + 30 * 60, "tenant-b");
+        mgr.store_tokens("legacy.default.jwt", "")
+            .expect("store legacy");
+        mgr.store_tenant_device_jwt(&ta, &jwt_a).expect("slot a");
+        mgr.store_tenant_device_jwt(&tb, &jwt_b).expect("slot b");
+
+        let (base, cap, _shutdown) = spawn_mock(vec![]);
+        let outcomes = refresh_tenant_slots(&mgr, &base, DID).await;
+
+        assert_eq!(
+            outcomes,
+            vec![
+                (ta, TenantSlotOutcome::Refreshed),
+                (tb, TenantSlotOutcome::Refreshed)
+            ],
+            "both slots must refresh"
+        );
+        // Each slot presented ITS OWN token as the bearer.
+        let seen = cap.bearers_seen.lock().unwrap().clone();
+        assert_eq!(seen, vec![jwt_a.clone(), jwt_b.clone()]);
+        // Each slot now holds ITS OWN re-minted token (echo-mint = bearer +
+        // ".refreshed"), proving no cross-slot mixing.
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&ta).unwrap().as_deref(),
+            Some(format!("{jwt_a}.refreshed").as_str())
+        );
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&tb).unwrap().as_deref(),
+            Some(format!("{jwt_b}.refreshed").as_str())
+        );
+        // LEGACY-SLOT PRESERVATION: the pass never touches access_token.
+        assert_eq!(mgr.get_access_token().unwrap(), "legacy.default.jwt");
+    }
+
+    #[tokio::test]
+    async fn failure_on_one_slot_does_not_abort_the_others() {
+        // Coord 500s tenant A's bearer; tenant B must still refresh. A keeps
+        // its existing token (REPLACE-not-REVOKE).
+        let mgr = test_auth_manager("multi_slot_failure_isolation");
+        let (ta, tb) = (tenant(0), tenant(1));
+        let now = chrono::Utc::now().timestamp();
+        let jwt_a = synth_jwt(now + 30 * 60, "tenant-a");
+        let jwt_b = synth_jwt(now + 30 * 60, "tenant-b");
+        mgr.store_tenant_device_jwt(&ta, &jwt_a).expect("slot a");
+        mgr.store_tenant_device_jwt(&tb, &jwt_b).expect("slot b");
+
+        let (base, cap, _shutdown) = spawn_mock(vec![jwt_a.clone()]);
+        let outcomes = refresh_tenant_slots(&mgr, &base, DID).await;
+
+        assert_eq!(
+            outcomes,
+            vec![
+                (ta, TenantSlotOutcome::KeptExisting),
+                (tb, TenantSlotOutcome::Refreshed)
+            ],
+            "A fails, B still refreshes — no abort"
+        );
+        // Both were attempted (B was not skipped because of A's failure).
+        assert_eq!(cap.bearers_seen.lock().unwrap().len(), 2);
+        // A's slot is UNCHANGED; B's slot advanced.
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&ta).unwrap().as_deref(),
+            Some(jwt_a.as_str())
+        );
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&tb).unwrap().as_deref(),
+            Some(format!("{jwt_b}.refreshed").as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_and_dead_slots_are_skipped_without_http() {
+        // A comfortably-fresh slot and an already-expired slot: neither hits
+        // coord, neither slot value changes.
+        let mgr = test_auth_manager("multi_slot_skip_fresh_dead");
+        let (ta, tb) = (tenant(0), tenant(1));
+        let now = chrono::Utc::now().timestamp();
+        let fresh = synth_jwt(now + 3 * 60 * 60, "fresh");
+        let expired = synth_jwt(now - 60, "expired");
+        mgr.store_tenant_device_jwt(&ta, &fresh).expect("slot a");
+        mgr.store_tenant_device_jwt(&tb, &expired).expect("slot b");
+
+        let (base, cap, _shutdown) = spawn_mock(vec![]);
+        let outcomes = refresh_tenant_slots(&mgr, &base, DID).await;
+
+        assert_eq!(
+            outcomes,
+            vec![
+                (ta, TenantSlotOutcome::SkippedFresh),
+                (tb, TenantSlotOutcome::SkippedNotRefreshable)
+            ]
+        );
+        assert!(
+            cap.bearers_seen.lock().unwrap().is_empty(),
+            "no HTTP call for fresh/expired slots"
+        );
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&ta).unwrap().as_deref(),
+            Some(fresh.as_str())
+        );
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&tb).unwrap().as_deref(),
+            Some(expired.as_str()),
+            "REPLACE-not-REVOKE: an expired slot is preserved, never cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_slot_set_is_a_no_op() {
+        let mgr = test_auth_manager("multi_slot_empty_noop");
+        let (base, cap, _shutdown) = spawn_mock(vec![]);
+        let outcomes = refresh_tenant_slots(&mgr, &base, DID).await;
+        assert!(outcomes.is_empty());
+        assert!(cap.bearers_seen.lock().unwrap().is_empty());
     }
 }

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -410,10 +410,14 @@ async fn publish_coord_credential_status(
         return;
     };
 
-    // tenant_id: machine.json::active_tenant_id, then the outgoing device-JWT
-    // claim (still parseable when expired). NULL is acceptable on the wire
-    // (coord's StatusUpsert.tenant_id is Option), but we send it when known so
-    // the row is tenant-scoped.
+    // tenant_id: machine.json::active_tenant_id (Phase 8b semantics: the
+    // DEVICE-LEVEL DEFAULT binding — this publish is a device-scoped surface,
+    // so the default is the correct attribution; session-scoped writes get
+    // their tenant from the owning session instead), then the outgoing
+    // device-JWT claim (still parseable when expired). NULL is acceptable on
+    // the wire (coord's StatusUpsert.tenant_id is Option), but we send it
+    // when known so the row is tenant-scoped — the explicit-tenant_id
+    // publisher posture D2 site 16b/Phase 8 item 7 asks for.
     let tenant_id = crate::session::dual_write::resolve_active_tenant_id().or_else(|| {
         auth_manager
             .get_access_token()

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -831,10 +831,22 @@ pub(crate) async fn try_device_self_refresh(
 }
 
 // ===========================================================================
-// Session-scoped multi-tenant Phase 1 (plan 2026-07-02, D4) — flag-gated DARK
-// multi-slot refresh. With `QONTINUI_MULTI_TENANT_JWT` unset (the default)
-// none of this runs and the refresher behaves byte-identically to today.
+// Session-scoped multi-tenant per-tenant slot refresh (plan 2026-07-02, D4).
+// Shipped behavior as of Phase 8a (the Phase-1 `QONTINUI_MULTI_TENANT_JWT`
+// flag gate is retired): every `device_jwt:<tenant_id>` slot self-refreshes
+// with its own claim each refresher iteration, independent of the legacy
+// `access_token` slot (which the pre-existing paths above keep owning).
 // ===========================================================================
+
+/// How the `IdleWrongTier` arm should wait (Phase 8a). With per-tenant
+/// slots held, the arm must wake on the steady cadence so the slot pass —
+/// which runs once per loop iteration — can't be starved by an unbounded
+/// block-until-kick (a wrong-tier runner may never receive a kick). With
+/// no slots, `None` preserves the historical block-until-kick. Pure, so
+/// the starvation fix is pinned by a unit test.
+pub(crate) fn idle_wrong_tier_wait(has_tenant_slots: bool) -> Option<Duration> {
+    has_tenant_slots.then_some(REFRESH_CHECK_INTERVAL)
+}
 
 /// What to do with one per-tenant device-JWT slot this pass. Pure output of
 /// [`plan_tenant_slot`] so the staleness branching is unit-testable without
@@ -1141,16 +1153,18 @@ async fn refresher_loop(
 
         let decision = next_action(settings_snapshot.tier, needs_refresh);
 
-        // Session-scoped multi-tenant Phase 1 (flag-gated DARK, default OFF):
-        // when `QONTINUI_MULTI_TENANT_JWT=1`, refresh every per-tenant
-        // device-JWT slot independently of the legacy `access_token` slot's
-        // own staleness/decision below. With the flag unset this whole block
-        // is a single false env check — behavior byte-identical to today.
-        // Placed before the decision match so the Idle arm (legacy JWT fresh)
-        // still ticks the tenant slots each cadence/kick. Note the
-        // IdleWrongTier arm blocks on kick — acceptable for the dark spike
-        // (the flag is only meaningful on Tier-2 runners).
-        if crate::auth::multi_tenant_jwt_enabled() {
+        // Session-scoped multi-tenant Phase 8a (plan 2026-07-02, D4): the
+        // per-tenant device-JWT slot pass is the SHIPPED behavior (the
+        // Phase-1 `QONTINUI_MULTI_TENANT_JWT` flag is retired). Every slot
+        // self-refreshes with ITS OWN claim, independently of the legacy
+        // `access_token` slot's own staleness/decision below; the
+        // machine.json tenant-precedence chain (`resolve_pair_tenant_id`)
+        // only ever feeds the DEFAULT slot's Cognito pair path. Placed
+        // before the decision match so the Idle arm (legacy JWT fresh)
+        // still ticks the tenant slots each cadence/kick. Runners with no
+        // tenant slots (never paired post-8a) skip in one storage read.
+        let has_tenant_slots = !auth_manager.list_tenant_device_jwt_tenants().is_empty();
+        if has_tenant_slots {
             let mt_device_id = std::env::var("QONTINUI_MACHINE_ID")
                 .ok()
                 .filter(|s| !s.trim().is_empty())
@@ -1173,7 +1187,7 @@ async fn refresher_loop(
                     }
                 }
                 None => warn!(
-                    "device_jwt_refresher: QONTINUI_MULTI_TENANT_JWT=1 but no device_id \
+                    "device_jwt_refresher: tenant device-JWT slots present but no device_id \
                      (QONTINUI_MACHINE_ID unset, machine.json unreadable) — skipping \
                      tenant-slot pass"
                 ),
@@ -1190,6 +1204,19 @@ async fn refresher_loop(
                     &coord_credential_health(decision, None),
                 )
                 .await;
+                // Phase 8a: with tenant slots held, a wrong-tier idle must
+                // NOT park indefinitely — the slot pass above only runs per
+                // loop iteration, so an unbounded block would starve slot
+                // refreshes until a kick that may never come. Bounded wait
+                // instead (kick/shutdown still wake early). Slot-less
+                // runners keep the historical block-until-kick behavior.
+                if let Some(wait) = idle_wrong_tier_wait(has_tenant_slots) {
+                    if wait_with_signals(wait, &mut shutdown_rx, &mut kick_rx).await {
+                        info!("Device-JWT refresher shutting down (was idle on non-Tier2)");
+                        return;
+                    }
+                    continue;
+                }
                 // Nothing to do until tier changes. Block on shutdown or
                 // kick (set_runner_tier kicks us on every transition).
                 tokio::select! {
@@ -2548,12 +2575,13 @@ mod device_self_refresh_tests {
 
 #[cfg(test)]
 mod tenant_slot_refresh_tests {
-    //! Session-scoped multi-tenant Phase 1 — hermetic tests for the
-    //! flag-gated per-tenant slot pass (`refresh_tenant_slots`) against an
-    //! in-process mock coord, plus the pure `plan_tenant_slot` staleness
-    //! decision and the `QONTINUI_MULTI_TENANT_JWT` gate. Injected tokens
-    //! only (the established refresher test pattern) — no live coord, no
-    //! `~/.qontinui`, no env-var mutation.
+    //! Session-scoped multi-tenant — hermetic tests for the per-tenant
+    //! slot pass (`refresh_tenant_slots`, shipped un-gated as of Phase
+    //! 8a) against an in-process mock coord, plus the pure
+    //! `plan_tenant_slot` staleness decision and the `IdleWrongTier`
+    //! bounded-wait rule. Injected tokens only (the established
+    //! refresher test pattern) — no live coord, no `~/.qontinui`, no
+    //! env-var mutation.
 
     use super::*;
     use axum::{
@@ -2835,5 +2863,15 @@ mod tenant_slot_refresh_tests {
         let outcomes = refresh_tenant_slots(&mgr, &base, DID).await;
         assert!(outcomes.is_empty());
         assert!(cap.bearers_seen.lock().unwrap().is_empty());
+    }
+
+    /// Phase 8a starvation fix: with tenant slots held, the wrong-tier
+    /// idle arm must wake on the steady cadence (so the per-slot pass at
+    /// the top of the loop keeps running); with no slots it keeps the
+    /// historical block-until-kick (`None`).
+    #[test]
+    fn idle_wrong_tier_waits_bounded_only_when_slots_exist() {
+        assert_eq!(idle_wrong_tier_wait(true), Some(REFRESH_CHECK_INTERVAL));
+        assert_eq!(idle_wrong_tier_wait(false), None);
     }
 }

--- a/src-tauri/src/observable_bridge/memory.rs
+++ b/src-tauri/src/observable_bridge/memory.rs
@@ -89,11 +89,20 @@ impl MemoryBridge {
         }
     }
 
-    /// Read the device-token JWT used as `Authorization: Bearer`.
-    /// Returns `None` if the runner is not paired — every call site
-    /// short-circuits in that case (best-effort posture).
-    fn device_token(&self) -> Option<String> {
-        crate::auth::AuthManager::new().get_access_token().ok()
+    /// Read the device-token JWT used as `Authorization: Bearer` — the
+    /// OWNING SESSION's tenant slot (Phase 8b per-session credential
+    /// selection, plan 2026-07-02-session-scoped-multi-tenant-device-binding
+    /// §D4): memories are hard tenant-scoped, so a session federating
+    /// tenant B's pool must present B's device JWT, not the machine
+    /// default's. `ctx.tenant_id` is the session's binding (resolved by
+    /// `federation::build_federation_ctx`: spawn input, else the device
+    /// default) — when it IS the default, `device_bearer_for` falls back to
+    /// the legacy slot, preserving today's behavior byte-for-byte. Returns
+    /// `None` if no credential exists for that tenant (slot-miss fail-soft:
+    /// never another tenant's token) — every call site short-circuits in
+    /// that case (best-effort posture).
+    fn device_token(&self, ctx: &SessionContext) -> Option<String> {
+        crate::auth::device_bearer_for(Some(&ctx.tenant_id))
     }
 
     /// Push one local change to coord. Inherent (NOT a trait method):
@@ -101,7 +110,7 @@ impl MemoryBridge {
     /// site through the trait object. Best-effort — failures are logged,
     /// never propagated.
     async fn push(&self, change: ObservableChange, session_ctx: &SessionContext) -> Result<()> {
-        let token = match self.device_token() {
+        let token = match self.device_token(session_ctx) {
             Some(t) if !t.is_empty() => t,
             _ => {
                 debug!("observable_bridge::memory::push: no device token; dropping change");
@@ -339,7 +348,7 @@ impl RunnerObservableBridge for MemoryBridge {
 
         let local_pre = snapshot_dir(&session_ctx.memory_dir)?;
 
-        let token = match self.device_token() {
+        let token = match self.device_token(session_ctx) {
             Some(t) if !t.is_empty() => t,
             _ => {
                 warn!(
@@ -552,7 +561,7 @@ impl RunnerObservableBridge for MemoryBridge {
         };
         let post_session = snapshot_dir(&session_ctx.memory_dir)?;
 
-        let token = match self.device_token() {
+        let token = match self.device_token(session_ctx) {
             Some(t) if !t.is_empty() => t,
             _ => {
                 warn!(

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -17,9 +17,11 @@
 //!   up a localhost callback server, and captures the device-token JWT
 //!   from the browser redirect (coord's `pair-complete` is called by the
 //!   web frontend, not the runner).
-//! - [`persist_pairing`] — writes the device-token JWT into
-//!   `AuthManager`'s access-token slot + the paired user_id to
-//!   `paired_user.json`.
+//! - [`persist_pairing`] — writes the device-token JWT into the paired
+//!   tenant's `device_jwt:<tenant_id>` slot (+ the legacy access-token
+//!   slot when that tenant is the device default) and appends/updates
+//!   the binding entry in `paired_user.json` (v2 multi-entry shape,
+//!   Phase 8a).
 //! - [`coord_http_base`] / [`coord_http_base_from_url`] — resolve the
 //!   coord HTTP base from the active profile's `coord_url`
 //!   (`ws[s]://host:port/ws` → `http[s]://host:port`).
@@ -247,17 +249,118 @@ pub(crate) fn paired_user_path() -> Option<PathBuf> {
     Some(base.join("paired_user.json"))
 }
 
+/// One tenant binding entry in the v2 `paired_user.json` shape
+/// (session-scoped multi-tenant plan 2026-07-02, Phase 8a / D4).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PairedBinding {
+    /// Stringified tenant UUID.
+    pub tenant_id: String,
+    /// The user who paired this binding (stringified UUID).
+    pub user_id: String,
+    /// RFC3339 timestamp of the (most recent) pair for this tenant.
+    /// Optional on read so a hand-edited / partially-written entry still
+    /// parses; always written by [`persist_pairing`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paired_at: Option<String>,
+}
+
+/// `paired_user.json` — BOTH wire shapes in one struct.
+///
+/// - **Legacy (v1)**: `{user_id, tenant_id?}` — single-entry, written
+///   before Phase 8a. Parses with `bindings == []`,
+///   `default_tenant_id == None`.
+/// - **v2 (Phase 8a, plan 2026-07-02 D4)**: adds
+///   `bindings: [{tenant_id, user_id, paired_at}]` +
+///   `default_tenant_id`. The legacy `user_id` / `tenant_id` fields are
+///   kept as **mirrors of the DEFAULT binding** so every legacy reader
+///   (this crate's pre-8a consumers, `bin/qontinui_profile.rs`'s local
+///   mirror struct, and any older installed binary during an upgrade
+///   window) keeps working unmodified.
+///
+/// Read-side migration is [`PairedUserFile::effective_bindings`] /
+/// [`PairedUserFile::effective_default_tenant_id`]: a legacy file's
+/// single entry is synthesized into a one-element binding set.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct PairedUserFile {
+    /// v2: mirror of the DEFAULT binding's `user_id`. Legacy: the paired
+    /// user.
     pub user_id: String,
     /// Stringified UUID. `#[serde(default)]` keeps legacy files
     /// (written before the 2026-05-22 schema bump) deserializing
     /// — they carry only `user_id`. A heartbeat/register caller
     /// that finds `None` here falls back to decoding the cached
     /// device-token JWT via [`tenant_id_from_oauth_claim`]
-    /// (see `fleet::resolve_tenant_id`).
+    /// (see `fleet::resolve_tenant_id`). v2: mirror of
+    /// `default_tenant_id`.
     #[serde(default)]
     pub tenant_id: Option<String>,
+    /// v2 multi-entry binding set. Empty on legacy files (serde default);
+    /// omitted from serialization when empty so a legacy-heal write keeps
+    /// the legacy shape byte-compatible.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bindings: Vec<PairedBinding>,
+    /// v2: which binding's JWT the legacy `access_token` slot holds (the
+    /// device-level default — D4). Set at first pair, changed only by
+    /// reconciliation dropping the default binding (never stolen by a
+    /// later additive pair).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_tenant_id: Option<String>,
+}
+
+impl PairedUserFile {
+    /// v2-migrated view of the binding set: the `bindings` array when
+    /// non-empty, else a single entry synthesized from the legacy
+    /// `user_id`/`tenant_id` fields (or empty when the legacy file has
+    /// no `tenant_id`).
+    pub(crate) fn effective_bindings(&self) -> Vec<PairedBinding> {
+        if !self.bindings.is_empty() {
+            return self.bindings.clone();
+        }
+        match &self.tenant_id {
+            Some(t) => vec![PairedBinding {
+                tenant_id: t.clone(),
+                user_id: self.user_id.clone(),
+                paired_at: None,
+            }],
+            None => Vec::new(),
+        }
+    }
+
+    /// v2-migrated view of the default tenant: `default_tenant_id` when
+    /// present, else the legacy single `tenant_id`.
+    pub(crate) fn effective_default_tenant_id(&self) -> Option<String> {
+        self.default_tenant_id
+            .clone()
+            .or_else(|| self.tenant_id.clone())
+    }
+
+    /// Is this file in the v2 multi-entry shape (vs pure legacy)?
+    fn is_v2(&self) -> bool {
+        !self.bindings.is_empty() || self.default_tenant_id.is_some()
+    }
+}
+
+/// Read + parse `paired_user.json` at an explicit path. `None` when the
+/// file is missing or unparseable (callers that must distinguish the two
+/// read the file themselves — see `reconcile_paired_bindings_with`).
+fn read_paired_user_file_at(path: &std::path::Path) -> Option<PairedUserFile> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Atomic write of `paired_user.json` (tmp + rename), pretty-printed —
+/// the shared writer for [`persist_pairing`], [`backfill_paired_tenant_id`]
+/// and [`reconcile_paired_bindings`].
+fn write_paired_user_file(path: &std::path::Path, pf: &PairedUserFile) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+    }
+    let pretty =
+        serde_json::to_vec_pretty(pf).map_err(|e| format!("serialize paired_user.json: {e}"))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &pretty).map_err(|e| format!("write tmp: {e}"))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("rename: {e}"))?;
+    Ok(())
 }
 
 /// Read the cached `user_id` written by a prior browser-pair. Returns
@@ -276,27 +379,60 @@ fn read_paired_user_id() -> Option<String> {
     Some(parsed.user_id)
 }
 
-/// Read the cached `tenant_id` from `paired_user.json`. Returns `None`
-/// if the file is missing OR the field is absent (legacy file written
-/// before the 2026-05-22 schema bump). Used by
-/// `fleet::resolve_tenant_id` as the primary resolution branch.
+/// Read the cached DEFAULT tenant_id from `paired_user.json`. Returns
+/// `None` if the file is missing OR no tenant is recorded (legacy file
+/// written before the 2026-05-22 schema bump). Used by
+/// `fleet::resolve_binding_set` as the primary resolution branch, and by
+/// every "which tenant is this device's default" consumer
+/// (`commands/tenant.rs`, `claude_session/federation.rs`).
+///
+/// v2-aware: prefers `default_tenant_id`, falling back to the legacy
+/// single `tenant_id` field (which v2 writers keep mirrored anyway).
 pub fn read_paired_tenant_id_from_disk() -> Option<String> {
     let path = paired_user_path()?;
-    let bytes = std::fs::read(&path).ok()?;
-    let parsed: PairedUserFile = serde_json::from_slice(&bytes).ok()?;
-    parsed.tenant_id
+    read_paired_user_file_at(&path)?.effective_default_tenant_id()
 }
 
-/// Opportunistically rewrite `paired_user.json` with the supplied
-/// `tenant_id`, preserving the existing `user_id`. Used by
-/// `fleet::resolve_tenant_id`'s JWT-claim fallback so a legacy file
-/// gets backfilled on the first heartbeat after a runner upgrade.
+/// Read the locally-held binding set from `paired_user.json` as parsed
+/// tenant UUIDs (deduped, file order preserved; entries with malformed
+/// `tenant_id` silently skipped). Legacy single-entry files yield their
+/// one synthesized binding. Empty when the file is missing/unparseable
+/// or carries no tenant. Phase 8a: this is what the register heartbeat
+/// sends as `tenant_ids` (D3).
+pub fn read_paired_binding_tenant_ids() -> Vec<uuid::Uuid> {
+    let Some(path) = paired_user_path() else {
+        return Vec::new();
+    };
+    let Some(pf) = read_paired_user_file_at(&path) else {
+        return Vec::new();
+    };
+    let mut out: Vec<uuid::Uuid> = Vec::new();
+    for b in pf.effective_bindings() {
+        if let Ok(t) = uuid::Uuid::parse_str(b.tenant_id.trim()) {
+            if !out.contains(&t) {
+                out.push(t);
+            }
+        }
+    }
+    out
+}
+
+/// LEGACY single-value heal: opportunistically rewrite `paired_user.json`
+/// with the supplied `tenant_id`, preserving the existing `user_id`.
+/// Phase 8a posture: this heal applies ONLY to pure-legacy (v1) files —
+/// a v2 multi-entry file's tenant state is owned by
+/// [`reconcile_paired_bindings`], and a single-value overwrite would
+/// clobber the binding set / flip the default (coord's single
+/// `tenant_id` echo means "most recently paired", NOT "your default").
+/// On a v2 file this is a quiet no-op success.
 ///
 /// No-op if the file doesn't exist (the JWT-claim path only fires
 /// when SOMETHING was paired previously, but we tolerate the race
 /// where pair-state was wiped between read and write). Returns
 /// `Err(String)` on filesystem failures so the caller can log them
 /// at `debug!` — the outer flow proceeds either way.
+///
+/// Scheduled for deletion in Phase 10 item 4 (with the echo-heal).
 pub fn backfill_paired_tenant_id(tenant_id: &uuid::Uuid) -> Result<(), String> {
     let path = paired_user_path().ok_or_else(|| "could not resolve data_local_dir".to_string())?;
     let bytes = match std::fs::read(&path) {
@@ -309,17 +445,230 @@ pub fn backfill_paired_tenant_id(tenant_id: &uuid::Uuid) -> Result<(), String> {
     };
     let mut parsed: PairedUserFile =
         serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {e}", path.display()))?;
+    if parsed.is_v2() {
+        // v2 file: the binding set is reconciled against coord's
+        // `tenant_ids` (Phase 8a); the single-value heal must not touch it.
+        return Ok(());
+    }
     if parsed.tenant_id.as_deref() == Some(tenant_id.to_string().as_str()) {
         // Already up-to-date; avoid an unnecessary disk write.
         return Ok(());
     }
     parsed.tenant_id = Some(tenant_id.to_string());
-    let pretty = serde_json::to_vec_pretty(&parsed)
-        .map_err(|e| format!("serialize paired_user.json: {e}"))?;
-    let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, &pretty).map_err(|e| format!("write tmp: {e}"))?;
-    std::fs::rename(&tmp, &path).map_err(|e| format!("rename: {e}"))?;
-    Ok(())
+    write_paired_user_file(&path, &parsed)
+}
+
+// ============================================================================
+// Binding reconciliation against coord's register echo (Phase 8a, D3)
+// ============================================================================
+
+/// What one [`reconcile_paired_bindings`] pass changed / observed.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BindingReconcileReport {
+    /// Local binding entries removed because coord's authoritative set no
+    /// longer contains them. Their per-tenant JWT slots were cleared too
+    /// (the designed home of slot deletion — REPLACE-not-REVOKE applies
+    /// everywhere else).
+    pub dropped: Vec<uuid::Uuid>,
+    /// Orphan per-tenant JWT slots (no binding entry) cleared because
+    /// coord's set doesn't contain them either.
+    pub dropped_slots: Vec<uuid::Uuid>,
+    /// Tenants coord reports bound to this device for which the runner
+    /// holds NO usable credential (no binding entry, or entry without a
+    /// JWT slot). Flag-only: the runner never fabricates a binding — the
+    /// operator must pair for that tenant to mint its JWT.
+    pub coord_only: Vec<uuid::Uuid>,
+    /// `Some` when the default binding was dropped and the default was
+    /// re-pointed (`Some(tenant)`) or cleared entirely (`None` — no
+    /// bindings remain).
+    pub default_repointed: Option<Option<uuid::Uuid>>,
+}
+
+impl BindingReconcileReport {
+    /// Did this pass mutate any local state (file or slots)?
+    pub fn changed(&self) -> bool {
+        !self.dropped.is_empty()
+            || !self.dropped_slots.is_empty()
+            || self.default_repointed.is_some()
+    }
+}
+
+/// Reconcile the local binding state (`paired_user.json` v2 entries +
+/// per-tenant JWT slots) against coord's authoritative server-side
+/// binding set, as echoed in the register response's `tenant_ids` field
+/// (D3 — replaces the single-value echo-heal for v2 state).
+///
+/// Semantics:
+/// - **Drop**: local binding entries whose tenant is NOT in `coord_set`
+///   are removed, and their `device_jwt:<tenant>` slots cleared (coord
+///   Phase 3's refresh gate would 403 them anyway). Orphan slots with no
+///   binding entry are cleared by the same rule.
+/// - **Flag**: tenants in `coord_set` the runner lacks a JWT for are
+///   reported (`coord_only`) — never fabricated locally; pair to heal.
+/// - **Default re-point**: if the default binding was dropped, the most
+///   recently paired surviving binding becomes the default and its slot
+///   JWT is copied into the legacy `access_token` slot (D4: the legacy
+///   slot always holds the DEFAULT binding's JWT). If no binding
+///   survives, the default is cleared but the legacy slot is left as-is
+///   (matching coord Phase 3's unpair posture — the stale JWT simply
+///   ages out, and the refresh gate stops it self-perpetuating).
+/// - **No silent churn**: the file is rewritten only when something
+///   actually changed, so the 30s heartbeat cadence costs no disk writes
+///   at steady state.
+///
+/// This function is only ever called when coord's response CARRIES a
+/// `tenant_ids` field (Phase 3 coord). The caller (`fleet::heartbeat`)
+/// must no-op when the field is absent — today's production coord.
+///
+/// Missing file → `Ok` empty report (nothing local to reconcile).
+/// Unparseable file → `Err` (caller logs at debug; never fatal).
+pub fn reconcile_paired_bindings(
+    coord_set: &[uuid::Uuid],
+) -> Result<BindingReconcileReport, String> {
+    let mgr = crate::auth::AuthManager::new();
+    let path = paired_user_path().ok_or_else(|| "could not resolve data_local_dir".to_string())?;
+    reconcile_paired_bindings_with(&mgr, &path, coord_set)
+}
+
+/// Parameterized core of [`reconcile_paired_bindings`] — explicit
+/// `AuthManager` + file path so the unit tests run hermetically against
+/// a temp store, never the operator's real credentials.
+pub(crate) fn reconcile_paired_bindings_with(
+    mgr: &crate::auth::AuthManager,
+    path: &std::path::Path,
+    coord_set: &[uuid::Uuid],
+) -> Result<BindingReconcileReport, String> {
+    let mut report = BindingReconcileReport::default();
+
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Never paired locally — nothing to reconcile. Coord-side
+            // bindings without ANY local file are still worth flagging.
+            for t in coord_set {
+                report.coord_only.push(*t);
+            }
+            return Ok(report);
+        }
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    let pf: PairedUserFile =
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {e}", path.display()))?;
+
+    // Partition the (migrated) binding set by coord membership. Entries
+    // with malformed tenant_id can never match coord and carry no slot —
+    // dropped as junk (logged, not reported).
+    let mut kept: Vec<PairedBinding> = Vec::new();
+    let mut dropped_malformed = false;
+    for b in pf.effective_bindings() {
+        match uuid::Uuid::parse_str(b.tenant_id.trim()) {
+            Ok(t) if coord_set.contains(&t) => kept.push(b),
+            Ok(t) => {
+                report.dropped.push(t);
+                // Designed home of slot deletion: coord no longer has the
+                // binding, so its credential is dead weight. Best-effort.
+                if let Err(e) = mgr.clear_tenant_device_jwt(&t) {
+                    tracing::debug!("reconcile: clear slot for dropped tenant {t} failed: {e}");
+                }
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "reconcile: dropping paired_user.json binding with malformed tenant_id {:?}",
+                    b.tenant_id
+                );
+                dropped_malformed = true;
+            }
+        }
+    }
+
+    // Orphan slots (credential without a binding entry) that coord's set
+    // doesn't contain either — same authority statement, same fate.
+    let kept_tenants: Vec<uuid::Uuid> = kept
+        .iter()
+        .filter_map(|b| uuid::Uuid::parse_str(b.tenant_id.trim()).ok())
+        .collect();
+    for t in mgr.list_tenant_device_jwt_tenants() {
+        if !coord_set.contains(&t) && !report.dropped.contains(&t) {
+            if let Err(e) = mgr.clear_tenant_device_jwt(&t) {
+                tracing::debug!("reconcile: clear orphan slot {t} failed: {e}");
+            } else {
+                report.dropped_slots.push(t);
+            }
+        }
+    }
+
+    // Flag coord-side bindings the runner cannot act for: no entry, or an
+    // entry without a JWT slot.
+    for t in coord_set {
+        let has_entry = kept_tenants.contains(t);
+        let has_jwt =
+            matches!(mgr.get_tenant_device_jwt(t), Ok(Some(ref j)) if !j.trim().is_empty());
+        if !has_entry || !has_jwt {
+            report.coord_only.push(*t);
+        }
+    }
+
+    // Default re-point when the default binding was dropped.
+    let old_default = pf
+        .effective_default_tenant_id()
+        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok());
+    let new_default: Option<uuid::Uuid> = match old_default {
+        Some(d) if kept_tenants.contains(&d) => Some(d),
+        _ => {
+            // Most recently paired survivor (RFC3339 strings order
+            // lexicographically; entries without paired_at sort oldest).
+            kept.iter()
+                .max_by(|a, b| a.paired_at.cmp(&b.paired_at))
+                .and_then(|b| uuid::Uuid::parse_str(b.tenant_id.trim()).ok())
+        }
+    };
+    if new_default != old_default {
+        report.default_repointed = Some(new_default);
+        if let Some(nd) = new_default {
+            // D4: the legacy access_token slot holds the DEFAULT
+            // binding's JWT — re-point it alongside the default.
+            match mgr.get_tenant_device_jwt(&nd) {
+                Ok(Some(jwt)) if !jwt.trim().is_empty() => {
+                    if let Err(e) = mgr.store_tokens(&jwt, "") {
+                        tracing::warn!(
+                            "reconcile: default re-pointed to {nd} but legacy-slot write \
+                             failed: {e} (legacy slot left as-is)"
+                        );
+                    }
+                }
+                _ => tracing::warn!(
+                    "reconcile: default re-pointed to {nd} but no JWT slot for it — \
+                     legacy access_token slot left as-is until the next pair/refresh"
+                ),
+            }
+        }
+        // No surviving binding → legacy slot deliberately left as-is
+        // (coord Phase 3 unpair posture; the refresh gate stops the stale
+        // JWT self-perpetuating).
+    }
+
+    let changed =
+        !report.dropped.is_empty() || report.default_repointed.is_some() || dropped_malformed;
+    if changed {
+        let default_binding = new_default.and_then(|d| {
+            kept.iter()
+                .find(|b| uuid::Uuid::parse_str(b.tenant_id.trim()).ok() == Some(d))
+                .cloned()
+        });
+        let out = PairedUserFile {
+            // Mirrors track the DEFAULT binding; with no survivor keep
+            // the old user_id (the field is required by legacy readers).
+            user_id: default_binding
+                .as_ref()
+                .map(|b| b.user_id.clone())
+                .unwrap_or_else(|| pf.user_id.clone()),
+            tenant_id: new_default.map(|d| d.to_string()),
+            bindings: kept,
+            default_tenant_id: new_default.map(|d| d.to_string()),
+        };
+        write_paired_user_file(path, &out)?;
+    }
+    Ok(report)
 }
 
 // ============================================================================
@@ -869,36 +1218,30 @@ pub fn pair_via_browser(
 // Persist: store device-token JWT + cache user_id
 // ============================================================================
 
-/// Persist the device-token JWT (via
-/// `qontinui_runner_lib::auth::AuthManager`) and write the paired
-/// user_id to `paired_user.json` so the next `device init` attaches it
-/// to the register payload.
+/// Persist a completed pairing: the device-token JWT into the paired
+/// tenant's `device_jwt:<tenant_id>` slot (and, when that tenant is the
+/// device's DEFAULT binding, also the legacy `access_token` slot), plus
+/// an appended/updated binding entry in `paired_user.json` (v2 shape).
 ///
-/// Storing the JWT in the `access_token` slot is intentional: the
-/// existing `AuthManager` already calls that slot the "primary
-/// credential," and the runner's outer code reads `get_access_token()`
-/// when authenticating to the web backend. The refresh-token slot is
-/// unused for the device-token flow (the device JWT has its own
-/// lifecycle managed by coord); we pass an empty string. See the
-/// format-change comment in `secure_storage.rs`.
+/// Phase 8a semantics (plan 2026-07-02, D4):
+/// - Pairing is ADDITIVE: an existing binding for another tenant is
+///   never removed or overwritten; re-pairing the same tenant updates
+///   its entry (user_id + paired_at) in place.
+/// - The paired tenant becomes the default ONLY when no default exists
+///   yet (first pair / legacy no-tenant file). An established default is
+///   never stolen by a later additive pair.
+/// - The legacy `access_token` slot keeps holding the DEFAULT binding's
+///   JWT, so every unmodified consumer (`backend_relay`,
+///   `commands/auth.rs` signed-in check, `attach_device_auth`, …) keeps
+///   working. Pairing a NON-default tenant therefore does NOT touch it.
+/// - The legacy `user_id`/`tenant_id` file fields are written as mirrors
+///   of the default binding so pre-8a readers (incl. the
+///   `qontinui_profile` bin's local struct) stay compatible.
 pub fn persist_pairing(resp: &PairCompleteResponse, tenant_id: uuid::Uuid) -> Result<(), String> {
     use crate::auth::AuthManager;
     let mgr = AuthManager::new();
-    mgr.store_tokens(&resp.token, "")
-        .map_err(|e| format!("AuthManager::store_tokens failed: {e}"))?;
     let path = paired_user_path().ok_or_else(|| "could not resolve data_local_dir".to_string())?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
-    }
-    let pf = PairedUserFile {
-        user_id: resp.user_id.clone(),
-        tenant_id: Some(tenant_id.to_string()),
-    };
-    let pretty =
-        serde_json::to_vec_pretty(&pf).map_err(|e| format!("serialize paired_user.json: {e}"))?;
-    let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, &pretty).map_err(|e| format!("write tmp: {e}"))?;
-    std::fs::rename(&tmp, &path).map_err(|e| format!("rename: {e}"))?;
+    persist_pairing_with(&mgr, &path, resp, tenant_id)?;
     if let Some(did) = &resp.device_id {
         // Best-effort: record device_id alongside the auth tokens so the
         // runner GUI can identify itself without reading machine.json.
@@ -909,6 +1252,90 @@ pub fn persist_pairing(resp: &PairCompleteResponse, tenant_id: uuid::Uuid) -> Re
         }
     }
     Ok(())
+}
+
+/// Parameterized core of [`persist_pairing`] — explicit `AuthManager` +
+/// file path so unit tests run hermetically against a temp store.
+pub(crate) fn persist_pairing_with(
+    mgr: &crate::auth::AuthManager,
+    path: &std::path::Path,
+    resp: &PairCompleteResponse,
+    tenant_id: uuid::Uuid,
+) -> Result<(), String> {
+    // 1. The paired tenant's slot ALWAYS gets the fresh JWT.
+    mgr.store_tenant_device_jwt(&tenant_id, &resp.token)
+        .map_err(|e| format!("store_tenant_device_jwt failed: {e}"))?;
+
+    // 2. Load + migrate the existing file (missing → fresh; unparseable
+    //    → start over, same clobber posture the pre-8a writer had).
+    let existing = match std::fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice::<PairedUserFile>(&bytes) {
+            Ok(pf) => Some(pf),
+            Err(e) => {
+                tracing::warn!(
+                    "persist_pairing: existing {} unparseable ({e}) — rewriting fresh",
+                    path.display()
+                );
+                None
+            }
+        },
+        Err(_) => None,
+    };
+    let mut bindings = existing
+        .as_ref()
+        .map(|pf| pf.effective_bindings())
+        .unwrap_or_default();
+
+    // 3. Append/update this tenant's binding entry.
+    let tenant_str = tenant_id.to_string();
+    let paired_at = Some(chrono::Utc::now().to_rfc3339());
+    match bindings
+        .iter_mut()
+        .find(|b| uuid::Uuid::parse_str(b.tenant_id.trim()).ok() == Some(tenant_id))
+    {
+        Some(b) => {
+            b.user_id = resp.user_id.clone();
+            b.paired_at = paired_at;
+        }
+        None => bindings.push(PairedBinding {
+            tenant_id: tenant_str.clone(),
+            user_id: resp.user_id.clone(),
+            paired_at,
+        }),
+    }
+
+    // 4. Default: keep the established one (if it still names a binding);
+    //    otherwise this pair sets it.
+    let default_tenant = existing
+        .as_ref()
+        .and_then(|pf| pf.effective_default_tenant_id())
+        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok())
+        .filter(|d| {
+            bindings
+                .iter()
+                .any(|b| uuid::Uuid::parse_str(b.tenant_id.trim()).ok() == Some(*d))
+        })
+        .unwrap_or(tenant_id);
+
+    // 5. Legacy access_token slot = the DEFAULT binding's JWT (D4).
+    if default_tenant == tenant_id {
+        mgr.store_tokens(&resp.token, "")
+            .map_err(|e| format!("AuthManager::store_tokens failed: {e}"))?;
+    }
+
+    // 6. Write the v2 file with legacy mirrors tracking the default.
+    let default_user_id = bindings
+        .iter()
+        .find(|b| uuid::Uuid::parse_str(b.tenant_id.trim()).ok() == Some(default_tenant))
+        .map(|b| b.user_id.clone())
+        .unwrap_or_else(|| resp.user_id.clone());
+    let pf = PairedUserFile {
+        user_id: default_user_id,
+        tenant_id: Some(default_tenant.to_string()),
+        bindings,
+        default_tenant_id: Some(default_tenant.to_string()),
+    };
+    write_paired_user_file(path, &pf)
 }
 
 // ============================================================================
@@ -1184,17 +1611,443 @@ mod tests {
 
     /// Forward shape — a newly-written `paired_user.json` round-trips
     /// both fields. Pins the serde representation against accidental
-    /// `#[serde(rename)]` / `#[serde(skip)]` regressions.
+    /// `#[serde(rename)]` / `#[serde(skip)]` regressions. Also pins the
+    /// Phase 8a legacy-shape preservation: a v1 struct (no bindings, no
+    /// default) serializes WITHOUT the v2 keys, so a legacy-heal write
+    /// keeps the legacy shape.
     #[test]
     fn paired_user_file_with_tenant_id_round_trips() {
         let original = PairedUserFile {
             user_id: "22222222-2222-4222-8222-222222222222".to_string(),
             tenant_id: Some("11111111-2222-3333-4444-555555555555".to_string()),
+            bindings: Vec::new(),
+            default_tenant_id: None,
         };
         let json = serde_json::to_string(&original).expect("serialize");
+        assert!(
+            !json.contains("bindings") && !json.contains("default_tenant_id"),
+            "empty v2 fields must not serialize (legacy shape preserved): {json}"
+        );
         let parsed: PairedUserFile = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(parsed.user_id, original.user_id);
         assert_eq!(parsed.tenant_id, original.tenant_id);
+        assert!(parsed.bindings.is_empty());
+        assert!(parsed.default_tenant_id.is_none());
+    }
+
+    // ------------------------------------------------------------------------
+    // Phase 8a — paired_user.json v2 multi-entry + migration + persist +
+    // reconciliation (plan 2026-07-02, D3/D4). All hermetic: temp file paths
+    // + AuthManager::with_storage — never the operator's real state.
+    // ------------------------------------------------------------------------
+
+    const T_A: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const T_B: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const T_C: &str = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const USER: &str = "22222222-2222-4222-8222-222222222222";
+
+    fn ta() -> uuid::Uuid {
+        uuid::Uuid::parse_str(T_A).unwrap()
+    }
+    fn tb() -> uuid::Uuid {
+        uuid::Uuid::parse_str(T_B).unwrap()
+    }
+    fn tc() -> uuid::Uuid {
+        uuid::Uuid::parse_str(T_C).unwrap()
+    }
+
+    fn temp_dir_for(test: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join("qontinui_test_paired_v2")
+            .join(format!("{test}_{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dir).expect("mkdir tempdir");
+        dir
+    }
+
+    fn test_mgr(dir: &std::path::Path) -> crate::auth::AuthManager {
+        let storage = crate::secure_storage::SecureStorage::with_path(dir.join("tokens.enc"))
+            .expect("test storage");
+        crate::auth::AuthManager::with_storage(storage)
+    }
+
+    fn pair_resp(token: &str) -> PairCompleteResponse {
+        PairCompleteResponse {
+            token: token.to_string(),
+            user_id: USER.to_string(),
+            device_id: None,
+            jti: None,
+            exp: None,
+            tenant_id: None,
+        }
+    }
+
+    fn read_file(path: &std::path::Path) -> PairedUserFile {
+        serde_json::from_slice(&std::fs::read(path).expect("read paired file"))
+            .expect("parse paired file")
+    }
+
+    /// Legacy (v1) shapes migrate through the effective-view accessors:
+    /// `{user_id, tenant_id}` yields one synthesized binding + that
+    /// default; `{user_id}` yields an empty set and no default.
+    #[test]
+    fn legacy_file_migrates_via_effective_view() {
+        let with_tenant: PairedUserFile =
+            serde_json::from_str(&format!(r#"{{"user_id":"{USER}","tenant_id":"{T_A}"}}"#))
+                .unwrap();
+        assert_eq!(
+            with_tenant.effective_bindings(),
+            vec![PairedBinding {
+                tenant_id: T_A.to_string(),
+                user_id: USER.to_string(),
+                paired_at: None,
+            }]
+        );
+        assert_eq!(
+            with_tenant.effective_default_tenant_id().as_deref(),
+            Some(T_A)
+        );
+
+        let no_tenant: PairedUserFile =
+            serde_json::from_str(&format!(r#"{{"user_id":"{USER}"}}"#)).unwrap();
+        assert!(no_tenant.effective_bindings().is_empty());
+        assert!(no_tenant.effective_default_tenant_id().is_none());
+    }
+
+    /// v2 files round-trip and the explicit `bindings`/`default_tenant_id`
+    /// win over the legacy mirror fields in the effective view.
+    #[test]
+    fn v2_file_round_trips_and_bindings_win_over_mirrors() {
+        let v2 = PairedUserFile {
+            user_id: USER.to_string(),
+            tenant_id: Some(T_A.to_string()),
+            bindings: vec![
+                PairedBinding {
+                    tenant_id: T_A.to_string(),
+                    user_id: USER.to_string(),
+                    paired_at: Some("2026-07-01T00:00:00Z".to_string()),
+                },
+                PairedBinding {
+                    tenant_id: T_B.to_string(),
+                    user_id: USER.to_string(),
+                    paired_at: Some("2026-07-02T00:00:00Z".to_string()),
+                },
+            ],
+            default_tenant_id: Some(T_A.to_string()),
+        };
+        let json = serde_json::to_string_pretty(&v2).unwrap();
+        let parsed: PairedUserFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.effective_bindings().len(), 2);
+        assert_eq!(parsed.effective_default_tenant_id().as_deref(), Some(T_A));
+        // Legacy mirrors present on the wire for pre-8a readers.
+        assert!(json.contains("\"user_id\""));
+        assert!(json.contains("\"tenant_id\""));
+    }
+
+    /// First pair: binding appended, becomes default, JWT written to BOTH
+    /// the tenant slot and the legacy access_token slot, mirrors set.
+    #[test]
+    fn persist_first_pair_sets_default_and_both_slots() {
+        let dir = temp_dir_for("persist_first");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).expect("persist");
+
+        let pf = read_file(&path);
+        assert_eq!(pf.bindings.len(), 1);
+        assert_eq!(pf.bindings[0].tenant_id, T_A);
+        assert_eq!(pf.bindings[0].user_id, USER);
+        assert!(pf.bindings[0].paired_at.is_some());
+        assert_eq!(pf.default_tenant_id.as_deref(), Some(T_A));
+        // Legacy mirrors track the default.
+        assert_eq!(pf.user_id, USER);
+        assert_eq!(pf.tenant_id.as_deref(), Some(T_A));
+        // Both credential slots hold the fresh JWT.
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&ta()).unwrap().as_deref(),
+            Some("jwt.a.1")
+        );
+        assert_eq!(mgr.get_access_token().unwrap(), "jwt.a.1");
+    }
+
+    /// Additive pair for a SECOND tenant: appended, default NOT stolen,
+    /// legacy access_token slot untouched (it holds the DEFAULT binding's
+    /// JWT — D4).
+    #[test]
+    fn persist_second_tenant_appends_without_stealing_default() {
+        let dir = temp_dir_for("persist_second");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).expect("persist A");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.b.1"), tb()).expect("persist B");
+
+        let pf = read_file(&path);
+        assert_eq!(pf.bindings.len(), 2, "pairing is additive");
+        assert_eq!(
+            pf.default_tenant_id.as_deref(),
+            Some(T_A),
+            "an established default is never stolen by a later pair"
+        );
+        assert_eq!(
+            pf.tenant_id.as_deref(),
+            Some(T_A),
+            "mirror stays on default"
+        );
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&tb()).unwrap().as_deref(),
+            Some("jwt.b.1")
+        );
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "jwt.a.1",
+            "legacy slot keeps the DEFAULT binding's JWT"
+        );
+    }
+
+    /// Re-pairing the DEFAULT tenant updates its entry in place (no
+    /// duplicate) and refreshes BOTH slots.
+    #[test]
+    fn persist_repair_default_updates_entry_and_both_slots() {
+        let dir = temp_dir_for("persist_repair");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).expect("persist A1");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.b.1"), tb()).expect("persist B");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.2"), ta()).expect("persist A2");
+
+        let pf = read_file(&path);
+        assert_eq!(pf.bindings.len(), 2, "re-pair must not duplicate the entry");
+        assert_eq!(pf.default_tenant_id.as_deref(), Some(T_A));
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&ta()).unwrap().as_deref(),
+            Some("jwt.a.2")
+        );
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "jwt.a.2",
+            "re-pairing the default refreshes the legacy slot too"
+        );
+    }
+
+    /// Pairing on top of a LEGACY (v1) file migrates it: the legacy
+    /// tenant becomes a binding AND stays the default; the new tenant is
+    /// appended; the legacy slot (still holding the legacy default's JWT)
+    /// is untouched.
+    #[test]
+    fn persist_migrates_legacy_file_preserving_its_default() {
+        let dir = temp_dir_for("persist_migrate");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+        std::fs::write(
+            &path,
+            format!(r#"{{"user_id":"{USER}","tenant_id":"{T_A}"}}"#),
+        )
+        .unwrap();
+        mgr.store_tokens("jwt.a.legacy", "").unwrap();
+
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.b.1"), tb()).expect("persist B");
+
+        let pf = read_file(&path);
+        assert_eq!(
+            pf.bindings.len(),
+            2,
+            "legacy entry synthesized + B appended"
+        );
+        assert_eq!(
+            pf.default_tenant_id.as_deref(),
+            Some(T_A),
+            "legacy tenant stays the default"
+        );
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "jwt.a.legacy",
+            "legacy slot untouched when pairing a non-default tenant"
+        );
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&tb()).unwrap().as_deref(),
+            Some("jwt.b.1")
+        );
+    }
+
+    /// The legacy single-value echo-heal must be a quiet no-op on v2
+    /// files (a single-value overwrite would clobber the binding set /
+    /// flip the default), while keeping its pre-8a behavior on v1 files.
+    #[test]
+    fn backfill_heal_noops_on_v2_shape_only() {
+        // v1 shape: is_v2() false → heal applies (behavior unchanged).
+        let v1: PairedUserFile =
+            serde_json::from_str(&format!(r#"{{"user_id":"{USER}","tenant_id":"{T_A}"}}"#))
+                .unwrap();
+        assert!(!v1.is_v2());
+        // v2 shape (either marker) → heal must no-op.
+        let v2_bindings: PairedUserFile = serde_json::from_str(&format!(
+            r#"{{"user_id":"{USER}","bindings":[{{"tenant_id":"{T_A}","user_id":"{USER}"}}]}}"#
+        ))
+        .unwrap();
+        assert!(v2_bindings.is_v2());
+        let v2_default: PairedUserFile = serde_json::from_str(&format!(
+            r#"{{"user_id":"{USER}","default_tenant_id":"{T_A}"}}"#
+        ))
+        .unwrap();
+        assert!(v2_default.is_v2());
+    }
+
+    /// Reconcile: entries coord no longer returns are dropped and their
+    /// slots cleared; the surviving default is kept; the file is
+    /// rewritten. Coord-side tenants the runner lacks a JWT for are
+    /// flagged (never fabricated).
+    #[test]
+    fn reconcile_drops_missing_and_flags_coord_only() {
+        let dir = temp_dir_for("reconcile_drop_flag");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).unwrap();
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.b.1"), tb()).unwrap();
+
+        // Coord says: A still bound, B gone, C newly bound elsewhere.
+        let report = reconcile_paired_bindings_with(&mgr, &path, &[ta(), tc()]).expect("reconcile");
+
+        assert_eq!(report.dropped, vec![tb()]);
+        assert_eq!(
+            report.coord_only,
+            vec![tc()],
+            "no local JWT for C → flagged"
+        );
+        assert_eq!(report.default_repointed, None, "default A survived");
+        assert!(
+            mgr.get_tenant_device_jwt(&tb()).unwrap().is_none(),
+            "dropped binding's slot is cleared (the designed slot-deletion home)"
+        );
+        let pf = read_file(&path);
+        assert_eq!(pf.bindings.len(), 1);
+        assert_eq!(pf.bindings[0].tenant_id, T_A);
+        assert_eq!(pf.default_tenant_id.as_deref(), Some(T_A));
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "jwt.a.1",
+            "legacy slot untouched when the default survives"
+        );
+    }
+
+    /// Reconcile: when the DEFAULT binding is dropped, the most recently
+    /// paired survivor becomes the default and its slot JWT is copied
+    /// into the legacy access_token slot (D4 invariant).
+    #[test]
+    fn reconcile_repoints_default_and_legacy_slot() {
+        let dir = temp_dir_for("reconcile_repoint");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).unwrap();
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.b.1"), tb()).unwrap();
+        assert_eq!(mgr.get_access_token().unwrap(), "jwt.a.1");
+
+        // Coord dropped A (the default); B survives.
+        let report = reconcile_paired_bindings_with(&mgr, &path, &[tb()]).expect("reconcile");
+
+        assert_eq!(report.dropped, vec![ta()]);
+        assert_eq!(report.default_repointed, Some(Some(tb())));
+        let pf = read_file(&path);
+        assert_eq!(pf.default_tenant_id.as_deref(), Some(T_B));
+        assert_eq!(
+            pf.tenant_id.as_deref(),
+            Some(T_B),
+            "mirror follows the default"
+        );
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "jwt.b.1",
+            "legacy slot re-pointed to the new default binding's JWT"
+        );
+        assert!(mgr.get_tenant_device_jwt(&ta()).unwrap().is_none());
+    }
+
+    /// Reconcile: present-but-EMPTY set = coord says zero bindings → all
+    /// entries + slots dropped, default cleared, but the legacy
+    /// access_token slot is deliberately left as-is (Phase 3 unpair
+    /// posture — the refresh gate stops it self-perpetuating).
+    #[test]
+    fn reconcile_empty_set_drops_all_but_preserves_legacy_slot() {
+        let dir = temp_dir_for("reconcile_empty");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).unwrap();
+
+        let report = reconcile_paired_bindings_with(&mgr, &path, &[]).expect("reconcile");
+
+        assert_eq!(report.dropped, vec![ta()]);
+        assert_eq!(report.default_repointed, Some(None), "default cleared");
+        let pf = read_file(&path);
+        assert!(pf.bindings.is_empty());
+        assert!(pf.default_tenant_id.is_none());
+        assert!(pf.tenant_id.is_none());
+        assert_eq!(pf.user_id, USER, "user_id kept for legacy readers");
+        assert!(mgr.get_tenant_device_jwt(&ta()).unwrap().is_none());
+        assert_eq!(
+            mgr.get_access_token().unwrap(),
+            "jwt.a.1",
+            "legacy slot left as-is when no binding survives"
+        );
+    }
+
+    /// Reconcile: a matching set is a pure no-op — no report changes and
+    /// NO disk write (the heartbeat calls this every 30s; steady state
+    /// must not churn the file).
+    #[test]
+    fn reconcile_matching_set_writes_nothing() {
+        let dir = temp_dir_for("reconcile_noop");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).unwrap();
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.b.1"), tb()).unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        let report = reconcile_paired_bindings_with(&mgr, &path, &[ta(), tb()]).expect("reconcile");
+
+        assert!(!report.changed(), "nothing changed: {report:?}");
+        assert!(report.coord_only.is_empty(), "both tenants hold JWTs");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "steady state must not rewrite the file"
+        );
+    }
+
+    /// Reconcile with NO local file: nothing to drop, coord-side
+    /// bindings flagged, quiet success (never an error).
+    #[test]
+    fn reconcile_missing_file_flags_only() {
+        let dir = temp_dir_for("reconcile_missing");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+
+        let report = reconcile_paired_bindings_with(&mgr, &path, &[ta()]).expect("reconcile");
+        assert!(report.dropped.is_empty());
+        assert_eq!(report.coord_only, vec![ta()]);
+        assert!(!path.exists(), "no file must be created");
+    }
+
+    /// Reconcile clears ORPHAN slots (credential without a binding
+    /// entry) that coord's set doesn't contain either.
+    #[test]
+    fn reconcile_clears_orphan_slots_outside_coord_set() {
+        let dir = temp_dir_for("reconcile_orphan");
+        let mgr = test_mgr(&dir);
+        let path = dir.join("paired_user.json");
+        persist_pairing_with(&mgr, &path, &pair_resp("jwt.a.1"), ta()).unwrap();
+        // Orphan slot for C: no binding entry, and coord doesn't have C.
+        mgr.store_tenant_device_jwt(&tc(), "jwt.c.orphan").unwrap();
+
+        let report = reconcile_paired_bindings_with(&mgr, &path, &[ta()]).expect("reconcile");
+
+        assert_eq!(report.dropped_slots, vec![tc()]);
+        assert!(mgr.get_tenant_device_jwt(&tc()).unwrap().is_none());
+        assert_eq!(
+            mgr.get_tenant_device_jwt(&ta()).unwrap().as_deref(),
+            Some("jwt.a.1"),
+            "coord-confirmed slot untouched"
+        );
     }
 
     // ------------------------------------------------------------------------

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -34,6 +34,11 @@ use tracing::{debug, info};
 /// Service identifier for the storage
 const SERVICE_NAME: &str = "com.qontinui.runner";
 
+/// Key prefix for the per-tenant device-JWT slots (session-scoped
+/// multi-tenant Phase 1, plan 2026-07-02). A slot for tenant
+/// `aaaa…` is stored under the map key `device_jwt:aaaa…`.
+const TENANT_DEVICE_JWT_PREFIX: &str = "device_jwt:";
+
 /// Storage file name
 const STORAGE_FILE: &str = "auth_tokens.enc";
 
@@ -86,6 +91,17 @@ struct StoredTokens {
     /// deserializing.
     #[serde(default)]
     agent_machine_key: Option<String>,
+    /// Per-tenant coord device-JWT slots (session-scoped multi-tenant
+    /// Phase 1, plan 2026-07-02). Keys are `device_jwt:<tenant_id>`; values
+    /// are the coord-minted device JWTs for that tenant binding. The legacy
+    /// `access_token` slot is COMPLETELY UNTOUCHED by these — it keeps
+    /// holding the DEFAULT binding's JWT so every unmodified consumer keeps
+    /// working during the compat window. Only populated when the
+    /// `QONTINUI_MULTI_TENANT_JWT=1` flag is on; `#[serde(default)]` keeps
+    /// every pre-Phase-1 `.enc` deserializing. BTreeMap so enumeration is
+    /// deterministic.
+    #[serde(default)]
+    tenant_device_jwts: std::collections::BTreeMap<String, String>,
 }
 
 /// Secure file-based storage manager.
@@ -278,13 +294,19 @@ impl SecureStorage {
         tokens.oauth_id_token = None;
         tokens.oauth_refresh_token = None;
         tokens.oauth_expires_at = None;
+        // Full sign-out also destroys every per-tenant device-JWT slot —
+        // they are bearer credentials just like the default-binding JWT.
+        // (`clear_interactive_session` deliberately preserves them, same as
+        // it preserves the other autonomy credentials.)
+        tokens.tenant_device_jwts.clear();
         self.save_tokens(&tokens)?;
         info!("Tokens cleared from secure file storage");
         Ok(())
     }
 
     /// Clears ONLY the device-JWT pair (`access_token` / `refresh_token`),
-    /// PRESERVING the four Cognito (`oauth_*`) slots and `device_id`.
+    /// PRESERVING the four Cognito (`oauth_*`) slots, the per-tenant
+    /// device-JWT slots, and `device_id`.
     ///
     /// This is the autonomy-preserving clear used by a default logout: the
     /// device JWT is dropped, but the long-lived `oauth_refresh_token` (and the
@@ -462,6 +484,73 @@ impl SecureStorage {
         Ok(())
     }
 
+    // ========================================================================
+    // Per-tenant device-JWT slots — session-scoped multi-tenant Phase 1
+    // (plan 2026-07-02-session-scoped-multi-tenant-device-binding, D4).
+    //
+    // One slot per tenant binding, keyed `device_jwt:<tenant_id>`. The legacy
+    // `access_token` slot is never read or written by these helpers — it keeps
+    // holding the DEFAULT binding's JWT. Like the oauth_* slots, the keychain
+    // backup is intentionally NOT mirrored here: the encrypted file is the
+    // source of truth (the keychain proved unreliable on Windows; see module
+    // docs).
+    // ========================================================================
+
+    /// Map key for a tenant's device-JWT slot: `device_jwt:<tenant_id>`.
+    fn tenant_device_jwt_key(tenant_id: &uuid::Uuid) -> String {
+        format!("{TENANT_DEVICE_JWT_PREFIX}{tenant_id}")
+    }
+
+    /// Store (or overwrite) the device JWT for one tenant binding. Leaves the
+    /// legacy `access_token` slot and every other slot untouched.
+    pub fn store_tenant_device_jwt(&self, tenant_id: &uuid::Uuid, jwt: &str) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens
+            .tenant_device_jwts
+            .insert(Self::tenant_device_jwt_key(tenant_id), jwt.to_string());
+        self.save_tokens(&tokens)?;
+        info!("Per-tenant device JWT stored for tenant {tenant_id}");
+        Ok(())
+    }
+
+    /// Retrieve the device JWT for one tenant binding. `Ok(None)` when no
+    /// slot exists for that tenant (vs an `Err` only on a decrypt/parse
+    /// failure of an existing store).
+    pub fn get_tenant_device_jwt(&self, tenant_id: &uuid::Uuid) -> Result<Option<String>> {
+        let tokens = self.load_tokens()?;
+        Ok(tokens
+            .tenant_device_jwts
+            .get(&Self::tenant_device_jwt_key(tenant_id))
+            .cloned())
+    }
+
+    /// Remove one tenant's device-JWT slot, leaving all other slots (incl.
+    /// the legacy `access_token`) intact. Idempotent.
+    pub fn clear_tenant_device_jwt(&self, tenant_id: &uuid::Uuid) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens
+            .tenant_device_jwts
+            .remove(&Self::tenant_device_jwt_key(tenant_id));
+        self.save_tokens(&tokens)?;
+        info!("Per-tenant device JWT cleared for tenant {tenant_id}");
+        Ok(())
+    }
+
+    /// Enumerate the tenant ids that currently have a device-JWT slot, in
+    /// deterministic (BTreeMap key) order. Unreadable stores and malformed
+    /// keys yield an empty / filtered list — enumeration is never fatal.
+    pub fn list_tenant_device_jwt_tenants(&self) -> Vec<uuid::Uuid> {
+        self.load_tokens()
+            .map(|t| {
+                t.tenant_device_jwts
+                    .keys()
+                    .filter_map(|k| k.strip_prefix(TENANT_DEVICE_JWT_PREFIX))
+                    .filter_map(|s| uuid::Uuid::parse_str(s).ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Deletes the storage file entirely.
     #[allow(dead_code)]
     pub fn delete_storage(&self) -> Result<()> {
@@ -626,6 +715,111 @@ mod tests {
         storage.clear_agent_machine_key().unwrap();
         assert!(storage.get_agent_machine_key().unwrap().is_none());
         assert_eq!(storage.get_access_token().unwrap(), "device.jwt");
+    }
+
+    /// Per-tenant device-JWT slots: round-trip + enumeration + legacy-slot
+    /// isolation (session-scoped multi-tenant Phase 1). Writing/clearing a
+    /// tenant slot must NEVER mutate the legacy `access_token` slot, and
+    /// vice versa.
+    #[test]
+    fn test_tenant_device_jwt_slots_round_trip_and_isolation() {
+        let storage = create_test_storage("test_tenant_device_jwt_slots");
+        let tenant_a = uuid::Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap();
+        let tenant_b = uuid::Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").unwrap();
+
+        // Legacy slot seeded first — it must survive everything below.
+        storage.store_tokens("legacy.default.jwt", "").unwrap();
+
+        // Absent before any store.
+        assert!(storage.get_tenant_device_jwt(&tenant_a).unwrap().is_none());
+        assert!(storage.list_tenant_device_jwt_tenants().is_empty());
+
+        // Round-trip both tenants.
+        storage
+            .store_tenant_device_jwt(&tenant_a, "jwt.for.a")
+            .unwrap();
+        storage
+            .store_tenant_device_jwt(&tenant_b, "jwt.for.b")
+            .unwrap();
+        assert_eq!(
+            storage.get_tenant_device_jwt(&tenant_a).unwrap().as_deref(),
+            Some("jwt.for.a")
+        );
+        assert_eq!(
+            storage.get_tenant_device_jwt(&tenant_b).unwrap().as_deref(),
+            Some("jwt.for.b")
+        );
+        let mut listed = storage.list_tenant_device_jwt_tenants();
+        listed.sort();
+        assert_eq!(listed, vec![tenant_a, tenant_b]);
+
+        // Overwrite is in-place (no duplicate slots).
+        storage
+            .store_tenant_device_jwt(&tenant_a, "jwt.for.a.v2")
+            .unwrap();
+        assert_eq!(
+            storage.get_tenant_device_jwt(&tenant_a).unwrap().as_deref(),
+            Some("jwt.for.a.v2")
+        );
+        assert_eq!(storage.list_tenant_device_jwt_tenants().len(), 2);
+
+        // LEGACY-SLOT PRESERVATION: none of the tenant-slot writes touched it.
+        assert_eq!(storage.get_access_token().unwrap(), "legacy.default.jwt");
+
+        // Clearing one tenant leaves the other + the legacy slot intact.
+        storage.clear_tenant_device_jwt(&tenant_a).unwrap();
+        assert!(storage.get_tenant_device_jwt(&tenant_a).unwrap().is_none());
+        assert_eq!(
+            storage.get_tenant_device_jwt(&tenant_b).unwrap().as_deref(),
+            Some("jwt.for.b")
+        );
+        assert_eq!(storage.get_access_token().unwrap(), "legacy.default.jwt");
+        // Idempotent clear.
+        storage.clear_tenant_device_jwt(&tenant_a).unwrap();
+
+        // And the reverse direction: a legacy-slot write leaves tenant slots
+        // untouched.
+        storage.store_tokens("legacy.default.jwt.v2", "").unwrap();
+        assert_eq!(
+            storage.get_tenant_device_jwt(&tenant_b).unwrap().as_deref(),
+            Some("jwt.for.b")
+        );
+    }
+
+    /// The FULL wipe (`clear_tokens`) destroys the per-tenant slots (they are
+    /// bearer credentials); the autonomy-preserving interactive clear keeps
+    /// them, exactly like it keeps the oauth_* credentials.
+    #[test]
+    fn test_tenant_device_jwt_slots_clear_semantics() {
+        let storage = create_test_storage("test_tenant_device_jwt_clear");
+        let tenant = uuid::Uuid::parse_str("cccccccc-cccc-4ccc-8ccc-cccccccccccc").unwrap();
+
+        storage.store_tokens("legacy.jwt", "").unwrap();
+        storage
+            .store_tenant_device_jwt(&tenant, "jwt.tenant")
+            .unwrap();
+
+        // Interactive clear: legacy pair dropped, tenant slots preserved.
+        storage.clear_interactive_session().unwrap();
+        assert!(storage.get_access_token().is_err());
+        assert_eq!(
+            storage.get_tenant_device_jwt(&tenant).unwrap().as_deref(),
+            Some("jwt.tenant")
+        );
+
+        // Full wipe: tenant slots destroyed too.
+        storage.clear_tokens().unwrap();
+        assert!(storage.get_tenant_device_jwt(&tenant).unwrap().is_none());
+        assert!(storage.list_tenant_device_jwt_tenants().is_empty());
+    }
+
+    /// A pre-Phase-1 `StoredTokens` JSON (no `tenant_device_jwts` key) must
+    /// still deserialize, with an empty slot map.
+    #[test]
+    fn test_legacy_stored_tokens_without_tenant_slots_deserializes() {
+        let raw = r#"{"access_token":"a","refresh_token":"r","device_id":"d"}"#;
+        let parsed: StoredTokens = serde_json::from_str(raw).expect("legacy shape must decode");
+        assert!(parsed.tenant_device_jwts.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -92,12 +92,13 @@ struct StoredTokens {
     #[serde(default)]
     agent_machine_key: Option<String>,
     /// Per-tenant coord device-JWT slots (session-scoped multi-tenant
-    /// Phase 1, plan 2026-07-02). Keys are `device_jwt:<tenant_id>`; values
-    /// are the coord-minted device JWTs for that tenant binding. The legacy
+    /// plan 2026-07-02; shipped un-gated as of Phase 8a). Keys are
+    /// `device_jwt:<tenant_id>`; values are the coord-minted device JWTs
+    /// for that tenant binding, written by `pair::persist_pairing` and
+    /// kept fresh by the refresher's per-slot pass. The legacy
     /// `access_token` slot is COMPLETELY UNTOUCHED by these — it keeps
     /// holding the DEFAULT binding's JWT so every unmodified consumer keeps
-    /// working during the compat window. Only populated when the
-    /// `QONTINUI_MULTI_TENANT_JWT=1` flag is on; `#[serde(default)]` keeps
+    /// working during the compat window. `#[serde(default)]` keeps
     /// every pre-Phase-1 `.enc` deserializing. BTreeMap so enumeration is
     /// deterministic.
     #[serde(default)]

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -591,6 +591,14 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
     let base = inner.coord_url.trim_end_matches('/');
     let kind = rec.event_kind.as_str();
 
+    // Phase 8b (plan 2026-07-02-session-scoped-multi-tenant-device-binding
+    // §D4) — per-session credential selection: every push presents the
+    // OWNING SESSION's device-JWT slot. `None` (session tenant unknown —
+    // pre-8b outbox rows, registry gone after restart, single-tenant
+    // installs) keeps the default slot, byte-identical to the old behavior.
+    let tenant = record_session_tenant(inner, rec);
+    let tenant_ref = tenant.as_ref();
+
     let result = match kind {
         "started" => {
             // POST /sessions with the full create body. The runner
@@ -598,14 +606,14 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
             // session start; we just forward it.
             let body = rebuild_create_body(rec);
             let url = format!("{base}/sessions");
-            crate::auth::attach_device_auth(inner.http.post(&url).json(&body))
+            crate::auth::attach_device_auth_for(inner.http.post(&url).json(&body), tenant_ref)
                 .send()
                 .await
         }
         "heartbeat" => {
             let url = format!("{base}/sessions/{}", rec.session_id);
             let body = json!({ "heartbeat": true });
-            crate::auth::attach_device_auth(inner.http.patch(&url).json(&body))
+            crate::auth::attach_device_auth_for(inner.http.patch(&url).json(&body), tenant_ref)
                 .send()
                 .await
         }
@@ -614,20 +622,20 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
             // The payload carries whatever fields the runner changed —
             // forward the subset coord understands.
             let body = state_change_body(&rec.payload);
-            crate::auth::attach_device_auth(inner.http.patch(&url).json(&body))
+            crate::auth::attach_device_auth_for(inner.http.patch(&url).json(&body), tenant_ref)
                 .send()
                 .await
         }
         "closed" => {
             let url = format!("{base}/sessions/{}", rec.session_id);
-            crate::auth::attach_device_auth(inner.http.delete(&url))
+            crate::auth::attach_device_auth_for(inner.http.delete(&url), tenant_ref)
                 .send()
                 .await
         }
         "claim_stolen" => {
             let url = format!("{base}/sessions/{}/steal", rec.session_id);
             let body = steal_body(rec);
-            crate::auth::attach_device_auth(inner.http.post(&url).json(&body))
+            crate::auth::attach_device_auth_for(inner.http.post(&url).json(&body), tenant_ref)
                 .send()
                 .await
         }
@@ -640,7 +648,7 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
             // stamps last_progress_at=now() when the body omits it.
             let url = format!("{base}/sessions/{}", rec.session_id);
             let body = progress_body(&rec.payload);
-            crate::auth::attach_device_auth(inner.http.patch(&url).json(&body))
+            crate::auth::attach_device_auth_for(inner.http.patch(&url).json(&body), tenant_ref)
                 .send()
                 .await
         }
@@ -650,10 +658,15 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
             // Body is the payload verbatim ({repo, branch, shas}); coord
             // resolves the session server-side from (repo, branch). Tenant
             // comes from the X-Qontinui-Tenant-Id header (post_device_register
-            // posture) — mirror `rebuild_create_body`'s machine.json resolve.
+            // posture) — Phase 8b: the OWNING SESSION's binding wins; the
+            // machine.json default only backfills tenant-less legacy rows.
             let url = format!("{base}/coord/commits/report");
-            let mut rb = crate::auth::attach_device_auth(inner.http.post(&url).json(&rec.payload));
-            if let Some(tid) = crate::session::dual_write::resolve_active_tenant_id() {
+            let mut rb = crate::auth::attach_device_auth_for(
+                inner.http.post(&url).json(&rec.payload),
+                tenant_ref,
+            );
+            if let Some(tid) = tenant.or_else(crate::session::dual_write::resolve_active_tenant_id)
+            {
                 rb = rb.header("X-Qontinui-Tenant-Id", tid.to_string());
             }
             rb.send().await
@@ -698,19 +711,55 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
     }
 }
 
+/// Resolve which tenant binding OWNS an outbox record's session — the slot
+/// selector for the per-session credential seam (Phase 8b, plan §D4).
+///
+/// Resolution order:
+/// 1. The record payload — the `started` create body carries the full
+///    intent (whose `tenant_id` the registry stamped at creation), and a
+///    top-level `tenant_id` is honored for future event kinds.
+/// 2. The live [`SessionRegistry`] record for `rec.session_id` — thin
+///    payloads (heartbeat / state_change / closed) carry no intent, but the
+///    registry still holds the session's stamped tenant while it's alive.
+/// 3. `None` — replayed rows for sessions the registry no longer holds
+///    (post-restart) and pre-8b rows. Callers treat `None` as "default
+///    slot", the pre-8b behavior, so nothing regresses.
+fn record_session_tenant(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> Option<Uuid> {
+    let from_payload = rec
+        .payload
+        .get("intent")
+        .and_then(|i| i.get("tenant_id"))
+        .or_else(|| rec.payload.get("tenant_id"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s.trim()).ok());
+    if from_payload.is_some() {
+        return from_payload;
+    }
+    inner
+        .registry
+        .lock()
+        .expect("coord_sync registry slot poisoned")
+        .as_ref()
+        .and_then(Weak::upgrade)
+        .and_then(|reg| reg.describe_by_id(rec.session_id).ok())
+        .and_then(|d| d.intent.tenant_id)
+}
+
 /// Reassemble a `POST /sessions` body from the outbox payload + the row's
 /// machine_id. The session start path writes the create body shape into
 /// `payload` directly (`{id, kind, intent, state, started_at}`), so
 /// rebuilding for the wire is mostly relabeling.
 fn rebuild_create_body(rec: &OutboxRecord) -> JsonValue {
-    // tenant_id resolution order: the intent/payload body (if the operator
-    // or a future resolver supplied it) → the device's `active_tenant_id`
-    // from `~/.qontinui/machine.json` → nil. The machine.json fallback is
-    // what makes a single-tenant operator's sessions visible on their
-    // tenant-scoped dashboard: without it, every session registers under
-    // the nil tenant `00000000-…` and the operator's `/sessions` view (which
-    // scopes to their resolved tenant) shows nothing despite a healthy
-    // pipeline.
+    // tenant_id resolution order: the intent/payload body (Phase 8b: the
+    // registry stamps the session's tenant into the intent at creation —
+    // spawn input or the machine.json default-for-new-sessions, so this arm
+    // is the common case now) → the device's `active_tenant_id` from
+    // `~/.qontinui/machine.json` (pre-8b outbox rows) → nil. The
+    // machine.json fallback is what makes a single-tenant operator's
+    // sessions visible on their tenant-scoped dashboard: without it, every
+    // session registers under the nil tenant `00000000-…` and the
+    // operator's `/sessions` view (which scopes to their resolved tenant)
+    // shows nothing despite a healthy pipeline.
     let intent = rec
         .payload
         .get("intent")
@@ -1092,6 +1141,7 @@ mod tests {
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
+            tenant_id: None,
         }
     }
 
@@ -1326,6 +1376,112 @@ mod tests {
             outbox.pending().map(|p| p.is_empty()).unwrap_or(false)
         })
         .await;
+    }
+
+    /// Phase 8b — an explicit spawn-input tenant survives to the coord
+    /// `POST /sessions` body verbatim (session-create goes explicit).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_forwards_explicit_session_tenant_in_create_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let (base, rec) = spawn_fake_coord().await;
+        let coord = CoordSync::new_for_test(
+            outbox.clone(),
+            base,
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+        );
+        let registry = build_registry(coord.clone());
+        let tenant = Uuid::from_bytes([0x42; 16]);
+        let mut intent = make_test_intent();
+        intent.tenant_id = Some(tenant);
+        let _handle = registry.start(intent).unwrap();
+        let _drain = coord.start_drain_task();
+
+        wait_until(Duration::from_secs(5), || {
+            let r = rec.try_lock();
+            r.map(|g| !g.posts.is_empty()).unwrap_or(false)
+        })
+        .await;
+
+        let g = rec.lock().await;
+        assert_eq!(
+            g.posts[0]["tenant_id"],
+            JsonValue::String(tenant.to_string()),
+            "explicit spawn tenant must land in the create body"
+        );
+        assert_eq!(
+            g.posts[0]["intent"]["tenant_id"],
+            JsonValue::String(tenant.to_string()),
+            "the stamped intent carries the session tenant too"
+        );
+    }
+
+    /// Phase 8b slot-selector resolution: payload intent wins, then the
+    /// top-level payload field, then the live registry record, else None
+    /// (→ default slot, the pre-8b behavior).
+    #[test]
+    fn record_session_tenant_prefers_payload_then_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let coord = CoordSync::new_for_test(
+            outbox,
+            "http://127.0.0.1:1".to_string(),
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+        );
+        let registry = build_registry(coord.clone());
+        let intent_tenant = Uuid::from_bytes([0xA1; 16]);
+        let payload_tenant = Uuid::from_bytes([0xB2; 16]);
+        let registry_tenant = Uuid::from_bytes([0xC3; 16]);
+
+        let mk = |session_id: Uuid, payload: JsonValue| OutboxRecord {
+            machine_id: Uuid::new_v4(),
+            session_id,
+            seq: 1,
+            event_kind: "heartbeat".to_string(),
+            payload,
+            recorded_at: chrono::Utc::now(),
+            acked_at: None,
+        };
+
+        // 1. intent.tenant_id wins over the top-level field.
+        let rec1 = mk(
+            Uuid::new_v4(),
+            json!({
+                "intent": { "tenant_id": intent_tenant.to_string() },
+                "tenant_id": payload_tenant.to_string(),
+            }),
+        );
+        assert_eq!(
+            record_session_tenant(&coord.inner, &rec1),
+            Some(intent_tenant)
+        );
+
+        // 2. top-level payload tenant_id when the intent has none.
+        let rec2 = mk(
+            Uuid::new_v4(),
+            json!({ "tenant_id": payload_tenant.to_string() }),
+        );
+        assert_eq!(
+            record_session_tenant(&coord.inner, &rec2),
+            Some(payload_tenant)
+        );
+
+        // 3. thin payload (heartbeat shape) → the live registry record's
+        //    stamped tenant.
+        let mut intent = make_test_intent();
+        intent.tenant_id = Some(registry_tenant);
+        let handle = registry.start(intent).unwrap();
+        let rec3 = mk(handle.id(), json!({ "at": chrono::Utc::now() }));
+        assert_eq!(
+            record_session_tenant(&coord.inner, &rec3),
+            Some(registry_tenant)
+        );
+
+        // 4. unknown session + thin payload → None (default slot).
+        let rec4 = mk(Uuid::new_v4(), json!({}));
+        assert_eq!(record_session_tenant(&coord.inner, &rec4), None);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -636,6 +636,15 @@ fn build_child_intent(state: &HandoffState) -> Result<Intent, HandoffError> {
         .and_then(|v| v.as_str())
         .map(str::to_string);
 
+    // Phase 8b — carry the SOURCE session's tenant binding across the
+    // handoff (session tenancy is immutable; the child continues the same
+    // tenant's work). Absent on legacy source intents → None, and the
+    // registry stamps this machine's default at materialization.
+    let tenant_id = src
+        .get("tenant_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok());
+
     Ok(Intent {
         kind,
         purpose,
@@ -647,6 +656,7 @@ fn build_child_intent(state: &HandoffState) -> Result<Intent, HandoffError> {
         declared_paths,
         share_output,
         redact_secrets,
+        tenant_id,
     })
 }
 

--- a/src-tauri/src/session/intent.rs
+++ b/src-tauri/src/session/intent.rs
@@ -74,6 +74,18 @@ pub struct Intent {
     /// [`Intent::share_output`] (see [`Intent::effective_redact_secrets`]).
     #[serde(default)]
     pub redact_secrets: Option<bool>,
+    /// Phase 8b (plan `2026-07-02-session-scoped-multi-tenant-device-binding`
+    /// §D4/§D7) — the tenant binding this session runs under, recorded at
+    /// creation: the SPAWN INPUT when the caller supplied one, else the
+    /// device's default (`machine.json::active_tenant_id`,
+    /// default-for-new-sessions), stamped by `SessionRegistry::start`/
+    /// `register_external`. Immutable for the session's life. Drives BOTH
+    /// the `POST /sessions` body's `tenant_id` and which device-JWT slot the
+    /// coord-sync loop presents for this session's writes. `None` only on
+    /// single-tenant installs with no configured default (coord then
+    /// resolves sole-binding server-side).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<uuid::Uuid>,
 }
 
 impl Intent {
@@ -144,6 +156,7 @@ mod tests {
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
+            tenant_id: None,
         }
     }
 
@@ -223,10 +236,28 @@ mod tests {
             declared_paths: vec![PathBuf::from("/repo/path")],
             share_output: true,
             redact_secrets: Some(false),
+            tenant_id: Some(uuid::Uuid::from_bytes([7; 16])),
         };
         let serialized = serde_json::to_string(&i).unwrap();
         let back: Intent = serde_json::from_str(&serialized).unwrap();
         assert_eq!(back, i);
+    }
+
+    #[test]
+    fn tenant_id_none_omits_key_and_some_round_trips() {
+        // `None` serializes WITHOUT the key (skip_serializing_if) so
+        // existing coord rows / consumers see no shape change; a legacy
+        // intent JSON with no tenant_id deserializes to None.
+        let serialized = serde_json::to_string(&good_intent()).unwrap();
+        assert!(!serialized.contains("tenant_id"));
+
+        let t = uuid::Uuid::from_bytes([9; 16]);
+        let mut with_tenant = good_intent();
+        with_tenant.tenant_id = Some(t);
+        let json = serde_json::to_string(&with_tenant).unwrap();
+        assert!(json.contains(&format!("\"tenant_id\":\"{t}\"")));
+        let back: Intent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, with_tenant);
     }
 
     #[test]

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -345,6 +345,22 @@ fn ambient_claude_code_session_id() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Phase 8b (plan `2026-07-02-session-scoped-multi-tenant-device-binding`
+/// §D4/§D7) — record the session's tenant AT CREATION: the spawn input
+/// (`intent.tenant_id`) wins; otherwise the device's default binding
+/// (`machine.json::active_tenant_id`, whose semantics are now
+/// default-for-NEW-sessions). Immutable afterwards — the recorded value
+/// drives both the coord `POST /sessions` body and which device-JWT slot the
+/// coord-sync loop presents for this session's writes. Stays `None` on
+/// single-tenant installs with no configured default (coord resolves
+/// sole-binding server-side, exactly the pre-8b behavior).
+fn stamp_session_tenant(mut intent: Intent) -> Intent {
+    if intent.tenant_id.is_none() {
+        intent.tenant_id = dual_write::resolve_active_tenant_id();
+    }
+    intent
+}
+
 impl SessionRegistry {
     pub fn new(
         machine_id: Uuid,
@@ -387,6 +403,7 @@ impl SessionRegistry {
         parent_session_id: Option<Uuid>,
     ) -> Result<SessionHandle, SessionError> {
         intent.validate()?;
+        let intent = stamp_session_tenant(intent);
 
         let transport = self.transports.pick(intent.kind);
         let transport_handle = transport.start(&intent)?;
@@ -501,6 +518,7 @@ impl SessionRegistry {
     /// off this is never reached.
     pub fn register_external(self: &Arc<Self>, intent: Intent) -> Result<Uuid, SessionError> {
         intent.validate()?;
+        let intent = stamp_session_tenant(intent);
 
         let id = uuid_v7();
         let now = chrono::Utc::now();
@@ -1072,6 +1090,7 @@ mod tests {
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
+            tenant_id: None,
         }
     }
 

--- a/src-tauri/src/session_attribution.rs
+++ b/src-tauri/src/session_attribution.rs
@@ -88,6 +88,16 @@ struct WipAttributionPayload {
     repo: String,
     /// Repo-relative path (joins `coord.primary_trees.dirty_files`).
     file: String,
+    /// Phase 8b (plan 2026-07-02-session-scoped-multi-tenant-device-binding,
+    /// Phase 8 item 7 / D2 site 12): EXPLICIT tenant attribution from the
+    /// owning session's binding — the lifecycle-hosted sessions this
+    /// publisher walks are operator terminal sessions, whose binding is the
+    /// device DEFAULT. Explicit-wins coord-side once Phase 5's resolver
+    /// deploys; today's coord ignores the extra field (serde tolerant).
+    /// Omitted when the runner has no resolvable default (coord then
+    /// resolves device-side, exactly the pre-8b behavior).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tenant_id: Option<uuid::Uuid>,
 }
 
 /// Map an absolute (or backslash) file path to `(repo, file)` IFF it lives
@@ -271,6 +281,12 @@ pub async fn run_attribution_cycle() -> Result<(), String> {
         .map_err(|e| format!("reqwest builder: {e}"))?;
     let url = format!("{base}/coord/wip-attribution");
 
+    // Phase 8b item 7 — explicit tenant attribution. Resolved once per
+    // cycle: every lifecycle-hosted session is an operator terminal session
+    // running under the device's DEFAULT binding (coord-spawned agent
+    // sessions publish through their own agent identity, not this walker).
+    let tenant_id = crate::fleet::resolve_tenant_id();
+
     let mut posted = 0usize;
     for rec in open {
         let session_id = rec.claude_session_id;
@@ -379,6 +395,7 @@ pub async fn run_attribution_cycle() -> Result<(), String> {
                 session_id: session_uuid,
                 repo,
                 file,
+                tenant_id,
             };
             match client.post(&url).json(&payload).send().await {
                 Ok(resp) if resp.status().is_success() => {
@@ -486,6 +503,39 @@ pub fn spawn_session_attribution() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- WipAttributionPayload wire shape (Phase 8b item 7) -------------------
+
+    #[test]
+    fn wip_payload_serializes_explicit_tenant_and_omits_none() {
+        let t = uuid::Uuid::from_bytes([0x77; 16]);
+        let with_tenant = WipAttributionPayload {
+            device_id: uuid::Uuid::nil(),
+            session_id: None,
+            repo: "qontinui-runner".into(),
+            file: "src/main.rs".into(),
+            tenant_id: Some(t),
+        };
+        let v = serde_json::to_value(&with_tenant).unwrap();
+        assert_eq!(
+            v.get("tenant_id").and_then(|x| x.as_str()),
+            Some(t.to_string().as_str()),
+            "explicit tenant must appear on the WIP wire"
+        );
+
+        let without = WipAttributionPayload {
+            device_id: uuid::Uuid::nil(),
+            session_id: None,
+            repo: "qontinui-runner".into(),
+            file: "src/main.rs".into(),
+            tenant_id: None,
+        };
+        let v = serde_json::to_value(&without).unwrap();
+        assert!(
+            v.get("tenant_id").is_none(),
+            "None tenant must be omitted (pre-8b wire shape preserved)"
+        );
+    }
 
     // ---- map_path_to_repo_file ------------------------------------------------
 


### PR DESCRIPTION
Runner slice of the session-scoped multi-tenant device-binding work (Option A — full concurrent). **Ships entirely dark** — per-tenant behavior only lights up once coord Phases 3–5 are deployed.

## ⚠ DRAFT — gated on coord PR deploy
**Deploy order (HARD): web migrations (qontinui-web#730) → coord (qontinui-coord#963) → this runner PR.** Runner has no ordering pressure to land (dark), but kept draft until coord is in so the sequence is clean. See `plans/2026-07-03-multi-tenant-integration-runbook.md`.

## What's in here
- **Phase 1** (`6ce37c07`) — per-tenant device-JWT secure-storage slots (`device_jwt:<tenant_id>`); legacy `access_token` slot holds the default binding. (The `QONTINUI_MULTI_TENANT_JWT` flag was introduced dark here and REMOVED in 8a — now dead.)
- **Phase 8a** (`cf6f14c9`) — `paired_user.json` v2 multi-entry bindings; un-gated per-slot refresher loop; heartbeat binding-set reconciliation (strict no-op against today's coord, which sends no `tenant_ids`).
- **Phase 8b** (`4e2b7ec0`) — per-session credential seam `device_bearer_for(Option<tenant>)` (unparameterized callers get the default slot by construction); explicit publisher tenant payloads; session-tenant selection threaded through the D4 audit list.

## Credential-model union with main's device machine-key
The origin/main merge composed our per-tenant JWT slots with main's Phase-4b device machine-key (`dmk_`) cold-start as an orthogonal union: secure-storage carries both; the refresher does both the machine-key cold-start (when no device JWT exists) and the per-slot refresh (per bound tenant). Machine-key cold-start seeds the default binding's slot.

## Verification
- `cargo check --workspace --all-targets`: OK. `cargo clippy --workspace --tests -- -D warnings`: clean. `cargo fmt --check`: clean.
- `cargo test --bin qontinui-runner -- device_jwt_refresher`: 44 passed (incl. main's machine-key exchange tests + our tenant-slot tests). Lib `secure_storage::`/`auth::`/`pair::`: 85 passed.
- No production routes added (boot-smoke axum-param risk n/a).

## Pending (post-deploy)
- Two-tenant concurrent live acceptance (needs coord P3–5 deployed).
- Phase 1 24h JWT-refresh soak.

Companion: web#730 + coord#963 (upstream, in deploy order).

Plan: `plans/2026-07-02-session-scoped-multi-tenant-device-binding.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)