### PR TITLE
feat(runner): brief autonomous claude sessions on runner context

### DIFF
--- a/src-tauri/resources/shell-integration.bash
+++ b/src-tauri/resources/shell-integration.bash
@@ -73,30 +73,23 @@ trap '__qontinui_debug_trap' DEBUG
 
 # ── Claude Code runner context ─────────────────────────────────────────────
 # Wrap the `claude` command so sessions launched from this terminal
-# automatically know they are running inside the Qontinui Runner.
+# automatically know they are running inside the Qontinui Runner. The briefing
+# text is the SINGLE SOURCE OF TRUTH rendered by the runner (Rust
+# `terminal::runner_context`) and delivered via $QONTINUI_RUNNER_CONTEXT — this
+# wrapper no longer authors its own copy. Fail-open: an empty value launches
+# claude unmodified.
 if [ "${QONTINUI_RUNNER_TERMINAL}" = "1" ]; then
-    __qontinui_api_port="${QONTINUI_RUNNER_API_PORT:-9876}"
-    __qontinui_runner_context="You are running inside the Qontinui Runner desktop application terminal.
-The runner provides AI-driven development automation with structured workflows and verification feedback loops.
-
-Runner HTTP API at http://localhost:${__qontinui_api_port}.
-Key endpoints:
-- GET /task-runs/running - list running task runs
-- GET /task-runs/{id}/output?tail_chars=N - live AI conversation output
-- GET /task-runs/{id}/workflow-state - workflow execution state
-- POST /unified-workflows/execute-inline - execute a workflow inline
-- GET /unified-workflows - list saved workflows
-
-Runner SQLite DB (Windows): ~/AppData/Roaming/com.qontinui.runner/runner.db
-Key tables: task_runs, task_run_events, unified_workflows, workflow_verification_phase_results"
-
     claude() {
         case "${1:-}" in
             mcp|config|update|doctor|api-key)
                 command claude "$@"
                 ;;
             *)
-                command claude --append-system-prompt "$__qontinui_runner_context" "$@"
+                if [ -n "${QONTINUI_RUNNER_CONTEXT}" ]; then
+                    command claude --append-system-prompt "$QONTINUI_RUNNER_CONTEXT" "$@"
+                else
+                    command claude "$@"
+                fi
                 ;;
         esac
     }

