### PR TITLE
feat(spec-ci): log in the headless browser for auth_required apps

### DIFF
--- a/src-tauri/src/mcp/headless_browser.rs
+++ b/src-tauri/src/mcp/headless_browser.rs
@@ -19,10 +19,24 @@ use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
 use super::types::{ApiResponse, ApiState};
+use crate::spec_api::auth_injection::AppCredentials;
 
 // =============================================================================
 // Types
 // =============================================================================
+
+/// Map fetched app credentials to the launcher's login env-var contract.
+///
+/// `headless-launcher.js` reads `QONTINUI_TEST_AUTO_LOGIN_EMAIL` /
+/// `QONTINUI_TEST_AUTO_LOGIN_PASSWORD`, mints a Cognito id token, and seeds the
+/// session before navigating. Pure + testable so the env-var names can't
+/// silently drift out of sync with the launcher.
+fn auth_launcher_env(creds: &AppCredentials) -> [(&'static str, String); 2] {
+    [
+        ("QONTINUI_TEST_AUTO_LOGIN_EMAIL", creds.email.clone()),
+        ("QONTINUI_TEST_AUTO_LOGIN_PASSWORD", creds.password.clone()),
+    ]
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -284,6 +298,33 @@ pub async fn spawn_headless(
         cmd.arg("--headless=false");
     }
 
+    // Authenticated spec CI: if the target app requires auth, fetch its login
+    // credentials and hand them to the launcher via the env vars it already
+    // reads (`headless-launcher.js` mints a Cognito id token from these and
+    // seeds the session before navigating). Env, not argv — the password must
+    // not appear in process listings. Fail-open: a missing/malformed SSM param
+    // logs a warning and spawns UNAUTHENTICATED rather than wedging CI.
+    if let Ok(Some(app)) = state.app_state.pg_db.get_app(&request.app_id).await {
+        if app.auth_required {
+            match crate::spec_api::auth_injection::fetch_app_credentials(&request.app_id).await {
+                Ok(Some(creds)) => {
+                    for (k, v) in auth_launcher_env(&creds) {
+                        cmd.env(k, v);
+                    }
+                    info!(app_id = %request.app_id, "spawn_headless: injected login credentials for auth-required app");
+                }
+                Ok(None) => warn!(
+                    app_id = %request.app_id,
+                    "spawn_headless: auth_required app has no SSM login credentials — spawning UNAUTHENTICATED (fail-open)"
+                ),
+                Err(e) => warn!(
+                    app_id = %request.app_id,
+                    "spawn_headless: auth_required app credential fetch failed ({e}) — spawning UNAUTHENTICATED (fail-open)"
+                ),
+            }
+        }
+    }
+
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
     // Prevent child from blocking on stdin
@@ -409,4 +450,24 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
     }
 
     r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_launcher_env_maps_to_the_launchers_contract() {
+        let creds = AppCredentials {
+            email: "spec-ci@example.com".into(),
+            password: "s3cr3t".into(),
+        };
+        let env = auth_launcher_env(&creds);
+        // Names MUST match what headless-launcher.js reads, or login silently
+        // never happens.
+        assert_eq!(env[0].0, "QONTINUI_TEST_AUTO_LOGIN_EMAIL");
+        assert_eq!(env[0].1, "spec-ci@example.com");
+        assert_eq!(env[1].0, "QONTINUI_TEST_AUTO_LOGIN_PASSWORD");
+        assert_eq!(env[1].1, "s3cr3t");
+    }
 }

--- a/src-tauri/src/spec_api/auth_injection.rs
+++ b/src-tauri/src/spec_api/auth_injection.rs
@@ -1,42 +1,35 @@
-//! Authentication injection for spec CI workflows.
+//! Credential fetching for authenticated spec CI.
 //!
-//! Provides automatic login step generation and credential fetching for apps
-//! requiring authentication. When a spec workflow targets an app with
-//! `auth_required=true`, this module:
+//! When a spec-CI headless browser targets an app with `auth_required=true`,
+//! `headless_browser::spawn_headless` calls [`fetch_app_credentials`] to pull a
+//! Cognito test user's `{email, password}` from AWS SSM Parameter Store
+//! (`/qontinui/apps/{app_id}/login`), then passes them to the Playwright
+//! launcher's login env vars. The launcher (`scripts/headless-launcher.js`)
+//! mints a Cognito id token from those credentials and seeds the session before
+//! navigating — so the snapshot is taken against the authenticated page, not the
+//! login screen.
 //!
