### PR TITLE
feat(update): working auto-update + v1.0.3 (make it the last manual install)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,10 +289,13 @@ jobs:
           }
 
       - name: Build Tauri app
-        # Tauri signing disabled for alpha - will be enabled when certificates arrive
-        # env:
-        #   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-        #   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        # Updater signing: with createUpdaterArtifacts=true, `tauri build`
+        # signs each bundle and emits a `<installer>.sig` next to it. The
+        # runner's updater plugin verifies that signature against the pubkey in
+        # tauri.conf.json. Both secrets must be set in the repo.
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         # --target must be tauri's OWN flag, not behind `--`. Under npm the
         # first `--` was eaten by npm itself, so tauri saw `--target`; pnpm
         # passes `--` through verbatim, which made tauri forward --target to
@@ -371,6 +374,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate updater manifest (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        # createUpdaterArtifacts=true makes `tauri build` sign each bundle and
+        # emit <installer>.sig next to it. Assemble the Tauri v2 updater
+        # manifest (latest.json) carrying the REAL signature, so an installed
+        # runner can verify + apply the update against the pubkey embedded in
+        # tauri.conf.json. Windows is the sole shipped platform, so a
+        # Windows-only manifest is correct. Fails loudly if the .sig is absent
+        # (signing key not set) — never ship an unverifiable "auto-update".
+        run: |
+          cd target/${{ matrix.target }}/release/bundle/nsis
+          sig_file=$(ls *-setup.exe.sig 2>/dev/null | head -1)
+          if [[ -z "$sig_file" ]]; then
+            echo "::error::No .sig produced — is TAURI_SIGNING_PRIVATE_KEY set and createUpdaterArtifacts=true?";
+            exit 1;
+          fi
+          sig=$(cat "$sig_file")
+          ver="${{ needs.create-release.outputs.release_version }}"
+          cat > latest.json << EOF
+          {
+            "version": "v${ver}",
+            "notes": "See https://github.com/${{ github.repository }}/releases/tag/v${ver} for release notes.",
+            "pub_date": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+            "platforms": {
+              "windows-x86_64": {
+                "signature": "${sig}",
+                "url": "https://github.com/${{ github.repository }}/releases/download/v${ver}/Qontinui.Runner_${ver}_x64-setup.exe"
+              }
+            }
+          }
+          EOF
+          echo "Generated latest.json:"; cat latest.json
+
       - name: Upload release assets (Windows)
         if: runner.os == 'Windows'
         uses: softprops/action-gh-release@v1
@@ -379,6 +416,8 @@ jobs:
           prerelease: true
           files: |
             target/${{ matrix.target }}/release/bundle/nsis/*.exe
+            target/${{ matrix.target }}/release/bundle/nsis/*.exe.sig
+            target/${{ matrix.target }}/release/bundle/nsis/latest.json
             target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -412,42 +451,13 @@ jobs:
             exit 1;
           }
 
-      - name: Generate update manifest
-        run: |
-          cat > update.json << EOF
-          {
-            "version": "v${{ needs.create-release.outputs.release_version }}",
-            "notes": "Beta release with stability improvements and auto-update support",
-            "pub_date": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-            "platforms": {
-              "darwin-x86_64": {
-                "signature": "",
-                "url": "https://github.com/${{ github.repository }}/releases/download/v${{ needs.create-release.outputs.release_version }}/qontinui-runner_${{ needs.create-release.outputs.release_version }}_x64.dmg"
-              },
-              "darwin-aarch64": {
-                "signature": "",
-                "url": "https://github.com/${{ github.repository }}/releases/download/v${{ needs.create-release.outputs.release_version }}/qontinui-runner_${{ needs.create-release.outputs.release_version }}_aarch64.dmg"
-              },
-              "linux-x86_64": {
-                "signature": "",
-                "url": "https://github.com/${{ github.repository }}/releases/download/v${{ needs.create-release.outputs.release_version }}/qontinui-runner_${{ needs.create-release.outputs.release_version }}_amd64.AppImage"
-              },
-              "windows-x86_64": {
-                "signature": "",
-                "url": "https://github.com/${{ github.repository }}/releases/download/v${{ needs.create-release.outputs.release_version }}/Qontinui.Runner_${{ needs.create-release.outputs.release_version }}_x64-setup.exe"
-              }
-            }
-          }
-          EOF
-
-      - name: Upload update manifest
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          prerelease: true
-          files: update.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The updater manifest (latest.json) is now produced by the Windows
+      # build leg ("Generate updater manifest (Windows)") with the REAL
+      # signature read from the bundler's .sig, and uploaded to the draft
+      # release there. The old hand-rolled update.json here carried empty
+      # signatures + a wrong (.msi) URL, so the updater could never verify —
+      # it has been removed. This job now only gates on the Windows installer
+      # and flips the release to published + latest.
 
       # All platform installers, checksums, and the update manifest are now
       # uploaded to the draft release. Flip it to published + non-prerelease as
@@ -462,4 +472,5 @@ jobs:
           gh release edit "v${{ needs.create-release.outputs.release_version }}" \
             --repo "${{ github.repository }}" \
             --draft=false \
-            --prerelease=false
+            --prerelease=false \
+            --latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6546,7 +6546,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-runner"
-version = "1.0.1"
+version = "1.0.3"
 dependencies = [
  "adb_client",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "pnpm": {
     "overrides": {
       "@qontinui/shared-types": "^0.6.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qontinui-runner"
-version = "1.0.1"
+version = "1.0.3"
 description = "Desktop app for AI-assisted development: orchestrated AI coding sessions with visual feedback, self-verification, and real-time UI inspection"
 authors = ["Qontinui <contact@qontinui.org>"]
 edition = "2021"

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -648,8 +648,8 @@ async fn finalize_signed_in(
     base: String,
 ) -> Result<CognitoSignInResponse, AppError> {
     use qontinui_runner_lib::pair::{
-        pair_with_auth_token_with_ids, persist_pairing, read_device_id_from_disk,
-        tenant_id_from_oauth_claim,
+        ensure_device_initialized, pair_with_auth_token_with_ids, persist_pairing,
+        read_device_id_from_disk, tenant_id_from_oauth_claim,
     };
 
     // 2. Persist the Cognito user tokens in the distinct oauth slots.
@@ -666,7 +666,10 @@ async fn finalize_signed_in(
             AppError::Raw(format!("persist Cognito tokens: {e}"))
         })?;
 
-    // 3. Device identity from disk.
+    // 3. Device identity from disk. Mint it first if a fresh install never
+    //    ran `device init` (startup already does this, but sign-in self-heals
+    //    the edge case rather than dead-ending the user with a CLI hint).
+    ensure_device_initialized();
     let device_id = read_device_id_from_disk().map_err(|e| {
         error!("finalize_signed_in: step 3 (read_device_id_from_disk) failed: {e}");
         AppError::Raw(format!("could not read device identity: {e}"))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2161,12 +2161,15 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             // the existing setup body rely on non-`move` semantics; see
             // the comment block above this closure).
             {
-                // Phase 0 multi-user readiness — normalize the operator's
-                // legacy `machine.json` so the canonical `device_id` key is
-                // present before any consumer reads it (the session machinery
-                // below + the coord data-plane bearer). No-op when the file is
-                // already canonical / missing.
-                qontinui_runner_lib::pair::ensure_device_id_persisted();
+                // Ensure the per-device identity file exists before any
+                // consumer reads it (the session machinery below, the coord
+                // data-plane bearer, and the sign-in device-binding step).
+                // On a fresh production install there is no machine.json and
+                // no end user runs `qontinui_profile device init`, so mint the
+                // identity here on first launch; on an existing file this just
+                // backfills the canonical `device_id` key. Fail-open + no-op
+                // when already canonical.
+                qontinui_runner_lib::pair::ensure_device_initialized();
 
                 let app_handle = app.handle().clone();
                 let term_state: tauri::State<'_, std::sync::Arc<terminal::TerminalManager>> =

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -243,6 +243,93 @@ pub fn ensure_device_id_persisted_at(path: &std::path::Path) {
     );
 }
 
+/// Ensure the per-device identity file `~/.qontinui/machine.json` EXISTS,
+/// minting it on first launch.
+///
+/// A fresh production install has no identity file. The sign-in chain
+/// (`crate::commands::auth::finalize_signed_in` step 3) and the pair-cli both
+/// call [`read_device_id_from_disk`], which hard-errors when the file is
+/// absent ("device not initialized — run `qontinui_profile device init`").
+/// No end user runs that CLI, so the runner mints the identity itself: a
+/// client-side UUID v4 + hostname, written atomically — the exact shape and
+/// recipe as `qontinui_profile device init`
+/// (`bin/qontinui_profile.rs::cmd_device_init`). Coord-side registration is
+/// intentionally NOT done here; it happens during sign-in
+/// (`pair_with_auth_token_with_ids`, which binds the device to the
+/// authenticated user + tenant server-side) or via the CLI's own coord UPSERT.
+///
+/// Idempotent + fail-open (never panics; safe to call on every launch):
+/// - Existing file → keep the UUID, delegate to [`ensure_device_id_persisted`]
+///   to backfill the canonical `device_id` key. Never overwrites an identity.
+/// - Missing file → mint `{device_id, hostname}` and write it.
+/// - Any error (no home dir, mkdir / write / rename failure) → logged and
+///   swallowed; the caller proceeds and, if the mint genuinely failed, the
+///   downstream read still surfaces the original clear error.
+pub fn ensure_device_initialized() {
+    let Some(path) = machine_file_path() else {
+        tracing::warn!("ensure_device_initialized: could not resolve home directory — skipping");
+        return;
+    };
+    ensure_device_initialized_at(&path);
+}
+
+/// Path-parameterized core of [`ensure_device_initialized`] (testable without
+/// touching the real home directory).
+pub fn ensure_device_initialized_at(path: &std::path::Path) {
+    if path.exists() {
+        // Existing identity: preserve the UUID, just normalize the key.
+        ensure_device_id_persisted_at(path);
+        return;
+    }
+    let device_id = uuid::Uuid::new_v4().to_string();
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string());
+    // Same on-disk shape as DeviceFile in the sidecar ({device_id, hostname};
+    // `name` is optional and omitted). Sibling readers alias machine_id.
+    let body = serde_json::json!({ "device_id": device_id, "hostname": hostname });
+    let pretty = match serde_json::to_vec_pretty(&body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("ensure_device_initialized: serialize failed: {e}");
+            return;
+        }
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            tracing::warn!(
+                "ensure_device_initialized: mkdir {} failed: {e}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, &pretty) {
+        tracing::warn!(
+            "ensure_device_initialized: write {} failed: {e}",
+            tmp.display()
+        );
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        tracing::warn!(
+            "ensure_device_initialized: rename {} → {} failed: {e}",
+            tmp.display(),
+            path.display()
+        );
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    tracing::info!(
+        "machine.json: minted device identity {} (host={}) at {}",
+        device_id,
+        hostname,
+        path.display()
+    );
+}
+
 /// Path to the paired-user JSON written by `device pair` and read by
 /// `device init` to attach a `user_id` to the register payload. Lives
 /// under the Tauri app's local data directory (alongside
@@ -2170,6 +2257,81 @@ mod tests {
         // File does not exist.
         ensure_device_id_persisted_at(&path);
         assert!(!path.exists(), "must not create the file");
+    }
+
+    // ------------------------------------------------------------------------
+    // ensure_device_initialized_at — mint machine.json on a fresh install so a
+    // production user never hits "device not initialized — run
+    // `qontinui_profile device init`". Tempdir-scoped; never touches real home.
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn autoinit_mints_identity_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        assert!(!path.exists());
+
+        ensure_device_initialized_at(&path);
+
+        assert!(path.exists(), "must mint machine.json on a fresh install");
+        let v = read_json(&path);
+        let id = v
+            .get("device_id")
+            .and_then(|x| x.as_str())
+            .expect("device_id present");
+        // A real UUID v4, not empty / placeholder.
+        uuid::Uuid::parse_str(id).expect("device_id is a valid UUID");
+        assert!(
+            v.get("hostname").and_then(|x| x.as_str()).is_some(),
+            "hostname recorded"
+        );
+        // The minted file must parse under the same MachineFile reader that
+        // errored before the fix (device_id present + deserializable).
+        let parsed: MachineFile = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(parsed.device_id, id);
+    }
+
+    #[test]
+    fn autoinit_preserves_uuid_on_second_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+
+        ensure_device_initialized_at(&path);
+        let id1 = read_json(&path)
+            .get("device_id")
+            .and_then(|x| x.as_str())
+            .unwrap()
+            .to_string();
+
+        ensure_device_initialized_at(&path);
+        let id2 = read_json(&path)
+            .get("device_id")
+            .and_then(|x| x.as_str())
+            .unwrap()
+            .to_string();
+
+        assert_eq!(id1, id2, "must never re-mint / overwrite an existing identity");
+    }
+
+    #[test]
+    fn autoinit_keeps_legacy_id_and_backfills() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        // Operator's legacy machine_id-only file: keep the id, don't re-mint.
+        std::fs::write(&path, r#"{"machine_id":"legacy-abc","hostname":"laptop"}"#).unwrap();
+
+        ensure_device_initialized_at(&path);
+
+        let v = read_json(&path);
+        assert_eq!(
+            v.get("device_id").and_then(|x| x.as_str()),
+            Some("legacy-abc"),
+            "existing identity preserved (backfill, not re-mint)"
+        );
+        assert_eq!(
+            v.get("machine_id").and_then(|x| x.as_str()),
+            Some("legacy-abc")
+        );
     }
 
     #[test]

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -2310,7 +2310,10 @@ mod tests {
             .unwrap()
             .to_string();
 
-        assert_eq!(id1, id2, "must never re-mint / overwrite an existing identity");
+        assert_eq!(
+            id1, id2,
+            "must never re-mint / overwrite an existing identity"
+        );
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Qontinui Runner",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "identifier": "com.qontinui.runner",
   "build": {
     "beforeBuildCommand": "npm run build && npm run bundle:profile-sidecar",
@@ -29,14 +29,17 @@
       "icons/icon.ico"
     ],
     "externalBin": ["binaries/qontinui_profile"],
-    "createUpdaterArtifacts": false
+    "createUpdaterArtifacts": true
   },
   "plugins": {
     "updater": {
       "endpoints": [
         "https://github.com/qontinui/qontinui-runner/releases/latest/download/latest.json"
       ],
-      "pubkey": ""
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEMxMzBCMkE5NTA4RTg2MjkKUldRcGhvNVFxYkl3d1MzTDd5dkNYYTlNK0QvRXp6bXo3NG5DeitobmZyQW5LK1NmSUZoZktLZ1cK",
+      "windows": {
+        "installMode": "passive"
+      }
     },
     "deep-link": {
       "desktop": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import { useStateMachineRegistration } from "./hooks/useStateMachineRegistration
 
 import { ToastContainer } from "./components/ToastContainer";
 import { BuildRefreshBanner } from "./components/BuildRefreshBanner";
+import { AutoUpdateChecker } from "./components/AutoUpdateChecker";
 import { ConflictModal } from "./components/ConflictModal";
 import { StolenBanner } from "./components/StolenBanner";
 import { MemoryFederationBanner } from "./components/MemoryFederationBanner";
@@ -969,6 +970,9 @@ export default function App() {
         the runner exe was swapped while this webview stayed open.
       */}
       <BuildRefreshBanner />