--- a/src-tauri/resources/shell-integration.ps1
+++ b/src-tauri/resources/shell-integration.ps1
@@ -58,25 +58,12 @@ function global:Prompt {
 
 # ── Claude Code runner context ─────────────────────────────────────────────
 # Wrap the `claude` command so sessions launched from this terminal
-# automatically know they are running inside the Qontinui Runner.
+# automatically know they are running inside the Qontinui Runner. The briefing
+# text is the SINGLE SOURCE OF TRUTH rendered by the runner (Rust
+# `terminal::runner_context`) and delivered via $env:QONTINUI_RUNNER_CONTEXT —
+# this wrapper no longer authors its own copy. Fail-open: if the env var is
+# empty we launch claude unmodified.
 if ($env:QONTINUI_RUNNER_TERMINAL -eq "1") {
-    $__qontinui_api_port = if ($env:QONTINUI_RUNNER_API_PORT) { $env:QONTINUI_RUNNER_API_PORT } else { "9876" }
-    $__qontinui_runner_context = @"
-You are running inside the Qontinui Runner desktop application terminal.
-The runner provides AI-driven development automation with structured workflows and verification feedback loops.
-
-Runner HTTP API at http://localhost:${__qontinui_api_port}. Use PowerShell Invoke-WebRequest on Windows (not curl).
-Key endpoints:
-- GET /task-runs/running - list running task runs
-- GET /task-runs/{id}/output?tail_chars=N - live AI conversation output
-- GET /task-runs/{id}/workflow-state - workflow execution state
-- POST /unified-workflows/execute-inline - execute a workflow inline
-- GET /unified-workflows - list saved workflows
-
-Runner SQLite DB (Windows): ~/AppData/Roaming/com.qontinui.runner/runner.db
-Key tables: task_runs, task_run_events, unified_workflows, workflow_verification_phase_results
-"@
-
     function global:claude {
         # Subcommands that do not accept --append-system-prompt
         $skip = @('mcp', 'config', 'update', 'doctor', 'api-key')
@@ -86,10 +73,11 @@ Key tables: task_runs, task_run_events, unified_workflows, workflow_verification
             Write-Host "claude: command not found" -ForegroundColor Red
             return
         }
-        if ($args.Count -gt 0 -and $skip -contains $args[0]) {
+        $ctx = $env:QONTINUI_RUNNER_CONTEXT
+        if (($args.Count -gt 0 -and $skip -contains $args[0]) -or [string]::IsNullOrEmpty($ctx)) {
             & $exe @args
         } else {
-            & $exe --append-system-prompt $__qontinui_runner_context @args
+            & $exe --append-system-prompt $ctx @args
         }
     }
 }

--- a/src-tauri/resources/shell-integration.zsh
+++ b/src-tauri/resources/shell-integration.zsh
@@ -49,30 +49,22 @@ PROMPT="%{$(printf '\033]633;A\007')%}${PROMPT}%{$(printf '\033]633;B\007')%}"
 
 # ── Claude Code runner context ─────────────────────────────────────────────
 # Wrap `claude` so sessions launched from this terminal know they run inside
-# the Qontinui Runner (mirrors shell-integration.bash).
+# the Qontinui Runner (mirrors shell-integration.bash). The briefing text is the
+# SINGLE SOURCE OF TRUTH rendered by the runner (Rust `terminal::runner_context`)
+# and delivered via $QONTINUI_RUNNER_CONTEXT. Fail-open: an empty value launches
+# claude unmodified.
 if [ "${QONTINUI_RUNNER_TERMINAL}" = "1" ]; then
-    __qontinui_api_port="${QONTINUI_RUNNER_API_PORT:-9876}"
-    __qontinui_runner_context="You are running inside the Qontinui Runner desktop application terminal.
-The runner provides AI-driven development automation with structured workflows and verification feedback loops.
-
-Runner HTTP API at http://localhost:${__qontinui_api_port}.
-Key endpoints:
-- GET /task-runs/running - list running task runs
-- GET /task-runs/{id}/output?tail_chars=N - live AI conversation output
-- GET /task-runs/{id}/workflow-state - workflow execution state
-- POST /unified-workflows/execute-inline - execute a workflow inline
-- GET /unified-workflows - list saved workflows
-
-Runner SQLite DB (Windows): ~/AppData/Roaming/com.qontinui.runner/runner.db
-Key tables: task_runs, task_run_events, unified_workflows, workflow_verification_phase_results"
-
     claude() {
         case "${1:-}" in
             mcp|config|update|doctor|api-key)
                 command claude "$@"
                 ;;
             *)
-                command claude --append-system-prompt "$__qontinui_runner_context" "$@"
+                if [ -n "${QONTINUI_RUNNER_CONTEXT}" ]; then
+                    command claude --append-system-prompt "$QONTINUI_RUNNER_CONTEXT" "$@"
+                else
+                    command claude "$@"
+                fi
                 ;;
         esac
     }

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -2309,6 +2309,7 @@ fn build_continuation_claude_command(
     pinned_session_id: &str,
     add_dir_args: Vec<String>,
     prompt: String,
+    system_prompt: Option<String>,
 ) -> Vec<String> {
     let mut command_vec = vec![
         claude_bin,
@@ -2316,6 +2317,18 @@ fn build_continuation_claude_command(
         "--session-id".to_string(),
         pinned_session_id.to_string(),
     ];
+    // Autonomous spawns exec `claude` directly (no shell wrapping), so unlike
+    // interactive panes they never pick up the shell-integration wrapper's
+    // `--append-system-prompt`. Inject the canonical runner-context briefing
+    // here so the fleet/gate-continuation sessions — the ones acting
+    // unattended against coord and the twin — carry the same capability +
+    // guardrail context an operator's pane gets. Placed among the flags,
+    // BEFORE the `--` end-of-options terminator, so it never disturbs the
+    // trailing-positional-prompt discipline the regression tests below guard.
+    if let Some(sp) = system_prompt {
+        command_vec.push("--append-system-prompt".to_string());
+        command_vec.push(sp);
+    }
     command_vec.extend(add_dir_args);
     command_vec.push("--".to_string());
     command_vec.push(prompt);
@@ -2422,6 +2435,9 @@ async fn run_continuation_terminal(
         &pinned_session_id,
         add_dir_args,
         payload.initial_prompt.clone(),
+        Some(crate::terminal::runner_context(
+            crate::mcp::types::get_mcp_api_port(),
+        )),
     ));
 
     // First repo (if any) is the session's intent_repo for coord attribution.
@@ -2697,6 +2713,9 @@ async fn run_condition_check_terminal(
         &pinned_session_id,
         Vec::new(),
         payload.initial_prompt.clone(),
+        Some(crate::terminal::runner_context(
+            crate::mcp::types::get_mcp_api_port(),
+        )),
     ));
 
     // Account selection (fail-loud) — identical posture to the gate path so the