-//! 1. Fetches login credentials from AWS SSM Parameter Store
-//! 2. Generates a deterministic auth setup step (shell command mode)
-//! 3. Prepends the auth step to the workflow's setup phase
-//!
-//! **Fail-Open Design:** If credentials cannot be fetched or auth fails,
-//! the workflow continues without authentication. Spec-check will run
-//! against the app's login page or partially-authenticated state.
+//! **Fail-Open Design:** if credentials cannot be fetched, `spawn_headless`
+//! spawns unauthenticated (warn-and-continue) rather than wedging CI. Only a
+//! parameter that EXISTS but is malformed returns `Err` (operator misconfig).
 
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
-
-use qontinui_types::workflow_step::{BaseStepFields, CommandMode, CommandStep, CommandStepPhase};
 
 // ============================================================================
 // Types
 // ============================================================================
 
-/// Credentials for app login retrieved from AWS SSM.
+/// Credentials for app login retrieved from AWS SSM. Consumed by
+/// `headless_browser::spawn_headless`, which hands `email`/`password` to the
+/// Playwright launcher's Cognito login env vars. (Login is Cognito
+/// token-mint, not form-fill — so no CSS-selector fields.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppCredentials {
-    /// Email or username for login
+    /// Cognito user email (username) for login
     pub email: String,
-    /// Password for login
+    /// Cognito user password for login
     pub password: String,
-    /// Optional CSS selector for email field (defaults to common patterns)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub email_selector: Option<String>,
-    /// Optional CSS selector for password field (defaults to common patterns)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub password_selector: Option<String>,
-    /// Optional CSS selector for login button (defaults to common patterns)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub login_button_selector: Option<String>,
 }
 
 /// Errors that can occur during auth step generation or credential fetching.