+      {/* Launch-time auto-update check: prompts + installs a newer signed
+          release on startup. Renders nothing; fail-open. */}
+      <AutoUpdateChecker />
       <UIBridgeProvider
         features={{ renderLog: true, control: true, debug: true }}
         browserCaptureConfig={{

--- a/src/components/AutoUpdateChecker.tsx
+++ b/src/components/AutoUpdateChecker.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { ask } from "@tauri-apps/plugin-dialog";
+
+/**
+ * Launch-time auto-update check.
+ *
+ * On startup this asks the backend whether a newer signed release is available
+ * (`check_for_updates` in `system_ops.rs`, which verifies the update signature
+ * against the `pubkey` embedded in `tauri.conf.json`). If one is, it prompts the
+ * user once and, on consent, downloads + installs it (`install_update`) — the
+ * app then restarts into the new version.
+ *
+ * Renders nothing. Intentionally fail-open: the backend commands are release-only
+ * (`#[cfg(not(debug_assertions))]`), so in dev the invoke rejects and is
+ * swallowed; any check/download error is caught and must never disrupt launch.
+ * The check is deferred a few seconds so it never competes with first paint or
+ * auth bootstrap, and runs at most once per launch.
+ */
+export function AutoUpdateChecker(): null {
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const result = (await invoke("check_for_updates")) as {
+            success: boolean;
+            data?: { available?: boolean; version?: string };
+          };
+          if (cancelled || !result.success || !result.data?.available) return;
+
+          const version = result.data.version
+            ? `Qontinui Runner v${result.data.version}`
+            : "A new version of Qontinui Runner";
+          const accepted = await ask(
+            `${version} is available.\n\nInstall it now? The app will restart to apply the update.`,
+            {
+              title: "Update available",
+              kind: "info",
+              okLabel: "Install & restart",
+              cancelLabel: "Later",
+            },
+          );
+          if (cancelled || !accepted) return;
+
+          // Downloads, installs, and relaunches into the new version.
+          await invoke("install_update");
+        } catch {
+          // Fail-open: a failed or blocked update check must never block launch.
+        }
+      })();
+    }, 4000);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Stacked on #732 (device auto-init). Together these are **v1.0.3**.