@@ -4141,6 +4160,7 @@ mod tests {
             "abc-123",
             vec!["--add-dir=D:/wt/sibling".to_string()],
             "do the thing".to_string(),
+            None,
         );
         assert_eq!(
             cmd.join("|"),
@@ -4164,6 +4184,7 @@ mod tests {
                 "--add-dir=D:/wt/web".to_string(),
             ],
             "run /implement-plan plans/x.md".to_string(),
+            None,
         );
         assert_eq!(
             cmd.last().map(String::as_str),
@@ -4190,12 +4211,53 @@ mod tests {
             "abc-123",
             vec![],
             "-prompt with dash".to_string(),
+            None,
         );
         assert_eq!(
             cmd.join("|"),
             "claude|--dangerously-skip-permissions|--session-id|abc-123|\
              --|-prompt with dash"
         );
+    }
+
+    /// The autonomous (direct-exec) path injects the runner-context briefing as
+    /// `--append-system-prompt <text>` — placed AFTER the pinned `--session-id`
+    /// and BEFORE the `--` terminator, so it never disturbs the trailing
+    /// positional prompt even when sibling `--add-dir=` args are present.
+    #[test]
+    fn continuation_command_injects_system_prompt_before_terminator() {
+        let cmd = build_continuation_claude_command(
+            "claude".to_string(),
+            "abc-123",
+            vec!["--add-dir=D:/wt/coord".to_string()],
+            "do the thing".to_string(),
+            Some("You are inside the Qontinui Runner.".to_string()),
+        );
+        // The prompt stays the trailing positional behind `--`.
+        assert_eq!(cmd.last().map(String::as_str), Some("do the thing"));
+        assert_eq!(
+            cmd.get(cmd.len() - 2).map(String::as_str),
+            Some("--"),
+            "the terminator must still immediately precede the prompt"
+        );
+        // The flag + value pair is present, together, ahead of the terminator.
+        let flag = cmd
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .expect("--append-system-prompt must be injected");
+        let term = cmd.iter().position(|a| a == "--").unwrap();
+        assert!(
+            flag < term,
+            "system prompt flag must precede the terminator"
+        );
+        assert_eq!(
+            cmd.get(flag + 1).map(String::as_str),
+            Some("You are inside the Qontinui Runner."),
+            "the briefing text must immediately follow its flag"
+        );
+        // Session id is still pinned before the injected flag.
+        let sid = cmd.iter().position(|a| a == "--session-id").unwrap();
+        assert!(sid < flag, "--session-id must precede the injected flag");
     }
 
     #[test]

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -23,6 +23,53 @@ pub mod vt_sanitize;
 
 pub use manager::TerminalManager;
 
