### PR TITLE
chore(release): bump version to 1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6546,7 +6546,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-runner"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "adb_client",
  "aes-gcm",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "typecheck": "tsc --noEmit"
   },
   "type": "module",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "pnpm": {
     "overrides": {
       "@qontinui/shared-types": "^0.6.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qontinui-runner"
-version = "1.0.3"
+version = "1.0.4"
 description = "Desktop app for AI-assisted development: orchestrated AI coding sessions with visual feedback, self-verification, and real-time UI inspection"
 authors = ["Qontinui <contact@qontinui.org>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Qontinui Runner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "identifier": "com.qontinui.runner",
   "build": {
     "beforeBuildCommand": "npm run build && npm run bundle:profile-sidecar",


### PR DESCRIPTION
## Release v1.0.4

Version-only bump `1.0.3 → 1.0.4` across the four release-version files
(`tauri.conf.json`, `Cargo.toml`, `Cargo.lock`, `package.json`).

### Why now
The setup-wizard **"Clone from GitHub"** feature (`bf8dc9c5`) landed on
`main` ~5h *after* v1.0.3 was tagged (`121b39df`), so it missed the
v1.0.3 build entirely. `git merge-base --is-ancestor bf8dc9c5 v1.0.3` → NO.

### What shipping v1.0.4 delivers
- Ships the GitHub-clone wizard feature to release users.
- **First end-to-end exercise of the working v1.0.3 auto-updater**:
  users already on v1.0.3 get v1.0.4 via the launch-time
  `AutoUpdateChecker` — no manual reinstall (that one-time cost was only
  v1.0.2→v1.0.3).

### Release mechanics
Pushing the `v1.0.4` tag triggers `.github/workflows/release.yml`
(signed build via operator-held `TAURI_SIGNING_PRIVATE_KEY*`), which
emits the `.sig` + `latest.json` and flips the update endpoint to v1.0.4.

No code changes — version strings only.