## Why
Installed v1.0.2 runners can't auto-update — they shipped with an empty updater `pubkey`, an endpoint (`latest.json`) the pipeline never produced, and empty signatures. So the v1.0.2→v1.0.3 hop needs a one-time reinstall regardless. This PR makes **v1.0.3 the last manual install**: from v1.0.3 onward the updater actually works.

## Changes
- **`tauri.conf.json`**: `createUpdaterArtifacts: true`, real minisign `pubkey`, `windows.installMode: passive`.
- **`release.yml`**: enable `TAURI_SIGNING_PRIVATE_KEY[_PASSWORD]` so the bundler signs + emits `<installer>.sig`; the Windows leg now assembles **`latest.json` with the REAL signature** (read from the `.sig`) + the correct `-setup.exe` URL and uploads it (the endpoint the client fetches). Removed the old hand-rolled empty-signature `update.json`. Added `--latest` to the publish step (supersedes #729).
- **`AutoUpdateChecker`**: launch-time check that prompts + installs a newer signed release on startup (fail-open, release-only), so updates are hands-off, not only when a user opens Settings → Updates.
- Version 1.0.1 → **1.0.3**.

Signing secrets `TAURI_SIGNING_PRIVATE_KEY` + `_PASSWORD` are set in the repo; the matching public key is embedded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)