### PR TITLE
fix(security): bump crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why

The `security` CI job (`cargo audit`) currently fails on **RUSTSEC-2026-0204** — an invalid pointer dereference in `crossbeam-epoch`'s `fmt::Pointer` impl for `Atomic`/`Shared`. It's the **sole** failing item (`error: 1 vulnerability found`); the other 26 findings are non-failing GTK3/unmaintained warnings. This blocks **every** runner PR right now (e.g. #725).

## Fix

**Remediate, not suppress.** The advisory's own fix is *"Upgrade to >=0.9.20"*, so bump the transitive dep to `0.9.20` — a semver-compatible patch. Only `crossbeam-epoch` changes (version + checksum; 249 deps unchanged); no `--ignore` entry added.

Unblocks the runner `security` gate repo-wide; #725 (AskTheTwin relay fix) picks it up on rebase.