### PR TITLE
fix(windows): suppress console windows on background subprocess spawns (CREATE_NO_WINDOW)

### DIFF
--- a/src-tauri/src/agent_pusher/mod.rs
+++ b/src-tauri/src/agent_pusher/mod.rs
@@ -332,7 +332,7 @@ async fn push_one(
     // coord's git-http gate is Bearer-only and rejects basic-auth, so the
     // agent JWT goes in an `Authorization: Bearer` header (not the URL).
     // `-c http.extraHeader=...` scopes the header to this one push.
-    let out = Command::new("git")
+    let out = crate::process_helpers::tokio_no_window("git")
         .arg("-C")
         .arg(&target.worktree_path)
         .arg("-c")

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -3284,7 +3284,7 @@ async fn materialize_worktrees(payload: &LaunchPayload) -> anyhow::Result<()> {
             );
             continue;
         }
-        let out = Command::new("git")
+        let out = crate::process_helpers::tokio_no_window("git")
             .args([
                 "-C",
                 repo_root
@@ -3497,7 +3497,7 @@ pub(crate) fn agent_git_identity_env() -> Vec<(String, String)> {
 /// box still attributes autonomous commits to its owner with zero config.
 fn host_git_identity() -> (Option<String>, Option<String>) {
     fn get(args: &[&str]) -> Option<String> {
-        std::process::Command::new("git")
+        crate::process_helpers::no_window("git")
             .args(args)
             .output()
             .ok()
@@ -3545,7 +3545,7 @@ fn pick_autonomous_git_identity(
 /// them.
 async fn spawn_claude_child(workdir: &str, initial_prompt: &str) -> anyhow::Result<Child> {
     let bin = claude_bin_path();
-    let mut cmd = Command::new(&bin);
+    let mut cmd = crate::process_helpers::tokio_no_window(&bin);
     cmd.current_dir(workdir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -533,7 +533,7 @@ fn git_registered_worktrees(canonical: &Path) -> Vec<PathBuf> {
         Some(s) => s,
         None => return Vec::new(),
     };
-    let out = match Command::new("git")
+    let out = match crate::process_helpers::no_window("git")
         .args(["-C", canonical_str, "worktree", "list", "--porcelain"])
         .output()
     {
@@ -589,7 +589,7 @@ fn git_capture(worktree: &Path, args: &[&str]) -> Option<String> {
     let wt = worktree.to_str()?;
     let mut full: Vec<&str> = vec!["-C", wt];
     full.extend_from_slice(args);
-    let out = Command::new("git").args(&full).output().ok()?;
+    let out = crate::process_helpers::no_window("git").args(&full).output().ok()?;
     if out.status.success() {
         Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
     } else {
@@ -620,7 +620,7 @@ fn compute_landed_in_main(worktree: &Path) -> Option<bool> {
     let wt = worktree.to_str()?;
 
     // (1) Ancestry test — exit 0 means HEAD is an ancestor of origin/main.
-    if let Ok(status) = Command::new("git")
+    if let Ok(status) = crate::process_helpers::no_window("git")
         .args([
             "-C",
             wt,

--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -589,7 +589,10 @@ fn git_capture(worktree: &Path, args: &[&str]) -> Option<String> {
     let wt = worktree.to_str()?;
     let mut full: Vec<&str> = vec!["-C", wt];
     full.extend_from_slice(args);
-    let out = crate::process_helpers::no_window("git").args(&full).output().ok()?;
+    let out = crate::process_helpers::no_window("git")
+        .args(&full)
+        .output()
+        .ok()?;
     if out.status.success() {
         Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
     } else {

--- a/src-tauri/src/agent_worktree/maintenance_executor.rs
+++ b/src-tauri/src/agent_worktree/maintenance_executor.rs
@@ -137,7 +137,7 @@ pub enum MaintenanceAction {
 /// Run `git -C <dir> <args>` capturing output. `Ok((success, stdout, stderr))`
 /// — `success` is the process exit status. `Err` only on spawn failure.
 fn git_capture(dir: &str, args: &[&str]) -> Result<(bool, String, String), String> {
-    let out = std::process::Command::new("git")
+    let out = crate::process_helpers::no_window("git")
         .arg("-C")
         .arg(dir)
         .args(args)

--- a/src-tauri/src/agent_worktree/reclaim.rs
+++ b/src-tauri/src/agent_worktree/reclaim.rs
@@ -359,7 +359,7 @@ fn remove_worktree(path: &Path) -> Result<(), String> {
     }
     let path_str = path.to_string_lossy().to_string();
     // `git -C <wt> worktree remove --force <wt>` prunes the registration.
-    let git_ok = std::process::Command::new("git")
+    let git_ok = crate::process_helpers::no_window("git")
         .args(["-C", &path_str, "worktree", "remove", "--force", &path_str])
         .output()
         .map(|o| o.status.success())
@@ -422,7 +422,7 @@ fn create_junction(link: &Path, target: &Path) -> Result<(), String> {
         }
     }
     // `cmd /C mklink /J <link> <target>` — /J = directory junction.
-    let out = std::process::Command::new("cmd")
+    let out = crate::process_helpers::no_window("cmd")
         .args([
             "/C",
             "mklink",
@@ -468,7 +468,7 @@ fn worktree_is_dirty(path: &Path) -> bool {
         Some(s) => s,
         None => return false,
     };
-    std::process::Command::new("git")
+    crate::process_helpers::no_window("git")
         .args(["-C", path_str, "status", "--porcelain"])
         .output()
         .map(|o| o.status.success() && !o.stdout.is_empty())

--- a/src-tauri/src/auto_commit.rs
+++ b/src-tauri/src/auto_commit.rs
@@ -182,7 +182,7 @@ fn has_staged_diff_for(cwd: &Path, paths: &[&str]) -> Result<bool, String> {
     let mut args: Vec<&str> = vec!["diff", "--cached", "--quiet", "--"];
     args.extend(paths.iter().copied());
 
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(&args)
         .current_dir(cwd)
         .output()

--- a/src-tauri/src/commands/command_interpreter.rs
+++ b/src-tauri/src/commands/command_interpreter.rs
@@ -133,7 +133,7 @@ pub async fn command_interpret(
         tools_json, text
     );
 
-    let output = Command::new("claude")
+    let output = crate::process_helpers::tokio_no_window("claude")
         .arg("-p")
         .arg("--output-format")
         .arg("json")

--- a/src-tauri/src/commands/instances.rs
+++ b/src-tauri/src/commands/instances.rs
@@ -298,7 +298,7 @@ pub async fn list_repo_worktrees(repo_root: String) -> Result<Vec<DevLoopWorktre
         _ => root_path,
     };
 
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .arg("-C")
         .arg(git_root)
         .args(["worktree", "list", "--porcelain"])

--- a/src-tauri/src/commands/state_machine_configs.rs
+++ b/src-tauri/src/commands/state_machine_configs.rs
@@ -327,7 +327,7 @@ process.stdout.write(emitPersistedStateMachineJSON(result.states, result.transit
         .parent()
         .unwrap_or(std::path::Path::new(&project_root));
 
-    let output = tokio::process::Command::new("node")
+    let output = crate::process_helpers::tokio_no_window("node")
         .arg("-e")
         .arg(&script)
         .current_dir(working_dir)

--- a/src-tauri/src/constraint_engine/evaluator.rs
+++ b/src-tauri/src/constraint_engine/evaluator.rs
@@ -448,7 +448,7 @@ impl ConstraintEngine {
             }];
         }
 
-        let mut child = match std::process::Command::new(parts[0])
+        let mut child = match crate::process_helpers::no_window(parts[0])
             .args(&parts[1..])
             .current_dir(&working_dir)
             .stdout(std::process::Stdio::piped())

--- a/src-tauri/src/credential_helper.rs
+++ b/src-tauri/src/credential_helper.rs
@@ -118,7 +118,7 @@ async fn fetch_registered_repos(coord_base: &str) -> Result<Vec<String>, String>
 }
 
 fn is_git_repo(working_dir: &Path) -> bool {
-    std::process::Command::new("git")
+    crate::process_helpers::no_window("git")
         .args([
             "-C",
             &working_dir.to_string_lossy(),
@@ -141,7 +141,7 @@ fn set_git_credential_helper(
     let config_str = config_path.to_string_lossy().replace('\\', "/");
     let helper_value = format!("{binary_str} --config {config_str}");
 
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args([
             "-C",
             &working_dir.to_string_lossy(),

--- a/src-tauri/src/dirty_poller/mod.rs
+++ b/src-tauri/src/dirty_poller/mod.rs
@@ -334,7 +334,7 @@ pub async fn tick_once(state: &Arc<DirtyPollerState>) -> Result<bool> {
 /// `git status --porcelain` + `git diff --shortstat HEAD` for one
 /// worktree.
 async fn read_worktree_dirty(t: &DirtyTarget) -> Result<WorktreeDirty> {
-    let status_out = Command::new("git")
+    let status_out = crate::process_helpers::tokio_no_window("git")
         .arg("-C")
         .arg(&t.worktree_path)
         .arg("status")
@@ -351,7 +351,7 @@ async fn read_worktree_dirty(t: &DirtyTarget) -> Result<WorktreeDirty> {
     }
     let files = parse_porcelain(&String::from_utf8_lossy(&status_out.stdout));
 
-    let shortstat_out = Command::new("git")
+    let shortstat_out = crate::process_helpers::tokio_no_window("git")
         .arg("-C")
         .arg(&t.worktree_path)
         .arg("diff")

--- a/src-tauri/src/drain.rs
+++ b/src-tauri/src/drain.rs
@@ -425,7 +425,7 @@ pub fn restore_wip_ref(
 /// Run a `git -C <repo_dir> <args...>` command, returning trimmed stdout on
 /// success or a descriptive error on non-zero exit / spawn failure.
 fn run_git(repo_dir: &std::path::Path, args: &[&str]) -> Result<String, String> {
-    let mut cmd = std::process::Command::new("git");
+    let mut cmd = crate::process_helpers::no_window("git");
     cmd.arg("-C").arg(repo_dir);
     cmd.args(args);
     let output = cmd

--- a/src-tauri/src/env_agent/collectors.rs
+++ b/src-tauri/src/env_agent/collectors.rs
@@ -213,11 +213,11 @@ pub async fn collect_db_schema() -> Option<Section> {
 /// subprocess pattern.
 fn version_of(cmd: &str, args: &[&str]) -> Option<String> {
     use std::io::Read;
-    use std::process::{Command, Stdio};
+    use std::process::Stdio;
     use std::time::Instant;
 
     let started = Instant::now();
-    let mut child = Command::new(cmd)
+    let mut child = crate::process_helpers::no_window(cmd)
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src-tauri/src/error_monitor/commands.rs
+++ b/src-tauri/src/error_monitor/commands.rs
@@ -473,7 +473,7 @@ pub async fn open_error_in_editor(
 
     // Try VS Code first (most common for developers)
     let vscode_arg = format!("{}:{}:{}", file_path, line, col);
-    let vscode_result = std::process::Command::new("code")
+    let vscode_result = crate::process_helpers::no_window("code")
         .args(["--goto", &vscode_arg])
         .spawn();
 

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -1261,7 +1261,6 @@ fn behind_default_compare_branch<'a>(branch: &str, default_branch: &'a str) -> O
 /// `git` calls use `process_helpers::no_window("git")` so they go through the operator's
 /// PATH-resolved git — same as the rest of the runner.
 fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
-
     let dot_git = repo_path.join(".git");
     if !dot_git.exists() {
         return None;

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -915,7 +915,7 @@ fn claude_probe_ttl() -> Duration {
 /// iff `claude` is invokable AND exits 0 within a 3s budget.
 ///
 /// Cached per [`CLAUDE_PROBE_CACHE`] for [`claude_probe_ttl`]. The
-/// probe is `Command::new("claude").arg("--version")` with stdout +
+/// probe is `no_window("claude").arg("--version")` with stdout +
 /// stderr captured (so a Claude Code that prints to stderr still counts
 /// as available). A child that times out, panics, or never spawns
 /// counts as unavailable.
@@ -941,11 +941,10 @@ pub fn claude_code_probe() -> bool {
 /// Uncached one-shot probe. Pure side-effect (spawns + waits on a
 /// subprocess); should never be called from a hot path directly.
 fn detect_claude_code_now() -> bool {
-    use std::process::Command;
     use std::time::Instant;
 
     let started = Instant::now();
-    let child = Command::new("claude")
+    let child = crate::process_helpers::no_window("claude")
         .arg("--version")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
@@ -1259,10 +1258,9 @@ fn behind_default_compare_branch<'a>(branch: &str, default_branch: &'a str) -> O
 
 /// Capture the state of a single primary git tree at `repo_path`. Returns
 /// `None` when the directory isn't a git repo (no `.git/` dir). All
-/// `git` calls use `Command::new("git")` so they go through the operator's
+/// `git` calls use `process_helpers::no_window("git")` so they go through the operator's
 /// PATH-resolved git — same as the rest of the runner.
 fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
-    use std::process::Command;
 
     let dot_git = repo_path.join(".git");
     if !dot_git.exists() {
@@ -1272,7 +1270,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
     let repo_name = repo_path.file_name()?.to_string_lossy().to_string();
 
     // HEAD SHA
-    let head_sha = Command::new("git")
+    let head_sha = crate::process_helpers::no_window("git")
         .args(["-C", repo_path.to_str()?, "rev-parse", "HEAD"])
         .output()
         .ok()
@@ -1285,7 +1283,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
         })?;
 
     // Current branch (best-effort — detached HEAD returns empty)
-    let symbolic_ref = Command::new("git")
+    let symbolic_ref = crate::process_helpers::no_window("git")
         .args(["-C", repo_path.to_str()?, "symbolic-ref", "--short", "HEAD"])
         .output()
         .ok();
@@ -1304,7 +1302,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
         .unwrap_or_else(|| "(detached)".to_string());
 
     // Dirty status — `git status --porcelain=v1` is one line per change.
-    let status_out = Command::new("git")
+    let status_out = crate::process_helpers::no_window("git")
         .args(["-C", repo_path.to_str()?, "status", "--porcelain=v1"])
         .output()
         .ok()?;
@@ -1353,7 +1351,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
             .max()
     } else {
         // git -C <path> log -1 --format=%cI  — committer-date ISO-8601.
-        Command::new("git")
+        crate::process_helpers::no_window("git")
             .args(["-C", repo_path.to_str()?, "log", "-1", "--format=%cI"])
             .output()
             .ok()
@@ -1383,7 +1381,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
     } else {
         format!("origin/{branch}")
     };
-    let behind_count: Option<i32> = Command::new("git")
+    let behind_count: Option<i32> = crate::process_helpers::no_window("git")
         .args([
             "-C",
             repo_path.to_str()?,
@@ -1408,7 +1406,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
     // line per untracked file. The orphan-untracked-file signal that
     // catches sub-agent worktree builds spilling scratch into the
     // primary tree.
-    let untracked_count: Option<i32> = Command::new("git")
+    let untracked_count: Option<i32> = crate::process_helpers::no_window("git")
         .args([
             "-C",
             repo_path.to_str()?,
@@ -1436,7 +1434,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
     // default branch from `origin/HEAD` (e.g. `origin/main` -> `main`),
     // falling back to `main`. No network fetch — uses last-fetched refs,
     // same posture as `behind_count` above.
-    let default_branch = Command::new("git")
+    let default_branch = crate::process_helpers::no_window("git")
         .args([
             "-C",
             repo_path.to_str()?,
@@ -1456,7 +1454,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
             }
         })
         .unwrap_or_else(|| "main".to_string());
-    let local_ahead: Option<i32> = Command::new("git")
+    let local_ahead: Option<i32> = crate::process_helpers::no_window("git")
         .args([
             "-C",
             repo_path.to_str()?,
@@ -1492,7 +1490,7 @@ fn capture_tree(repo_path: &std::path::Path) -> Option<TreeStatePayload> {
     // an error.
     let behind_default_count: Option<i32> =
         match behind_default_compare_branch(&branch, &default_branch) {
-            Some(cmp) => Command::new("git")
+            Some(cmp) => crate::process_helpers::no_window("git")
                 .args([
                     "-C",
                     repo_path.to_str()?,
@@ -1640,12 +1638,11 @@ fn fetch_due(repo_path: &std::path::Path, now: std::time::Instant) -> bool {
 /// call from a blocking context. Non-zero/spawn errors `warn!` and return — a
 /// stale ref is no worse than skipping the fetch entirely.
 fn fetch_remote_refs_blocking(repo_path: &std::path::Path) {
-    use std::process::Command;
     let path_str = match repo_path.to_str() {
         Some(s) => s,
         None => return,
     };
-    match Command::new("git")
+    match crate::process_helpers::no_window("git")
         .args(["-C", path_str, "fetch", "origin", "--prune"])
         .output()
     {
@@ -1671,8 +1668,7 @@ fn fetch_remote_refs_blocking(repo_path: &std::path::Path) {
 /// Resolve a repo's default branch from `origin/HEAD` (`origin/main` -> `main`),
 /// falling back to `main`. No network — uses the last-fetched symbolic ref.
 fn resolve_default_branch(repo_path: &std::path::Path) -> String {
-    use std::process::Command;
-    Command::new("git")
+    crate::process_helpers::no_window("git")
         .args([
             "-C",
             repo_path.to_str().unwrap_or("."),
@@ -1722,7 +1718,6 @@ fn apply_pull_verdict_blocking(
     hold_reason: Option<&str>,
     restore: Option<RestoreParams>,
 ) -> PullOutcome {
-    use std::process::Command;
     let default_branch = resolve_default_branch(repo_path);
     let repo_str = repo_path.to_str().unwrap_or(".");
 
@@ -1744,7 +1739,7 @@ fn apply_pull_verdict_blocking(
             // Pure local-default ref fast-forward; never touches the checked-out
             // tree. git refuses a non-ff ref update, so an unpushed local
             // default is safe.
-            let out = Command::new("git")
+            let out = crate::process_helpers::no_window("git")
                 .args([
                     "-C",
                     repo_str,
@@ -1793,14 +1788,14 @@ fn apply_pull_verdict_blocking(
             // §5 apply-time safety re-check: branch + clean-tree can change
             // between the decision and now. Re-verify we are STILL on the
             // default branch and the tree is STILL clean before pulling.
-            let cur_branch = Command::new("git")
+            let cur_branch = crate::process_helpers::no_window("git")
                 .args(["-C", repo_str, "symbolic-ref", "--short", "HEAD"])
                 .output()
                 .ok()
                 .filter(|o| o.status.success())
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string());
             let on_default = cur_branch.as_deref() == Some(default_branch.as_str());
-            let clean = Command::new("git")
+            let clean = crate::process_helpers::no_window("git")
                 .args(["-C", repo_str, "status", "--porcelain=v1"])
                 .output()
                 .ok()
@@ -1817,7 +1812,7 @@ fn apply_pull_verdict_blocking(
                 };
             }
             // ff-only pull — the ONLY tree-mutating op the executor performs.
-            let out = Command::new("git")
+            let out = crate::process_helpers::no_window("git")
                 .args([
                     "-C",
                     repo_str,
@@ -1829,7 +1824,7 @@ fn apply_pull_verdict_blocking(
                 .output();
             match out {
                 Ok(o) if o.status.success() => {
-                    let new_sha = Command::new("git")
+                    let new_sha = crate::process_helpers::no_window("git")
                         .args(["-C", repo_str, "rev-parse", "HEAD"])
                         .output()
                         .ok()
@@ -1915,7 +1910,6 @@ fn apply_restore_default_blocking(
     default_branch: &str,
     p: &RestoreParams,
 ) -> PullOutcome {
-    use std::process::Command;
     let pr = p
         .pr_number
         .map(|n| format!("#{n}"))
@@ -1932,7 +1926,7 @@ fn apply_restore_default_blocking(
         };
     }
     // (2) Still on the parked branch coord decided about.
-    let cur_branch = Command::new("git")
+    let cur_branch = crate::process_helpers::no_window("git")
         .args(["-C", repo_str, "symbolic-ref", "--short", "HEAD"])
         .output()
         .ok()
@@ -1949,7 +1943,7 @@ fn apply_restore_default_blocking(
         };
     }
     // (3) Still porcelain-clean (includes untracked).
-    let clean = Command::new("git")
+    let clean = crate::process_helpers::no_window("git")
         .args(["-C", repo_str, "status", "--porcelain=v1"])
         .output()
         .ok()
@@ -1964,7 +1958,7 @@ fn apply_restore_default_blocking(
     }
     // (4) Local HEAD still equals the merged PR's head SHA — the zero-work-loss
     //     proof. A new local commit since the verdict fails this and aborts.
-    let head = Command::new("git")
+    let head = crate::process_helpers::no_window("git")
         .args(["-C", repo_str, "rev-parse", "HEAD"])
         .output()
         .ok()
@@ -1983,7 +1977,7 @@ fn apply_restore_default_blocking(
 
     // Fetch the default ref first so the ff-only merge lands on CURRENT main
     // (the parked tree's origin/<default> may be arbitrarily stale).
-    let fetch = Command::new("git")
+    let fetch = crate::process_helpers::no_window("git")
         .args(["-C", repo_str, "fetch", "origin", default_branch])
         .output();
     if !fetch.as_ref().map(|o| o.status.success()).unwrap_or(false) {
@@ -2002,7 +1996,7 @@ fn apply_restore_default_blocking(
             git_op: None,
         };
     }
-    let switch = Command::new("git")
+    let switch = crate::process_helpers::no_window("git")
         .args(["-C", repo_str, "switch", default_branch])
         .output();
     if !switch.as_ref().map(|o| o.status.success()).unwrap_or(false) {
@@ -2021,7 +2015,7 @@ fn apply_restore_default_blocking(
             git_op: None,
         };
     }
-    let merge = Command::new("git")
+    let merge = crate::process_helpers::no_window("git")
         .args([
             "-C",
             repo_str,
@@ -2061,7 +2055,7 @@ fn apply_restore_default_blocking(
     // an ancestor of the default branch, so -d always refuses it — and the
     // (re-verified) HEAD == merged-PR-head equality above is the actual
     // safety proof (the content is on GitHub as the PR head regardless).
-    let del = Command::new("git")
+    let del = crate::process_helpers::no_window("git")
         .args(["-C", repo_str, "branch", "-D", &p.parked_branch])
         .output();
     let del_note = if del.as_ref().map(|o| o.status.success()).unwrap_or(false) {
@@ -2078,7 +2072,7 @@ fn apply_restore_default_blocking(
                 .unwrap_or_else(|e| format!("spawn failed: {e}"))
         )
     };
-    let new_head = Command::new("git")
+    let new_head = crate::process_helpers::no_window("git")
         .args(["-C", repo_str, "rev-parse", "HEAD"])
         .output()
         .ok()

--- a/src-tauri/src/graphql/mutation.rs
+++ b/src-tauri/src/graphql/mutation.rs
@@ -284,7 +284,7 @@ impl MutationRoot {
             info!("GraphQL: Killing AI process PID {} for task {}", pid, id);
             #[cfg(target_os = "windows")]
             {
-                let _ = std::process::Command::new("taskkill")
+                let _ = crate::process_helpers::no_window("taskkill")
                     .args(["/F", "/T", "/PID", &pid.to_string()])
                     .output();
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,10 @@ pub mod accessibility;
 // Pure logic only — no async, no coord/keyring deps. See the module doc.
 pub mod intercept_core;
 pub mod observable_bridge;
+// Windows CREATE_NO_WINDOW spawn helpers. Declared in BOTH the lib and the
+// runner bin (same file, like `coord_doctor`) so lib-crate modules
+// (`profile_cli`, `env_agent`) can suppress console-window flashes too.
+pub mod process_helpers;
 pub mod profile_cli;
 pub mod profiles;
 pub mod relay_envelopes;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4144,7 +4144,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                             pids_to_kill
                         );
                         for pid in &pids_to_kill {
-                            let result = std::process::Command::new("taskkill")
+                            let result = crate::process_helpers::no_window("taskkill")
                                 .args(["/F", "/T", "/PID", &pid.to_string()])
                                 .output();
                             match result {

--- a/src-tauri/src/mcp/code_semantics/cargo_check.rs
+++ b/src-tauri/src/mcp/code_semantics/cargo_check.rs
@@ -38,7 +38,7 @@ pub fn is_available() -> bool {
 }
 
 fn probe_cargo() -> Result<(), String> {
-    match std::process::Command::new("cargo")
+    match crate::process_helpers::no_window("cargo")
         .arg("--version")
         .output()
     {
@@ -240,7 +240,7 @@ async fn observe(file: &Path, manifest: &Path) -> Envelope {
     let crate_dir = manifest.parent().unwrap_or(Path::new("."));
     let target_dir = isolated_target_dir(manifest);
 
-    let mut cmd = Command::new("cargo");
+    let mut cmd = crate::process_helpers::tokio_no_window("cargo");
     cmd.arg("check")
         .arg("--message-format=json")
         .arg("--manifest-path")

--- a/src-tauri/src/mcp/code_semantics/mypy_check.rs
+++ b/src-tauri/src/mcp/code_semantics/mypy_check.rs
@@ -46,7 +46,10 @@ pub fn is_available() -> bool {
 /// Probe `mypy --version`, then `python -m mypy --version` / `python3 -m mypy`.
 fn probe_mypy() -> MypyInvocation {
     // 1. direct `mypy`
-    if let Ok(out) = crate::process_helpers::no_window("mypy").arg("--version").output() {
+    if let Ok(out) = crate::process_helpers::no_window("mypy")
+        .arg("--version")
+        .output()
+    {
         if out.status.success() {
             return MypyInvocation::Direct;
         }

--- a/src-tauri/src/mcp/code_semantics/mypy_check.rs
+++ b/src-tauri/src/mcp/code_semantics/mypy_check.rs
@@ -45,17 +45,15 @@ pub fn is_available() -> bool {
 
 /// Probe `mypy --version`, then `python -m mypy --version` / `python3 -m mypy`.
 fn probe_mypy() -> MypyInvocation {
-    use std::process::Command as StdCommand;
-
     // 1. direct `mypy`
-    if let Ok(out) = StdCommand::new("mypy").arg("--version").output() {
+    if let Ok(out) = crate::process_helpers::no_window("mypy").arg("--version").output() {
         if out.status.success() {
             return MypyInvocation::Direct;
         }
     }
     // 2. `<python> -m mypy`
     for py in ["python", "python3"] {
-        if let Ok(out) = StdCommand::new(py)
+        if let Ok(out) = crate::process_helpers::no_window(py)
             .args(["-m", "mypy", "--version"])
             .output()
         {
@@ -71,12 +69,12 @@ fn probe_mypy() -> MypyInvocation {
 fn mypy_command(inv: &MypyInvocation, args: &[String]) -> Option<Command> {
     match inv {
         MypyInvocation::Direct => {
-            let mut c = Command::new("mypy");
+            let mut c = crate::process_helpers::tokio_no_window("mypy");
             c.args(args);
             Some(c)
         }
         MypyInvocation::Module(py) => {
-            let mut c = Command::new(py);
+            let mut c = crate::process_helpers::tokio_no_window(py);
             c.arg("-m").arg("mypy").args(args);
             Some(c)
         }

--- a/src-tauri/src/mcp/code_semantics/node_bridge.rs
+++ b/src-tauri/src/mcp/code_semantics/node_bridge.rs
@@ -178,7 +178,7 @@ impl NodeBridge {
             self.node,
             self.script.display()
         );
-        let mut cmd = Command::new(&self.node);
+        let mut cmd = crate::process_helpers::tokio_no_window(&self.node);
         cmd.arg(&self.script)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/src-tauri/src/mcp/development_intelligence.rs
+++ b/src-tauri/src/mcp/development_intelligence.rs
@@ -333,7 +333,7 @@ fn extract_keywords(name: &str) -> Vec<String> {
 // ============================================================================
 
 fn git_last_change(project_path: &Path, file_path: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(["log", "-1", "--format=%aI", "--", file_path])
         .current_dir(project_path)
         .output()
@@ -349,7 +349,7 @@ fn git_last_change(project_path: &Path, file_path: &str) -> Option<String> {
 
 fn git_commit_count_since(project_path: &Path, file_path: &str, days: u32) -> usize {
     let since = format!("--since={} days ago", days);
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(["log", "--oneline", &since, "--", file_path])
         .current_dir(project_path)
         .output();

--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -1077,7 +1077,7 @@ async fn build_recent_git_log(cwd: &str) -> String {
         return String::new();
     }
 
-    let mut cmd = tokio::process::Command::new("git");
+    let mut cmd = crate::process_helpers::tokio_no_window("git");
     cmd.args(["log", "-5", "--oneline"]);
     cmd.current_dir(cwd);
 

--- a/src-tauri/src/mcp/headless_browser.rs
+++ b/src-tauri/src/mcp/headless_browser.rs
@@ -130,7 +130,7 @@ pub async fn launch_headless(
         })?;
 
     // Spawn the Node.js process
-    let mut cmd = tokio::process::Command::new("node");
+    let mut cmd = crate::process_helpers::tokio_no_window("node");
     cmd.arg(script)
         .arg(format!("--url={}", request.url))
         .arg(format!("--timeout={}", timeout));
@@ -273,7 +273,7 @@ pub async fn spawn_headless(
         })?;
 
     // Spawn the Node.js process
-    let mut cmd = tokio::process::Command::new("node");
+    let mut cmd = crate::process_helpers::tokio_no_window("node");
     cmd.arg(script)
         .arg(format!("--url={}", request.url))
         .arg(format!("--timeout={}", timeout));
@@ -344,7 +344,7 @@ pub async fn spawn_headless(
         );
         // Kill the child process since it failed to connect
         if child.id().is_some() {
-            let _ = std::process::Command::new("taskkill")
+            let _ = crate::process_helpers::no_window("taskkill")
                 .args(["/PID", &pid.to_string(), "/F"])
                 .output();
         }

--- a/src-tauri/src/mcp/session_recap.rs
+++ b/src-tauri/src/mcp/session_recap.rs
@@ -950,7 +950,7 @@ fn normalize_import_path(path: &str) -> String {
 }
 
 fn run_git(repo_path: &Path, args: &[&str]) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(args)
         .current_dir(repo_path)
         .output()

--- a/src-tauri/src/mcp/task_runs.rs
+++ b/src-tauri/src/mcp/task_runs.rs
@@ -196,7 +196,7 @@ pub async fn stop_task_run(
     let mut killed_count = 0;
     for pid in &pids_to_kill {
         info!("Killing AI process PID {} for task {}", pid, id);
-        let result = std::process::Command::new("taskkill")
+        let result = crate::process_helpers::no_window("taskkill")
             .args(["/F", "/T", "/PID", &pid.to_string()])
             .output();
 

--- a/src-tauri/src/mcp/ws_bridge_dispatch.rs
+++ b/src-tauri/src/mcp/ws_bridge_dispatch.rs
@@ -125,14 +125,14 @@ pub async fn dispatch_command(command_name: &str, payload: &Value) -> Value {
     let pyproject = bridge_dir.join("pyproject.toml");
     let mut cmd = if pyproject.exists() {
         debug!("ws_bridge_dispatch: using poetry from {:?}", bridge_dir);
-        let mut c = Command::new("poetry");
+        let mut c = crate::process_helpers::tokio_no_window("poetry");
         c.current_dir(&bridge_dir);
         c.arg("run").arg("python").arg("-u");
         c.arg("-m").arg("handlers.dispatch").arg(command_name);
         c
     } else {
         debug!("ws_bridge_dispatch: falling back to system python");
-        let mut c = Command::new("python");
+        let mut c = crate::process_helpers::tokio_no_window("python");
         c.current_dir(&bridge_dir);
         c.arg("-u")
             .arg("-m")

--- a/src-tauri/src/mcp_client/mod.rs
+++ b/src-tauri/src/mcp_client/mod.rs
@@ -615,7 +615,7 @@ impl McpClientManager {
         );
 
         // Build the subprocess command
-        let mut cmd = tokio::process::Command::new(&stdio_config.command);
+        let mut cmd = crate::process_helpers::tokio_no_window(&stdio_config.command);
         cmd.args(&stdio_config.args);
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());

--- a/src-tauri/src/planning_bridge.rs
+++ b/src-tauri/src/planning_bridge.rs
@@ -174,7 +174,7 @@ pub async fn execute_htn_attempt(
         }
     }
 
-    let mut child = tokio::process::Command::new(python)
+    let mut child = crate::process_helpers::tokio_no_window(python)
         .args(["-m", "qontinui.planning_integration"])
         .env("PYTHONPATH", pythonpath)
         .stdin(std::process::Stdio::piped())

--- a/src-tauri/src/productivity/backfill_tasks.rs
+++ b/src-tauri/src/productivity/backfill_tasks.rs
@@ -369,7 +369,7 @@ async fn run_git_log(repo: &str, since: &str) -> Result<String, String> {
     // by a blank line, followed by `--name-only` paths, followed by a
     // blank line before the next commit header.
     let format_arg = "--format=%H%x09%cI%x09%s";
-    let mut cmd = tokio::process::Command::new("git");
+    let mut cmd = crate::process_helpers::tokio_no_window("git");
     cmd.args([
         "log",
         &format!("--since={}", since),

--- a/src-tauri/src/productivity/review.rs
+++ b/src-tauri/src/productivity/review.rs
@@ -612,7 +612,7 @@ fn parse_diff_stat(text: &str) -> (u32, u32, u32) {
 }
 
 async fn run_git(repo_path: &str, args: &[&str]) -> Result<String, String> {
-    let mut cmd = Command::new("git");
+    let mut cmd = crate::process_helpers::tokio_no_window("git");
     cmd.arg("-C")
         .arg(repo_path)
         .args(args)
@@ -793,7 +793,7 @@ async fn run_command_with_timeout(
     cwd: &str,
     timeout_secs: u64,
 ) -> CommandOutcome {
-    let mut cmd = Command::new(program);
+    let mut cmd = crate::process_helpers::tokio_no_window(program);
     cmd.args(args)
         .current_dir(cwd)
         .stdout(Stdio::piped())

--- a/src-tauri/src/profile_cli.rs
+++ b/src-tauri/src/profile_cli.rs
@@ -282,7 +282,7 @@ fn compute_path_addition(current: &str, dir: &str, sep: char) -> Option<String> 
 /// Read the current USER-scope `Path` (Windows). Returns "" when unset.
 #[cfg(windows)]
 fn read_user_path() -> Result<String, String> {
-    let out = std::process::Command::new("powershell")
+    let out = crate::process_helpers::no_window("powershell")
         .args([
             "-NoProfile",
             "-NonInteractive",
@@ -306,7 +306,7 @@ fn read_user_path() -> Result<String, String> {
 /// so a long PATH with special characters survives argument parsing intact.
 #[cfg(windows)]
 fn write_user_path(new_value: &str) -> Result<(), String> {
-    let out = std::process::Command::new("powershell")
+    let out = crate::process_helpers::no_window("powershell")
         .env("QONTINUI_NEW_USER_PATH", new_value)
         .args([
             "-NoProfile",

--- a/src-tauri/src/repo_detection.rs
+++ b/src-tauri/src/repo_detection.rs
@@ -14,7 +14,7 @@ static REGISTERED_REPOS_CACHE: once_cell::sync::Lazy<RwLock<(Instant, HashSet<St
 const CACHE_TTL: Duration = Duration::from_secs(60);
 
 pub fn detect_repo_slug(working_dir: &str) -> Option<String> {
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(["-C", working_dir, "remote", "get-url", "origin"])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())

--- a/src-tauri/src/restate/durable_executor.rs
+++ b/src-tauri/src/restate/durable_executor.rs
@@ -497,7 +497,7 @@ async fn is_stop_requested(app_state: &AppState, execution_id: &str) -> bool {
 /// Get the current git HEAD commit hash for compensation tracking.
 /// Uses the current working directory unless `repo_path` is specified.
 async fn get_current_commit_hash_in(repo_path: Option<&str>) -> Option<String> {
-    let mut cmd = tokio::process::Command::new("git");
+    let mut cmd = crate::process_helpers::tokio_no_window("git");
     cmd.args(["rev-parse", "HEAD"]);
     if let Some(path) = repo_path {
         cmd.current_dir(path);
@@ -523,7 +523,7 @@ async fn get_current_commit_hash() -> Option<String> {
 /// Get the list of files modified since the last commit (unstaged + staged).
 /// Used to populate `WorkflowOutput.files_modified`.
 pub async fn get_modified_files() -> Vec<String> {
-    let output = tokio::process::Command::new("git")
+    let output = crate::process_helpers::tokio_no_window("git")
         .args(["diff", "--name-only", "HEAD"])
         .output()
         .await;

--- a/src-tauri/src/restate/lifecycle.rs
+++ b/src-tauri/src/restate/lifecycle.rs
@@ -110,7 +110,7 @@ fn download_target() -> Result<&'static str, String> {
 
 /// Validate the installed Restate binary version.
 async fn validate_binary_version(binary_path: &Path, expected_version: &str) -> bool {
-    match tokio::process::Command::new(binary_path)
+    match crate::process_helpers::tokio_no_window(binary_path)
         .arg("--version")
         .output()
         .await

--- a/src-tauri/src/spec_api/auth_injection.rs
+++ b/src-tauri/src/spec_api/auth_injection.rs
@@ -185,7 +185,7 @@ pub async fn fetch_app_credentials(
     let region =
         std::env::var("QONTINUI_SSM_REGION").unwrap_or_else(|_| "eu-central-1".to_string());
 
-    let output = tokio::process::Command::new("aws")
+    let output = crate::process_helpers::tokio_no_window("aws")
         .args([
             "ssm",
             "get-parameter",

--- a/src-tauri/src/terminal/commit_report.rs
+++ b/src-tauri/src/terminal/commit_report.rs
@@ -265,7 +265,7 @@ pub fn parse_repo_full_name(remote_url: &str) -> Option<String> {
 
 /// Run a git subcommand in `dir`, returning trimmed stdout on success.
 fn git(dir: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .current_dir(dir)
         .args(args)
         .output()

--- a/src-tauri/src/terminal/coord_warn.rs
+++ b/src-tauri/src/terminal/coord_warn.rs
@@ -237,7 +237,7 @@ fn resolve_repo(working_dir: &str) -> Option<(String, String)> {
 /// `git -C <dir> rev-parse --show-toplevel`, or `None` if `dir` isn't in a
 /// git repo / git is unavailable.
 fn git_toplevel(dir: &Path) -> Option<PathBuf> {
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .arg("-C")
         .arg(dir)
         .args(["rev-parse", "--show-toplevel"])

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -1597,7 +1597,7 @@ impl TerminalSession {
         if let Some(pid) = self.child_pid {
             #[cfg(target_os = "windows")]
             {
-                let _ = std::process::Command::new("taskkill")
+                let _ = crate::process_helpers::no_window("taskkill")
                     .args(["/F", "/T", "/PID", &pid.to_string()])
                     .output();
             }

--- a/src-tauri/src/unified_workflow_executor/multi_agent_pipeline_loop.rs
+++ b/src-tauri/src/unified_workflow_executor/multi_agent_pipeline_loop.rs
@@ -2459,7 +2459,7 @@ impl PipelineShared {
 /// L0 file tree: directory structure only (unique directory paths).
 /// Much smaller than the full file listing — typically 10-50x fewer lines.
 pub(super) fn get_file_tree_l0(project_path: &str) -> String {
-    let output = std::process::Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(["ls-files", "--others", "--cached", "--exclude-standard"])
         .current_dir(project_path)
         .output();

--- a/src-tauri/src/workflow/dag_driver.rs
+++ b/src-tauri/src/workflow/dag_driver.rs
@@ -647,7 +647,7 @@ async fn execute_loop_node(
                     .unwrap_or(1)
             };
             #[cfg(not(target_os = "windows"))]
-            let exit_code = tokio::process::Command::new("bash")
+            let exit_code = crate::process_helpers::tokio_no_window("bash")
                 .arg("-c")
                 .arg(bash_cmd)
                 .status()

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1084,7 +1084,7 @@ fn get_head_commit(repo_path: &Path) -> Result<String, String> {
 }
 
 pub(crate) fn run_git_command(repo_path: &Path, args: &[&str]) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(args)
         .current_dir(repo_path)
         .output()
@@ -1102,7 +1102,7 @@ pub(crate) fn run_git_command(repo_path: &Path, args: &[&str]) -> Result<String,
 }
 
 fn run_git_command_with_status(repo_path: &Path, args: &[&str]) -> Result<String, String> {
-    let output = Command::new("git")
+    let output = crate::process_helpers::no_window("git")
         .args(args)
         .current_dir(repo_path)
         .output()

--- a/src-tauri/src/wrappers/manager.rs
+++ b/src-tauri/src/wrappers/manager.rs
@@ -149,7 +149,7 @@ impl WrapperManager {
             .map_err(|e| format!("failed to allocate port for '{}': {}", wrapper_id, e))?;
         let env = build_env(wrapper_id, &wrapper.manifest);
 
-        let mut cmd = Command::new("node");
+        let mut cmd = crate::process_helpers::tokio_no_window("node");
         cmd.current_dir(&install_path)
             .arg(&entry)
             .env("WRAPPER_PORT", port.to_string())
@@ -503,7 +503,7 @@ fn instant_to_epoch_ms(then: Instant) -> i64 {
 /// pipeline at startup so we can fail fast with a useful error rather
 /// than letting every spawn explode mysteriously.
 pub fn node_available() -> bool {
-    std::process::Command::new("node")
+    crate::process_helpers::no_window("node")
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/src-tauri/src/wrappers/registry.rs
+++ b/src-tauri/src/wrappers/registry.rs
@@ -519,7 +519,7 @@ async fn run_manifest_only(cwd: &Path, entry: &Path) -> Result<String, RegistryE
     let cwd = cwd.to_path_buf();
     let entry = entry.to_path_buf();
     let result = tokio::task::spawn_blocking(move || -> Result<String, String> {
-        let mut cmd = Command::new("node");
+        let mut cmd = crate::process_helpers::no_window("node");
         cmd.current_dir(&cwd)
             .arg(&entry)
             .arg("--manifest-only")


### PR DESCRIPTION
## Symptom (observed live)

The runner is a Tauri GUI process (windows subsystem, no console). Its 30s fleet
heartbeat iterates every registered repo running `git status --porcelain=v1`,
`git rev-parse HEAD`, `git symbolic-ref --short HEAD`, and
`git rev-list --count --left-right origin/main...HEAD` per repo, plus a
`claude --version` probe — all via raw `std::process::Command` /
`tokio::process::Command` without `CREATE_NO_WINDOW`. On Windows, every
console-subsystem child of a GUI parent allocates a fresh console; with Windows
Terminal as the default terminal host that is a **visible terminal window
flash**. Measured on the operator's machine: **~350 windows in 12 minutes**
(one every ~2s = 30s heartbeat x N repos x 4 git calls, plus census/dirty-poller
background paths).

## Root cause

The repo already has the canonical suppression helpers
(`src-tauri/src/process_helpers.rs`: `no_window` / `tokio_no_window` /
`cmd_no_window`), but ~90 spawn sites across 44 files still constructed raw
`Command`s. Every one of those spawns a console-subsystem exe (git, claude,
node, powershell, taskkill, cargo, mypy, aws, gh, poetry, python, bash, ffmpeg
launcher paths, ...) with output captured — none of them wants a window.

## Fix

Mechanical, comprehensive audit of `Command::new(` under `src-tauri/src`:
routed **89 sites in 44 files** through `process_helpers::no_window` (std) /
`process_helpers::tokio_no_window` (tokio). Args/env/cwd/stdio are preserved
exactly — the helpers only add `CREATE_NO_WINDOW` (0x08000000) on Windows and
are transparent passthroughs elsewhere. `process_helpers` is now also exported
from the lib crate (`lib.rs`) so lib-side modules (`profile_cli`, `env_agent`)
can use it — same both-crates pattern as `coord_doctor`.

Priority background paths covered: `fleet.rs` (heartbeat git dirty-status x4,
claude --version probe, update/switch-branch flows),
`agent_worktree/census.rs` (rev-list census), `dirty_poller`, `auto_commit`,
`drain`, `agent_pusher`, `productivity` backfill/review, `mcp/*` tool backends,
`restate`, `mcp_client` stdio server spawns, wrappers, and one-shot command
paths.

## Deliberately left as raw `Command` (audited, with reasons)

- **Visible-by-design:** `commands/ai_settings.rs` (opens a visible
  PowerShell/terminal window for `claude auth login`),
  `commands/execution/system_ops.rs` (`explorer`/`open`/`xdg-open` folder
  reveal), `mcp/shared.rs` (explicit `CREATE_NEW_CONSOLE`).
- **Already flagged:** `orchestration_loop/fix_agent.rs`,
  `process_capture/manager.rs`, `process_capture/process.rs`,
  `mcp/transport/ios.rs` (existing `creation_flags` incl. `CREATE_NO_WINDOW`),
  `pm_detect.rs` (module-local `no_window` wrapper already applied).
- **Non-Windows cfg-gated:** `window_manager.rs` (wmctrl/xdotool/osascript),
  `ai_provider/oauth_refresh.rs` + `coord_doctor.rs` (macOS `security`),
  `graphql/mutation.rs` unix `kill` arm, `terminal/transcript.rs` unix `ps`
  arm, `step_executor/handlers/shell_command.rs` non-Windows bash stub.
- **Test-only code:** `#[cfg(test)]` modules in `agent_runtime.rs`,
  `agent_worktree/{census,mod,fs_observer}.rs`, `auto_commit.rs`, `drain.rs`,
  `fleet.rs`, `git_status_subset.rs`, `worktree.rs`,
  `install_effects_producer/{intercept/mod,registry_creds}.rs`,
  `mcp/code_semantics/mod.rs`.
- **Console-subsystem binaries:** `bin/qontinui_shim.rs` (children inherit the
  shim's own console; no new window is allocated).
- **PTY spawns** (portable-pty/conpty) are unaffected by design.

## Verification

- `cargo check --bin qontinui-runner` clean (isolated `CARGO_TARGET_DIR`).
- No new warnings in touched files (unused `Command` imports cleaned up).
