### PR TITLE
chore(release): bump version to 1.0.2 (no Python for AI Dev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6546,7 +6546,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-runner"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "adb_client",
  "aes-gcm",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "pnpm": {
     "overrides": {
       "@qontinui/shared-types": "^0.6.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qontinui-runner"
-version = "1.0.1"
+version = "1.0.2"
 description = "Desktop app for AI-assisted development: orchestrated AI coding sessions with visual feedback, self-verification, and real-time UI inspection"
 authors = ["Qontinui <contact@qontinui.org>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Qontinui Runner",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "com.qontinui.runner",
   "build": {
     "beforeBuildCommand": "npm run build && npm run bundle:profile-sidecar",


### PR DESCRIPTION
Version bump for the first release after the native-Rust setup wizard (#715).

The runner's **AI Dev functions** — setup/folder-scan, terminal AI sessions, coord, UI Bridge — now require **no external Python**; everything they need ships in the package. The optional GUI-automation executor remains a separate Python sidecar (not bundled in the production binary, by design).

Tagging `v1.0.2` builds the Windows NSIS installer and **auto-publishes** it (via the publish-update-json fix in #701) as the "latest" release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)