+/// The canonical "you are inside the Qontinui Runner" briefing appended to the
+/// system prompt of every `claude` session the runner hosts.
+///
+/// This is the SINGLE SOURCE OF TRUTH for the briefing text. Both launch paths
+/// render it from here so they can never drift:
+///   - Interactive panes (a human types `claude`) read it via the
+///     `QONTINUI_RUNNER_CONTEXT` env var that [`session`] injects at spawn; the
+///     `shell-integration.{ps1,bash,zsh}` wrapper passes it to
+///     `--append-system-prompt`.
+///   - Autonomous direct-exec spawns (gate continuations, fleet/batch) never
+///     source shell integration, so they inject it into the argv directly via
+///     `agent_runtime::build_continuation_claude_command`.
+///
+/// It deliberately carries NO tenant/agent identity — that is an RCE-class
+/// invariant (a prompt must never cross tenants) and is deferred to the vetted
+/// session-identity fabric plan. Only tenant-agnostic capability + guardrail
+/// guidance lives here.
+pub fn runner_context(api_port: u16) -> String {
+    format!(
+        "You are running inside the Qontinui Runner — an AI-driven development \
+environment, NOT a plain checkout. You have live access to multi-agent \
+coordination (coord) and the digital twin, so your actions have real blast radius.
+
+Coordination (coord): you are one of several agents sharing this repo through a \
+live merge train. BEFORE you edit files or write a plan, call \
+coord_declare_intent so peers can see your scope and you can sequence around \
+them. Check coord_is_merge_safe / gate status before landing. Verify a change \
+actually landed by its CONTENT on origin/main — never trust a green workflow or \
+a PR \"merged\" state alone.
+
+Digital twin: inspect and verify UI through the UI Bridge tooling (/ui-bridge, \
+/visual-audit, /page-health). Never use Playwright for the runner, qontinui-web, \
+or qontinui-mobile.
+
+Runner HTTP API at http://localhost:{api_port} (on Windows use Invoke-WebRequest, \
+not curl):
+- GET /task-runs/running — running task runs
+- GET /task-runs/{{id}}/output?tail_chars=N — live AI conversation output
+- GET /unified-workflows — saved workflows; POST /unified-workflows/execute-inline runs one inline
+Runner SQLite DB (Windows): ~/AppData/Roaming/com.qontinui.runner/runner.db \
+(tables: task_runs, task_run_events, unified_workflows).
+
+Guardrail: confirm before outward-facing or irreversible actions unless you are \
+already authorized to proceed."
+    )
+}
+
 /// Strip ANSI escape sequences from text for readable scrollback previews.
 ///
 /// Handles CSI (`ESC [ ... letter`) and OSC (`ESC ] ... BEL`) sequences plus

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -450,9 +450,19 @@ impl TerminalSession {
         // Mark this terminal as running inside the Qontinui Runner so that tools
         // (e.g. Claude Code via the shell integration wrapper) can detect the context.
         cmd.env("QONTINUI_RUNNER_TERMINAL", "1");
+        let runner_api_port = crate::mcp::types::get_mcp_api_port();
+        cmd.env("QONTINUI_RUNNER_API_PORT", runner_api_port.to_string());
+        // Canonical runner-context briefing (capabilities + coord + twin +
+        // guardrails), rendered from the SINGLE source of truth. The shell
+        // integration wrapper reads this env var and passes it to
+        // `--append-system-prompt` for interactive `claude` panes. Autonomous
+        // direct-exec spawns bypass shell integration and inject the same text
+        // into their argv instead (see
+        // `agent_runtime::build_continuation_claude_command`). Purely additive
+        // and fail-open: an empty/unset value simply means no briefing.
         cmd.env(
-            "QONTINUI_RUNNER_API_PORT",
-            crate::mcp::types::get_mcp_api_port().to_string(),
+            "QONTINUI_RUNNER_CONTEXT",
+            crate::terminal::runner_context(runner_api_port),
         );
 
         // Phase 2c — caller-supplied launch env (e.g.


### PR DESCRIPTION
## Problem

The runner briefs `claude` sessions that they're running inside it (capabilities, API, etc.) — but **only interactive panes get it**. That briefing is added by the `shell-integration.{ps1,bash,zsh}` wrapper via `--append-system-prompt`. Autonomous sessions — **gate continuations and fleet/batch spawns** — exec `claude` **directly with no shell wrapping** (`build_continuation_claude_command`), so they never hit the wrapper and received **zero** runner context.

That inverts the intuition: the sessions acting **unattended against coord and the digital twin** — the ones that most need to know they can declare intent, check merge-safety, and drive the twin instead of Playwright — were the ones flying blind.

## Change

- **Single source of truth** — `terminal::runner_context(api_port)` renders the canonical "you are inside the runner" briefing: capabilities + coord (declare intent before editing, verify-by-content on `origin/main`) + digital twin (UI Bridge, not Playwright) + guardrails.
- **Interactive path** — `session.rs` injects it as `QONTINUI_RUNNER_CONTEXT` at spawn; the three shell wrappers now **read that env var** instead of each authoring their own heredoc copy (kills the triplication drift). Fail-open: empty/unset ⇒ no briefing.
- **Autonomous path** — `build_continuation_claude_command` gained an `Option<String>` system-prompt param and injects `--append-system-prompt` **after `--session-id`, before the `--` terminator**, so the trailing-positional-prompt discipline (guarded by existing regression tests) is untouched. Both real callers pass `Some(runner_context(...))`.

## Deliberately excluded: identity

No tenant/agent identity in the briefing. Injecting resolved identity into a system prompt is an RCE-class risk (prompt must never cross tenants) and identity resolution is not yet provably per-session — that's the vetted **session-identity fabric plan**, which owns identity. This PR ships only tenant-agnostic capability + guardrail guidance.

## Verification

- `cargo check --all-targets` — clean.
- `continuation_command` unit tests — **5/5 pass**, including a new `continuation_command_injects_system_prompt_before_terminator` and the 3 pre-existing flag/positional regression tests (now passing `None`).
- prepush `cargo fmt + clippy` — clean.
- Interactive panes: behavior-preserving (identical briefing text, now single-sourced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
