### PR TITLE
fix(release): mark auto-published release as --latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,4 +462,5 @@ jobs:
           gh release edit "v${{ needs.create-release.outputs.release_version }}" \
             --repo "${{ github.repository }}" \
             --draft=false \
-            --prerelease=false
+            --prerelease=false \
+            --latest


### PR DESCRIPTION
The un-draft step (named "mark as latest") never passed `--latest`, so when a prior release was explicitly marked latest, GitHub's "latest" pointer didn't move. v1.0.2 published fine but the download endpoints kept serving v1.0.1 until I set `--latest` by hand. This adds `--latest` so future releases become latest automatically — the last manual step in the release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)