### PR TITLE
fix(apps): adopt qontinui-types 0.8.0 apps fields — unbreak main + drain the merge train

### DIFF
--- a/src-tauri/src/database/pg/apps.rs
+++ b/src-tauri/src/database/pg/apps.rs
@@ -44,6 +44,9 @@ fn row_to_app(r: &tokio_postgres::Row) -> App {
         auth_required: auth_required.unwrap_or(false),
         red_threshold: red_threshold.unwrap_or(0.5),
         yellow_threshold: yellow_threshold.unwrap_or(0.8),
+        update_strategy: "pull_only".to_string(),
+        build_command: None,
+        start_command: None,
     }
 }
 
@@ -345,6 +348,9 @@ pub async fn bootstrap_dev_apps(pg: &PgDb) -> Result<(), AppError> {
         auth_required: false,
         red_threshold: 0.5,
         yellow_threshold: 0.8,
+        update_strategy: "pull_only".to_string(),
+        build_command: None,
+        start_command: None,
     }];
 
     if let Some(root) = web_root {
@@ -356,6 +362,9 @@ pub async fn bootstrap_dev_apps(pg: &PgDb) -> Result<(), AppError> {
             auth_required: false,
             red_threshold: 0.5,
             yellow_threshold: 0.8,
+            update_strategy: "pull_only".to_string(),
+            build_command: None,
+            start_command: None,
         });
     }
 
@@ -368,6 +377,9 @@ pub async fn bootstrap_dev_apps(pg: &PgDb) -> Result<(), AppError> {
             auth_required: false,
             red_threshold: 0.5,
             yellow_threshold: 0.8,
+            update_strategy: "pull_only".to_string(),
+            build_command: None,
+            start_command: None,
         });
     }
 
@@ -444,6 +456,9 @@ mod tests {
             auth_required: false,
             red_threshold: 0.5,
             yellow_threshold: 0.8,
+            update_strategy: "pull_only".to_string(),
+            build_command: None,
+            start_command: None,
         }
     }
 
@@ -497,6 +512,9 @@ mod tests {
             auth_required: false,
             red_threshold: 0.5,
             yellow_threshold: 0.8,
+            update_strategy: "pull_only".to_string(),
+            build_command: None,
+            start_command: None,
         };
         let err = pg
             .insert_app(&req)
@@ -578,6 +596,9 @@ mod tests {
             auth_required: None,
             red_threshold: None,
             yellow_threshold: None,
+            update_strategy: None,
+            build_command: None,
+            start_command: None,
         };
         let updated = pg.update_app(&app_id, &patch).await.expect("update_app");
         assert_eq!(updated.ui_bridge_url, new_url);
@@ -613,6 +634,9 @@ mod tests {
             auth_required: Some(true),
             red_threshold: Some(0.55),
             yellow_threshold: Some(0.85),
+            update_strategy: None,
+            build_command: None,
+            start_command: None,
         };
         let updated = pg.update_app(&app_id, &patch).await.expect("update_app");
         assert!(updated.auth_required);

--- a/src-tauri/src/spec_api/apps.rs
+++ b/src-tauri/src/spec_api/apps.rs
@@ -67,6 +67,11 @@ pub fn app_error_into_response(err: AppError) -> Response {
             "already-registered",
             json!({ "appId": app_id }),
         ),
+        AppError::InvalidUpdateStrategy { update_strategy } => (
+            StatusCode::BAD_REQUEST,
+            "invalid-update-strategy",
+            json!({ "updateStrategy": update_strategy }),
+        ),
     };
     (status, Json(SpecError::with_detail(reason, detail))).into_response()
 }

--- a/src-tauri/src/spec_api/proposals.rs
+++ b/src-tauri/src/spec_api/proposals.rs
@@ -1487,6 +1487,9 @@ mod tests {
                 auth_required: false,
                 red_threshold: 0.5,
                 yellow_threshold: 0.8,
+                update_strategy: "pull_only".to_string(),
+                build_command: None,
+                start_command: None,
             })
             .await
             .expect("insert_app");
@@ -1545,6 +1548,9 @@ mod tests {
                 auth_required: false,
                 red_threshold: 0.5,
                 yellow_threshold: 0.8,
+                update_strategy: "pull_only".to_string(),
+                build_command: None,
+                start_command: None,
             })
             .await
             .expect("insert_app");

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -2156,6 +2156,9 @@ mod tests {
             auth_required: false,
             red_threshold: 0.5,
             yellow_threshold: 0.8,
+            update_strategy: "pull_only".to_string(),
+            build_command: None,
+            start_command: None,
         };
         pg.insert_app(&req).await.expect("insert app");
 

--- a/src-tauri/src/spec_api/tests.rs
+++ b/src-tauri/src/spec_api/tests.rs
@@ -906,6 +906,9 @@ mod handler_tests {
             auth_required: false,
             red_threshold: 0.5,
             yellow_threshold: 0.8,
+            update_strategy: "pull_only".to_string(),
+            build_command: None,
+            start_command: None,
         };
         pg.insert_app(&req).await.expect("insert app");
 


### PR DESCRIPTION
## Summary

Unbreaks `qontinui-runner` `main` — currently red on CI, wedging the entire runner merge train (**8 green PRs stuck up to 60h**).

**Root cause: cross-repo schema drift.** Runner builds `qontinui-types` via a **path dependency** (`../../qontinui-schemas/rust`). When `qontinui-schemas` v0.8.0 landed the auto-fresh-engine `apps` fields (PR #676) — `update_strategy` / `build_command` / `start_command` on `App`+`RegisterAppRequest`, plus the `AppError::InvalidUpdateStrategy` variant — every runner build immediately began failing to compile (`E0063` missing fields, `E0004` non-exhaustive match) with **no runner commit involved**. main went red, so coord correctly refused to land anything onto it, and the whole train froze.

Confirmed the failure is real (GitHub's `b261dafc` tree lacks the fields/arm; `cargo check` against schema v0.8.0 fails with 5 errors) — not a coord defect.

## Change

Fill the three new fields at every `App`/`RegisterAppRequest` constructor (default `pull_only` / `None`, matching the current `SELECT` which does not yet read these columns) and handle the new `AppError::InvalidUpdateStrategy` variant (400 `invalid-update-strategy`). Test-site constructors updated too.

## Test plan

- `cargo check --bin qontinui-runner` clean against schema v0.8.0 (was 5 compile errors).
- CI must go green; once landed, the 8 stuck PRs' speculative merges compile and the train drains.

Follow-up (separate remediation plan): runner CI has no guard against this cross-repo path-dep drift, and the 60h wedge fired no stuck-train alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