@@ -63,98 +56,13 @@ impl std::fmt::Display for AuthInjectionError {
 impl std::error::Error for AuthInjectionError {}
 
 // ============================================================================
-// Step Generation
-// ============================================================================
-
-/// Generate an authentication setup step for an app requiring login.
-///
-/// Creates a deterministic command-mode step that:
-/// 1. Navigates to the app's login page (via curl)
-/// 2. Enters email and password (via UI Bridge execute actions)
-/// 3. Submits the login form
-/// 4. Waits for successful redirect
-///
-/// # Fail-Open Behavior
-///
-/// If credentials are `None`, returns `Ok(None)` and logs a debug message.
-/// The caller should skip auth step injection when `None` is returned.
-///
-/// # Properties
-///
-/// - `id`: `auth-setup-{app_id}-{uuid}`
-/// - `name`: "Authenticate with {app_name}"
-/// - `phase`: `setup` (always the first phase)
-/// - `mode`: `shell` (command mode, deterministic)
-/// - `required`: `false` (fail-open: login failures don't halt the workflow)
-/// - `timeout_seconds`: 30
-/// - `fail_on_error`: `false` (login failures are recoverable)
-pub async fn create_auth_setup_step(
-    app_id: &str,
-    app_name: &str,
-    ui_bridge_url: &str,
-    credentials: Option<AppCredentials>,
-) -> Result<Option<CommandStep>, AuthInjectionError> {
-    // If credentials were not fetched, log and return None (fail-open)
-    let creds = match credentials {
-        Some(c) => c,
-        None => {
-            debug!(
-                app_id = %app_id,
-                "auth injection skipped: no credentials available (fail-open)"
-            );
-            return Ok(None);
-        }
-    };
-
-    // Generate a unique step ID
-    let step_id = format!("auth-setup-{}-{}", app_id, uuid::Uuid::new_v4());
-
-    // Build the login command sequence.
-    // This is a simplified approach using shell commands and UI Bridge calls.
-    // In production, this could be enhanced to:
-    // - Support multiple login pages (redirect detection)
-    // - Handle CSRF tokens and cookies
-    // - Support OAuth flows via browser
-    let command = format!(
-        "echo \"Authenticating to {}...\"; \
-        curl -s -X GET \"{}\" -L -I > /dev/null; \
-        sleep 1; \
-        echo \"Login credentials will be entered via UI Bridge\"",
-        app_name, ui_bridge_url
-    );
-
-    let step = CommandStep {
-        base: BaseStepFields {
-            id: step_id,
-            name: format!("Authenticate with {}", app_name),
-            fail_on_console_errors: Some(false),
-            ..Default::default()
-        },
-        phase: CommandStepPhase::Setup,
-        mode: Some(CommandMode::Shell),
-        command: Some(command),
-        timeout_seconds: Some(30),
-        fail_on_error: Some(false), // Fail-open: don't halt workflow on auth failure
-        ..Default::default()
-    };
-
-    info!(
-        app_id = %app_id,
-        step_id = %step.base.id,
-        "generated authentication setup step"
-    );
-
-    Ok(Some(step))
-}
-
-// ============================================================================
 // Credential Fetching
 // ============================================================================
 
 /// Fetch app credentials from AWS SSM Parameter Store.
 ///
 /// Retrieves the SecureString parameter `/qontinui/apps/{app_id}/login`
-/// (JSON: `{"email": "...", "password": "...", "email_selector"?: ...}`)
+/// (JSON: `{"email": "...", "password": "..."}` — a Cognito test user)
 /// by shelling out to the `aws` CLI. The CLI is the fleet's established
 /// SSM access path (dev machines and CI carry configured CLIs; the runner
 /// deliberately has no AWS SDK dependency — adding aws-config/aws-sdk-ssm
@@ -290,39 +198,19 @@ mod tests {
 
     #[test]
     fn app_credentials_deserializes_from_json() {
+        // Unknown fields (e.g. legacy selector keys still in an SSM param) are
+        // ignored by serde default — only email + password are read.
         let json = r#"
         {
             "email": "test@example.com",
             "password": "secret",
-            "email_selector": "[name='email']",
-            "password_selector": "[name='password']",
-            "login_button_selector": "[type='submit']"
+            "email_selector": "ignored-legacy-field"
         }
         "#;
 
         let creds: AppCredentials = serde_json::from_str(json).unwrap();
         assert_eq!(creds.email, "test@example.com");
         assert_eq!(creds.password, "secret");
-        assert_eq!(creds.email_selector, Some("[name='email']".into()));
-        assert_eq!(creds.password_selector, Some("[name='password']".into()));
-        assert_eq!(creds.login_button_selector, Some("[type='submit']".into()));
-    }
-
-    #[test]
-    fn app_credentials_selectors_optional() {
-        let json = r#"
-        {
-            "email": "test@example.com",
-            "password": "secret"
-        }
-        "#;
-
-        let creds: AppCredentials = serde_json::from_str(json).unwrap();
-        assert_eq!(creds.email, "test@example.com");
-        assert_eq!(creds.password, "secret");
-        assert_eq!(creds.email_selector, None);
-        assert_eq!(creds.password_selector, None);
-        assert_eq!(creds.login_button_selector, None);
     }
 
     #[test]
@@ -351,13 +239,12 @@ mod tests {
 
     #[test]
     fn parse_valid_envelope_returns_creds() {
-        let value = r##"{"email":"a@b.c","password":"pw","email_selector":"#e"}"##;
+        let value = r#"{"email":"a@b.c","password":"pw"}"#;
         let creds = parse_ssm_get_parameter_output(&envelope(value), "/p")
             .unwrap()
             .expect("creds");
         assert_eq!(creds.email, "a@b.c");
         assert_eq!(creds.password, "pw");
-        assert_eq!(creds.email_selector, Some("#e".into()));
     }
 
     #[test]


### PR DESCRIPTION
## What
Makes `App.auth_required` actually do something. It was stored in the DB but never read — so spec CI against an auth-gated app matched against the **login page**, silently producing garbage match rates. This wires it into working behavior.

## How
`spawn_headless` (`mcp/headless_browser.rs`) now fetches the target app and, when `auth_required`, pulls a Cognito test user's `{email,password}` from SSM via `fetch_app_credentials` and sets the launcher's **existing** login env vars (`QONTINUI_TEST_AUTO_LOGIN_EMAIL/PASSWORD`). `scripts/headless-launcher.js` already mints a Cognito id token from those and seeds the session before navigating — so the snapshot is taken against the authenticated page. **No launcher change needed.**

- Password via `.env()`, never argv (not visible in process listings).
- **Fail-open:** missing/malformed SSM creds → `warn!` + spawn unauthenticated, never wedge CI.
- Pure `auth_launcher_env` helper + unit test pins the env-var names to the launcher's contract so they can't silently drift.

## Cleanup (the vet finding)
`auth_injection.rs` was built on a wrong model — prepend a form-fill `CommandStep` to a spec 'workflow' that doesn't exist, with CSS selectors the Cognito launcher never uses. Deleted `create_auth_setup_step`, dropped the three selector fields from `AppCredentials`, rewrote the module doc. Kept `fetch_app_credentials` + SSM parse tests. Net −52 lines.

## Verified
`cargo check --tests`, `clippy -- -D warnings`, `cargo fmt --check` all clean; `auth_injection` 8/8 + the helper test pass.

## Known limitation (v1)
The launcher mints against one Cognito pool (`QONTINUI_COGNITO_CI_CLIENT_ID`/`_REGION`, env-overridable). v1 authenticates apps in that pool (qontinui-web spec CI — the actual current need); a different-pool app would need per-app client-id/region plumbed through — noted for a follow-up, no such app exists yet.

Plan: `2026-07-05-spec-ci-browser-side-auth-login`.