### PR TITLE
fix(device): auto-mint machine.json on first launch (fixes prod 'device not initialized')

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -648,8 +648,8 @@ async fn finalize_signed_in(
     base: String,
 ) -> Result<CognitoSignInResponse, AppError> {
     use qontinui_runner_lib::pair::{
-        pair_with_auth_token_with_ids, persist_pairing, read_device_id_from_disk,
-        tenant_id_from_oauth_claim,
+        ensure_device_initialized, pair_with_auth_token_with_ids, persist_pairing,
+        read_device_id_from_disk, tenant_id_from_oauth_claim,
     };
 
     // 2. Persist the Cognito user tokens in the distinct oauth slots.
@@ -666,7 +666,10 @@ async fn finalize_signed_in(
             AppError::Raw(format!("persist Cognito tokens: {e}"))
         })?;
 
-    // 3. Device identity from disk.
+    // 3. Device identity from disk. Mint it first if a fresh install never
+    //    ran `device init` (startup already does this, but sign-in self-heals
+    //    the edge case rather than dead-ending the user with a CLI hint).
+    ensure_device_initialized();
     let device_id = read_device_id_from_disk().map_err(|e| {
         error!("finalize_signed_in: step 3 (read_device_id_from_disk) failed: {e}");
         AppError::Raw(format!("could not read device identity: {e}"))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2161,12 +2161,15 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             // the existing setup body rely on non-`move` semantics; see
             // the comment block above this closure).
             {
-                // Phase 0 multi-user readiness — normalize the operator's
-                // legacy `machine.json` so the canonical `device_id` key is
-                // present before any consumer reads it (the session machinery
-                // below + the coord data-plane bearer). No-op when the file is
-                // already canonical / missing.
-                qontinui_runner_lib::pair::ensure_device_id_persisted();
+                // Ensure the per-device identity file exists before any
+                // consumer reads it (the session machinery below, the coord
+                // data-plane bearer, and the sign-in device-binding step).
+                // On a fresh production install there is no machine.json and
+                // no end user runs `qontinui_profile device init`, so mint the
+                // identity here on first launch; on an existing file this just
+                // backfills the canonical `device_id` key. Fail-open + no-op
+                // when already canonical.
+                qontinui_runner_lib::pair::ensure_device_initialized();
 
                 let app_handle = app.handle().clone();
                 let term_state: tauri::State<'_, std::sync::Arc<terminal::TerminalManager>> =

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -243,6 +243,93 @@ pub fn ensure_device_id_persisted_at(path: &std::path::Path) {
     );
 }
 
+/// Ensure the per-device identity file `~/.qontinui/machine.json` EXISTS,
+/// minting it on first launch.
+///
+/// A fresh production install has no identity file. The sign-in chain
+/// (`crate::commands::auth::finalize_signed_in` step 3) and the pair-cli both
+/// call [`read_device_id_from_disk`], which hard-errors when the file is
+/// absent ("device not initialized — run `qontinui_profile device init`").
+/// No end user runs that CLI, so the runner mints the identity itself: a
+/// client-side UUID v4 + hostname, written atomically — the exact shape and
+/// recipe as `qontinui_profile device init`
+/// (`bin/qontinui_profile.rs::cmd_device_init`). Coord-side registration is
+/// intentionally NOT done here; it happens during sign-in
+/// (`pair_with_auth_token_with_ids`, which binds the device to the
+/// authenticated user + tenant server-side) or via the CLI's own coord UPSERT.
+///
+/// Idempotent + fail-open (never panics; safe to call on every launch):
+/// - Existing file → keep the UUID, delegate to [`ensure_device_id_persisted`]
+///   to backfill the canonical `device_id` key. Never overwrites an identity.
+/// - Missing file → mint `{device_id, hostname}` and write it.
+/// - Any error (no home dir, mkdir / write / rename failure) → logged and
+///   swallowed; the caller proceeds and, if the mint genuinely failed, the
+///   downstream read still surfaces the original clear error.
+pub fn ensure_device_initialized() {
+    let Some(path) = machine_file_path() else {
+        tracing::warn!("ensure_device_initialized: could not resolve home directory — skipping");
+        return;
+    };
+    ensure_device_initialized_at(&path);
+}
+
+/// Path-parameterized core of [`ensure_device_initialized`] (testable without
+/// touching the real home directory).
+pub fn ensure_device_initialized_at(path: &std::path::Path) {
+    if path.exists() {
+        // Existing identity: preserve the UUID, just normalize the key.
+        ensure_device_id_persisted_at(path);
+        return;
+    }
+    let device_id = uuid::Uuid::new_v4().to_string();
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+    // Same on-disk shape as DeviceFile in the sidecar ({device_id, hostname};
+    // `name` is optional and omitted). Sibling readers alias machine_id.
+    let body = serde_json::json!({ "device_id": device_id, "hostname": hostname });
+    let pretty = match serde_json::to_vec_pretty(&body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("ensure_device_initialized: serialize failed: {e}");
+            return;
+        }
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::warn!(
+                "ensure_device_initialized: mkdir {} failed: {e}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, &pretty) {
+        tracing::warn!(
+            "ensure_device_initialized: write {} failed: {e}",
+            tmp.display()
+        );
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        tracing::warn!(
+            "ensure_device_initialized: rename {} → {} failed: {e}",
+            tmp.display(),
+            path.display()
+        );
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    tracing::info!(
+        "machine.json: minted device identity {} (host={}) at {}",
+        device_id,
+        hostname,
+        path.display()
+    );
+}
+
 /// Path to the paired-user JSON written by `device pair` and read by
 /// `device init` to attach a `user_id` to the register payload. Lives
 /// under the Tauri app's local data directory (alongside
@@ -2170,6 +2257,81 @@ mod tests {
         // File does not exist.
         ensure_device_id_persisted_at(&path);
         assert!(!path.exists(), "must not create the file");
+    }
+
+    // ------------------------------------------------------------------------
+    // ensure_device_initialized_at — mint machine.json on a fresh install so a
+    // production user never hits "device not initialized — run
+    // `qontinui_profile device init`". Tempdir-scoped; never touches real home.
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn autoinit_mints_identity_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        assert!(!path.exists());
+
+        ensure_device_initialized_at(&path);
+
+        assert!(path.exists(), "must mint machine.json on a fresh install");
+        let v = read_json(&path);
+        let id = v
+            .get("device_id")
+            .and_then(|x| x.as_str())
+            .expect("device_id present");
+        // A real UUID v4, not empty / placeholder.
+        uuid::Uuid::parse_str(id).expect("device_id is a valid UUID");
+        assert!(
+            v.get("hostname").and_then(|x| x.as_str()).is_some(),
+            "hostname recorded"
+        );
+        // The minted file must parse under the same MachineFile reader that
+        // errored before the fix (device_id present + deserializable).
+        let parsed: MachineFile = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(parsed.device_id, id);
+    }
+
+    #[test]
+    fn autoinit_preserves_uuid_on_second_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+
+        ensure_device_initialized_at(&path);
+        let id1 = read_json(&path)
+            .get("device_id")
+            .and_then(|x| x.as_str())
+            .unwrap()
+            .to_string();
+
+        ensure_device_initialized_at(&path);
+        let id2 = read_json(&path)
+            .get("device_id")
+            .and_then(|x| x.as_str())
+            .unwrap()
+            .to_string();
+
+        assert_eq!(id1, id2, "must never re-mint / overwrite an existing identity");
+    }
+
+    #[test]
+    fn autoinit_keeps_legacy_id_and_backfills() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        // Operator's legacy machine_id-only file: keep the id, don't re-mint.
+        std::fs::write(&path, r#"{"machine_id":"legacy-abc","hostname":"laptop"}"#).unwrap();
+
+        ensure_device_initialized_at(&path);
+
+        let v = read_json(&path);
+        assert_eq!(
+            v.get("device_id").and_then(|x| x.as_str()),
+            Some("legacy-abc"),
+            "existing identity preserved (backfill, not re-mint)"
+        );
+        assert_eq!(
+            v.get("machine_id").and_then(|x| x.as_str()),
+            Some("legacy-abc")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem (production, v1.0.2)
A user installed the production runner on a clean machine, logged into qontinui-web successfully, then the runner errored:

> could not read device identity: device not initialized -- run 'qontinui_profile device init' first (no C:\Users\<user>\.qontinui\machine.json on disk)

### Root cause
The runner has **no automatic device initialization**. The shared post-login chain `finalize_signed_in` (auth.rs) step 3 calls `read_device_id_from_disk()`, which **hard-errors when `~/.qontinui/machine.json` is absent** (`pair.rs::read_device_id`). The **only** thing that creates that file is the manual CLI `qontinui_profile device init` (`bin/qontinui_profile.rs::cmd_device_init`, a client-side UUID v4) — the runner never spawns it, and no end user runs it. `ensure_device_id_persisted()` (startup) only *backfills* an existing file. So a fresh install dead-ends right after web login.

(The `C:\Users\<user>\...` path is dynamically resolved from `dirs::home_dir()` — not a leaked dev-machine path.)

## Fix
`pair::ensure_device_initialized[_at]`: mint `{device_id: uuid_v4, hostname}` to `machine.json` when absent (same shape/recipe as `qontinui_profile device init`), atomic write, **idempotent** (existing file → backfill canonical key only, never re-mint), **fail-open** (errors logged, never panic). Wired at:
- **startup** (`main.rs` setup) — replaces the backfill-only call so the identity always exists before any consumer reads it;
- **`finalize_signed_in`** before the device read — belt-and-braces self-heal.

Coord-side registration is unchanged — it still happens during sign-in (`pair_with_auth_token_with_ids` binds device→user+tenant server-side); this only mints the local identity file.

## Tests
3 unit tests (tempdir-scoped): mints-when-missing (valid UUID + parses under `MachineFile`), idempotent (never overwrites), legacy `machine_id` file preserved + backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)