### PR TITLE
feat(coord-mcp): Phase 0 inject caller agent_session_id on proxied coord_* calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -144,8 +144,8 @@ impl AiCoordRegistrar {
     }
 
     /// R4 — resolve a runner `task_run_id` to its coord `session_id` (the
-    /// durable handle). Useful for the inject-audit / observability path.
-    #[allow(dead_code)]
+    /// durable handle). Consumed by the coord-mcp proxy's caller
+    /// self-identification (session-fabric Phase 0) and the inject-audit path.
     pub fn session_id_for(&self, task_run_id: &str) -> Option<Uuid> {
         self.inner
             .reverse

--- a/src-tauri/src/claude_session/manager.rs
+++ b/src-tauri/src/claude_session/manager.rs
@@ -178,9 +178,9 @@ impl SessionManager {
                 continue;
             };
             let matches = wt.path.to_string_lossy() == workdir
-                || target_canon.as_deref().is_some_and(|tc| {
-                    std::fs::canonicalize(&wt.path).ok().as_deref() == Some(tc)
-                });
+                || target_canon
+                    .as_deref()
+                    .is_some_and(|tc| std::fs::canonicalize(&wt.path).ok().as_deref() == Some(tc));
             if matches {
                 return Some(task_run_id.clone());
             }

--- a/src-tauri/src/claude_session/manager.rs
+++ b/src-tauri/src/claude_session/manager.rs
@@ -157,6 +157,37 @@ impl SessionManager {
         removed
     }
 
+    /// Resolve the `task_run_id` of the active `ClaudeSession` whose isolated
+    /// worktree checkout is `workdir` (session-fabric Phase 0 self-identification).
+    ///
+    /// The coord-mcp loopback proxy knows only the session WORKDIR its
+    /// per-session nonce was provisioned into; this bridges that back to the
+    /// `task_run_id` the `AiCoordRegistrar` keys the coord `agent_session_id`
+    /// on. Matches on the promoted worktree path — the terminal chokepoint
+    /// (`acquire_for_terminal`) provisions the nonce into exactly that dir.
+    ///
+    /// Sessions NOT promoted into a worktree carry no stored cwd to match, so
+    /// they resolve `None`: a documented Phase-0 residual (the proxy then omits
+    /// the caller-session header and coord keeps its fuzzy fallback). O(N) over
+    /// active sessions (bounded by the operator's live terminal count).
+    pub fn task_run_id_for_workdir(&self, workdir: &str) -> Option<String> {
+        let target_canon = std::fs::canonicalize(workdir).ok();
+        let guard = self.sessions.lock().ok()?;
+        for (task_run_id, session) in guard.iter() {
+            let Some(wt) = session.worktree() else {
+                continue;
+            };
+            let matches = wt.path.to_string_lossy() == workdir
+                || target_canon.as_deref().is_some_and(|tc| {
+                    std::fs::canonicalize(&wt.path).ok().as_deref() == Some(tc)
+                });
+            if matches {
+                return Some(task_run_id.clone());
+            }
+        }
+        None
+    }
+
     /// Register an inline (non-interactive) session's PID for stale task sweep visibility.
     /// Unlike `register`, this doesn't require a full ClaudeSession — just the PID.
     pub fn register_inline_pid(&self, task_run_id: &str, pid: u32) {

--- a/src-tauri/src/coord_mcp.rs
+++ b/src-tauri/src/coord_mcp.rs
@@ -356,6 +356,35 @@ fn mint_and_register_nonce(
     (nonce, snapshot)
 }
 
+/// Request header the runner proxy injects on forwarded `coord_*` calls: the
+/// calling terminal's coord `agent_session_id`, so coord self-identifies the
+/// caller deterministically instead of guessing the device's most-recent
+/// session (session-fabric Phase 0). MUST match coord's `CALLER_SESSION_HEADER`.
+pub(crate) const CALLER_SESSION_HEADER: &str = "x-coord-caller-session";
+
+/// `true` when deterministic caller self-identification is enabled
+/// (`COORD_SESSION_SELF_ID=observe`). Off/unset/any-other value ⇒ the proxy
+/// injects nothing and coord keeps its fuzzy fallback — byte-for-byte today's
+/// behavior. Mirrors coord's own gate so both halves arm from one env var.
+pub(crate) fn session_self_id_enabled() -> bool {
+    std::env::var("COORD_SESSION_SELF_ID").as_deref() == Ok("observe")
+}
+
+/// The session WORKDIR a registered proxy nonce was provisioned into (the
+/// terminal's cwd / isolated worktree path). `None` for an empty or
+/// unregistered nonce. Backs session-fabric Phase 0 caller self-identification:
+/// the proxy maps nonce → workdir → task_run_id → coord `agent_session_id`.
+pub(crate) fn workdir_for_nonce(nonce: &str) -> Option<String> {
+    if nonce.is_empty() {
+        return None;
+    }
+    proxy_nonces()
+        .lock()
+        .expect("proxy nonce map poisoned")
+        .get(nonce)
+        .map(|b| b.workdir.clone())
+}
+
 /// True iff `nonce` is a currently-registered per-session proxy key.
 pub(crate) fn proxy_nonce_is_valid(nonce: &str) -> bool {
     !nonce.is_empty()

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -454,7 +454,28 @@ async fn drain_handler(
 /// the body + non-hop-by-hop request headers, return coord's status + headers
 /// + body bytes verbatim. Generic header passthrough keeps us correct if coord
 /// ever adds SSE negotiation headers, but no streaming machinery is built.
+/// Resolve the calling terminal's coord `agent_session_id` for the caller-self
+/// header (session-fabric Phase 0). Bridges the only thing the proxy knows —
+/// the per-session nonce — back to a coord session id:
+/// `nonce → workdir → task_run_id → coord agent_session_id`. Every link is
+/// best-effort; a break anywhere returns `None` (the caller then omits the
+/// header and coord keeps its fuzzy fallback — today's behavior). Pure lookups,
+/// no I/O beyond the in-memory maps + a `canonicalize` in the workdir match.
+fn resolve_caller_session_id(state: &Arc<ApiState>, nonce: Option<&str>) -> Option<uuid::Uuid> {
+    let nonce = nonce?;
+    let workdir = crate::coord_mcp::workdir_for_nonce(nonce)?;
+    let session_manager = state
+        .app_handle
+        .try_state::<Arc<crate::claude_session::SessionManager>>()?;
+    let task_run_id = session_manager.task_run_id_for_workdir(&workdir)?;
+    let registrar = state
+        .app_handle
+        .try_state::<Arc<crate::claude_session::coord_register::AiCoordRegistrar>>()?;
+    registrar.session_id_for(&task_run_id)
+}
+
 async fn coord_mcp_proxy_handler(
+    axum::extract::State(state): axum::extract::State<Arc<ApiState>>,
     headers: axum::http::HeaderMap,
     body: axum::body::Bytes,
 ) -> axum::response::Response {
@@ -585,6 +606,22 @@ async fn coord_mcp_proxy_handler(
     }
     let bearer = bearer.unwrap_or_default(); // gate guarantees Some(non-empty)
 
+    // Session-fabric Phase 0: resolve the calling terminal's OWN coord
+    // agent_session_id so coord self-identifies the caller deterministically
+    // instead of guessing the device's most-recent session. Flag-gated
+    // (COORD_SESSION_SELF_ID=observe); DEVICE principal only — agent-spawn
+    // sessions carry their own scoped identity and are out of scope here.
+    // Best-effort: any missing link (unknown workdir / un-promoted session /
+    // unregistered coord session) yields None ⇒ the header is omitted and coord
+    // falls back to its fuzzy pick (today's behavior).
+    let caller_session_id: Option<uuid::Uuid> = if crate::coord_mcp::session_self_id_enabled()
+        && matches!(&principal, crate::coord_mcp::ProxyPrincipal::Device)
+    {
+        resolve_caller_session_id(&state, nonce.as_deref())
+    } else {
+        None
+    };
+
     // Shared client: connect fast-fail, generous overall timeout (coord MCP
     // tool calls can legitimately run long).
     static COORD_PROXY_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
@@ -600,8 +637,11 @@ async fn coord_mcp_proxy_handler(
     let mut req = client.post(&url).bearer_auth(&bearer).body(body.to_vec());
     for (name, value) in headers.iter() {
         let n = name.as_str();
-        // Hop-by-hop / recomputed headers, plus the two we own: the nonce must
-        // not leak upstream and the Authorization slot is the live bearer.
+        // Hop-by-hop / recomputed headers, plus the ones we own: the nonce must
+        // not leak upstream, the Authorization slot is the live bearer, and the
+        // caller-session header is authoritative ONLY when the RUNNER sets it —
+        // a client-supplied one must never pass through (it could otherwise name
+        // a sibling session on the same device to spoof its identity).
         if matches!(
             n,
             "host"
@@ -611,10 +651,18 @@ async fn coord_mcp_proxy_handler(
                 | "accept-encoding"
                 | "authorization"
         ) || n == crate::coord_mcp::COORD_MCP_PROXY_KEY_HEADER
+            || n == crate::coord_mcp::CALLER_SESSION_HEADER
         {
             continue;
         }
         req = req.header(n, value.as_bytes());
+    }
+    // Inject the runner-resolved caller-session id (Phase 0). Coord still
+    // validates it fail-closed as bound to the caller's device before trusting
+    // it, so this is advisory — but stripping any client copy above means coord
+    // only ever sees the runner's own attribution.
+    if let Some(sid) = caller_session_id {
+        req = req.header(crate::coord_mcp::CALLER_SESSION_HEADER, sid.to_string());
     }
 
     let upstream = match req.send().await {


### PR DESCRIPTION
Phase 0 of plan `2026-07-05-session-identity-messaging-restore-fabric` (7 phases). Runner half of deterministic caller self-identification. Pairs with qontinui-coord#967.

## What
The coord-mcp loopback proxy forwards every `coord_*` call under a live device JWT that carries no session id, so coord could only guess which of the device's sessions is calling. This injects the calling terminal's coord `agent_session_id` as `X-Coord-Caller-Session`.

- Resolve `nonce → workdir → task_run_id → coord agent_session_id`: `workdir_for_nonce` (coord_mcp.rs), `SessionManager::task_run_id_for_workdir` (path-matched against each session's isolated worktree), existing `AiCoordRegistrar::session_id_for`.
- **Documented residual:** a session not promoted into a worktree resolves `None`, so the header is omitted and coord keeps its fuzzy fallback (the plan's "runner-proxied callers only" scope; fully closed by Phase 1's bearer-carried handle).

## Safety
Gated on `COORD_SESSION_SELF_ID=observe`, **DEVICE principal only**. Strips any client-supplied `X-Coord-Caller-Session` before forwarding so a sibling session on the same device can never spoof another's identity; coord still validates the injected id fail-closed. **Flag off or unresolved caller ⇒ header omitted ⇒ byte-for-byte prior behavior.** `cargo check --bin qontinui-runner` clean.